### PR TITLE
Add plain html support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/testfiles/tmpl/CookieFlowTemplate.de-DE.tmpl.html
 test/testfiles/tmpl/CookieFlowTemplate.fr-FR.tmpl.html
 test/testfiles/tmpl/nostrings.de-DE.tmpl.html
 test/testfiles/tmpl/nostrings.fr-FR.tmpl.html
+/node_modules/

--- a/build.xml
+++ b/build.xml
@@ -263,6 +263,22 @@ limitations under the License.
 		<debug script="${build.test}/testJavaScriptFileType.js" dir="${build.test}"/>
 	</target>
 
+    <target name="test.htmlfile" description="Run only the tests for the HTML file">
+        <run script="${build.test}/testHTMLFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.htmlfile" description="Debug only the tests for HTML files">
+        <debug script="${build.test}/testHTMLFile.js" dir="${build.test}"/>
+    </target>
+
+    <target name="test.htmlfiletype" description="Run only the tests for the HTML file type">
+        <run script="${build.test}/testHTMLFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.htmlfiletype" description="Debug only the tests for the HTML file type">
+        <debug script="${build.test}/testHTMLFileType.js" dir="${build.test}"/>
+    </target>
+
 	<target name="test.htmltemplatefile" description="Run only the tests for the HTML templates">
 		<run script="${build.test}/testHTMLTemplateFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
 	</target>
@@ -527,7 +543,7 @@ limitations under the License.
         <debug script="${build.test}/testJsxFileType.js" dir="${build.test}"/>
     </target>
 
-	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype">
+	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype">
 	</target>
 
 	<macrodef name="runsql">

--- a/lib/HTMLFile.js
+++ b/lib/HTMLFile.js
@@ -1,0 +1,605 @@
+/*
+ * HTMLFile.js - plugin to extract resources from an HTML file
+ *
+ * Copyright © 2018, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var log4js = require("log4js");
+var htmlParser = require("html-parser");
+var jsstl = require("js-stl");
+var ilib = require("ilib");
+var Locale = require("ilib/lib/Locale.js");
+var isAlnum = require("ilib/lib/isAlnum.js");
+var isIdeo = require("ilib/lib/isIdeo.js");
+
+var Queue = jsstl.Queue;
+var Stack = jsstl.Stack;
+
+var utils = require("./utils.js");
+var ResourceString = require("./ResourceString.js");
+var TranslationSet = require("./TranslationSet.js");
+
+var logger = log4js.getLogger("loctool.lib.HTMLFile");
+
+// load the data for these
+isAlnum._init();
+isIdeo._init();
+
+/**
+ * Create a new HTML file with the given path name and within
+ * the given project.
+ *
+ * @param {Project} project the project object
+ * @param {String} pathName path to the file relative to the root
+ * of the project file
+ * @param {FileType} type the file type instance of this file
+ */
+var HTMLFile = function(project, pathName, type) {
+    this.project = project;
+    this.pathName = pathName;
+    this.type = type;
+    this.set = new TranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
+};
+
+/**
+ * Make a new key for the given string.
+ *
+ * @private
+ * @param {String} source the source string to make a resource
+ * key for
+ * @returns {String} a unique key for this string
+ */
+HTMLFile.prototype.makeKey = function(source) {
+    // the English source is the key as well
+    return source.
+        replace(/\s+/g, " ").
+        replace(/([^%])> /g, "$1>").
+        replace(/ <([^%][^=])/g, "<$1").
+        trim();
+};
+
+// list of html5 tags and their attributes that contain localizable strings
+var localizableAttributes = {
+    "area": {"alt":true},
+    "img": {"alt":true},
+    "input": {
+        "alt": true,
+        "placeholder": true
+    },
+    "optgroup": {"label":true},
+    "option": {"label":true},
+    "textarea": {"placeholder":true},
+    "track": {"label":true}
+};
+
+var entityRE = new RegExp(/^&(\w*);/);
+var spaceEntities = {
+    "nbsp": true,
+    "nnbsp": true,
+    "mmsp": true
+};
+
+function isNotSpaceEntity(s, i) {
+    entityRE.lastIndex = i;
+    var match = entityRE.exec(s);
+    if (!match) return true;
+    return !spaceEntities[match[1]];
+}
+
+function isAllWhite(str) {
+    for (i = 0; i < str.length; i++) {
+        if (!utils.isWhite(str.charAt(i)) && isNotSpaceEntity(str, i)) return false;
+    }
+    return true;
+}
+
+function containsActualText(str) {
+    // remove the html and entities first
+    var cleaned = str.replace(/<("(\\"|[^"])*"|'(\\'|[^'])*'|[^>])*>/g, "").replace(/&[a-zA-Z]+;/g, "");
+
+    for (i = 0; i < cleaned.length; i++) {
+        var c = cleaned.charAt(i);
+        if (isAlnum(c) || isIdeo(c)) return true;
+    }
+    return false;
+}
+
+function escapeInvalidChars(str) {
+    var ret = "";
+    for (var i = 0; i < str.length; i++) {
+        var c = str.charCodeAt(i);
+        if (c < 0x09 || (c > 0x0D && c < 0x20)) {
+            ret += "&#" + c + ";";
+        } else {
+            ret += str.charAt(i);
+        }
+    }
+    return ret;
+};
+
+/**
+ * @param {boolean} escape true if you want the translated
+ * text to be escaped for attribute values
+ * @private
+ */
+HTMLFile.prototype._emitText = function(escape) {
+    if (!this.text.length) return;
+
+    var i, pre = "", post = "";
+
+    for (i = 0; i < this.text.length && utils.isWhite(this.text.charAt(i)); i++);
+
+    if (i >= this.text.length) {
+        // all white space, so skip it
+        this.accumulator += this.text;
+        this.text = "";
+
+        // then append any non-breaking tags that had no real text in front of it
+        if (this.tagtext) {
+            this.accumulator += this.tagtext;
+            this.tagtext = "";
+        }
+        return;
+    }
+
+    if (i > 0) {
+        pre = this.text.substring(0, i);
+        this.text = this.text.substring(i);
+    }
+
+    for (i = this.text.length-1; i > -1 && utils.isWhite(this.text.charAt(i)); i--);
+
+    if (i < this.text.length-1) {
+        post = this.text.substring(i+1);
+        this.text = this.text.substring(0, i+1);
+    }
+
+    this.accumulator += pre;
+    this.segments.enqueue({
+        localizable: false,
+        text: this.accumulator
+    });
+
+    logger.trace('text: pre is "' + pre + '" value is "' + this.text + '" and post is "' + post + '"');
+
+    if (this.text.length) {
+        this.segments.enqueue({
+            localizable: true,
+            text: escapeInvalidChars(this.text),
+            escape: escape
+        });
+
+        this.set.add(new ResourceString({
+            project: this.project.getProjectId(),
+            key: this.makeKey(escapeInvalidChars(this.text)),
+            sourceLocale: this.project.sourceLocale,
+            source: escapeInvalidChars(this.text),
+            autoKey: true,
+            pathName: this.pathName,
+            state: "new",
+            comment: this.comment,
+            datatype: "html"
+        }));
+    }
+
+    if (this.tagtext.length) {
+        // this tag had no text behind, so it just goes on the accumulator
+        post += this.tagtext;
+    }
+
+    this.accumulator = post;
+    this.text = "";
+    this.tagtext = "";
+    this.comment = undefined;
+};
+
+/**
+ * Parse the data string looking for the localizable strings and add them to the
+ * project's translation set.
+ * @param {String} data the string to parse
+ */
+HTMLFile.prototype.parse = function(data) {
+    logger.debug("Extracting strings from " + this.pathName);
+
+    // accumulates characters in non-text segments
+    this.accumulator = "";
+
+    // accumulates characters in text segments
+    this.text = "";
+
+    // accumulates characters of non-breaking tags that may
+    // eventually be part of a text segment if it is surrounded
+    // on both sides by non-whitespace text
+    this.tagtext = "";
+
+    this.segments = new Queue();
+
+    var lastTagName;
+
+    // stack of non-breaking opened tags that have to be closed eventually
+    // This does not include self-closing tags like <p> or <br>
+    var tagStack = new Stack();
+
+    var x = htmlParser.parse(data, {
+        openElement: function(name) {
+            logger.trace('open tag: ' + name);
+            lastTagName = name;
+            if (this.text) {
+                if (utils.nonBreakingTags[name]) {
+                    this.tagtext += '<' + name;
+                    tagStack.push(name);
+                } else {
+                    this._emitText();
+                    this.accumulator += '<' + name;
+                }
+            } else {
+                this.accumulator += '<' + name;
+            }
+        }.bind(this),
+        closeOpenedElement: function(name, token, unary) {
+            logger.trace('close opened tag: ' + name + ", token: " + token + ', unary: ' + unary);
+            if (this.tagtext) {
+                this.tagtext += token;
+            } else if (this.text) {
+                this.text += token;
+            } else {
+                this.accumulator += token;
+            }
+            lastTagName = undefined;
+        }.bind(this),
+        closeElement: function(name) {
+            logger.trace('close: %s', name);
+            if (this.tagtext || this.text) {
+                if (utils.nonBreakingTags[name] && !tagStack.isEmpty()) {
+                    var tag = tagStack.pop();
+                    while (tag !== name && !tagStack.isEmpty()) {
+                        tag = tagStack.pop();
+                    }
+                    if (tag === name) {
+                        if (this.tagtext) {
+                            this.tagtext += '</' + name + '>';
+                        } else {
+                            this.text += '</' + name + '>';
+                        }
+                        return;
+                    }
+                }
+                this._emitText();
+            }
+
+            tagStack = new Stack(); // reset
+            this.accumulator += '</' + name + '>';
+        }.bind(this),
+        comment: function(value) {
+            logger.trace('comment: %s', value);
+            // strip comments from the output, but keep i18n comments
+            // for the resources
+            value = value.trim();
+            if (value.substring(0, 5) === "i18n:") {
+                this.comment = value.substring(5).trim();
+            }
+        }.bind(this),
+        cdata: function(value) {
+            logger.trace('cdata: %s', value);
+            if (this.text || this.tagtext) {
+                this._emitText();
+            }
+            this.accumulator += value;
+        }.bind(this),
+        attribute: function(name, value, quote) {
+            logger.trace('attribute: %s=%s%s%s', name, quote, value, quote);
+            if (!value && !quote) {
+                // make sure there are at least empty quotes
+                quote = '"';
+            }
+            value = value || "";
+            if ((name === "title" || (localizableAttributes[lastTagName] && localizableAttributes[lastTagName][name])) &&
+                    value.trim().length > 0 && value.substring(0,2) !== "<%") {
+                this.set.add(new ResourceString({
+                    project: this.project.getProjectId(),
+                    key: this.makeKey(value),
+                    sourceLocale: this.project.sourceLocale,
+                    source: value,
+                    autoKey: true,
+                    pathName: this.pathName,
+                    state: "new",
+                    comment: this.comment,
+                    datatype: "html"
+                }));
+
+                if (this.tagtext) {
+                    this.segments.enqueue({
+                        localizable: true,
+                        attributeSubstitution: true,
+                        text: utils.escapeQuotes(value),
+                        replacement: '{' + name + '}',
+                        escape: true
+                    });
+
+                    this.tagtext += " " + name + '=' + quote + '{' + name + '}' + quote;
+                } else {
+                    this.accumulator += " " + name + '=' + quote;
+
+                    this.text = utils.escapeQuotes(value);
+                    this._emitText(true);
+
+                    this.accumulator += quote; // trailing quote same as opening quote
+                }
+            } else {
+                // non-localizable and values containing template tags just get added without localization
+                if (this.tagtext) {
+                    this.tagtext += " " + name + '=' + quote + utils.escapeQuotes(value) + quote;
+                } else if (this.text) {
+                    this.text += " " + name + '=' + quote + utils.escapeQuotes(value) + quote;
+                } else {
+                    this.accumulator += " " + name + '=' + quote + utils.escapeQuotes(value) + quote;
+                }
+            }
+        }.bind(this),
+        docType: function(value) {
+            logger.trace('doctype: %s', value);
+            this.accumulator += value;
+        }.bind(this),
+        text: function(value) {
+            logger.trace('text: value is "' + value + '"');
+            if (isAllWhite(value)) {
+                if (this.tagtext) {
+                    this.tagtext += value;
+                } else if (this.text) {
+                    this.text += value;
+                } else {
+                    this.accumulator += value;
+                }
+            } else {
+                if (this.accumulator) {
+                    this.segments.enqueue({
+                        localizable: false,
+                        text: this.accumulator
+                    });
+                    this.accumulator = "";
+                }
+
+                if (this.tagtext) {
+                    // the tag text has regular text on either side of it, so just
+                    // add it to the regular text as a non-breaking tag
+                    this.text += this.tagtext;
+                    this.tagtext = "";
+                }
+
+                this.text += value;
+            }
+        }.bind(this)
+    });
+
+    if (this.text || this.tagtext) {
+        this._emitText();
+    }
+
+    if (this.accumulator.length) {
+        this.segments.enqueue({
+            localizable: false,
+            text: this.accumulator
+        });
+        this.accumulator = "";
+    }
+};
+
+/**
+ * Extract all the localizable strings from the HTML file and add them to the
+ * project's translation set.
+ */
+HTMLFile.prototype.extract = function() {
+    logger.debug("Extracting strings from " + this.pathName);
+    if (this.pathName) {
+        var p = path.join(this.project.root, this.pathName);
+        try {
+            var data = fs.readFileSync(p, "utf8");
+            if (data) {
+                this.parse(data);
+            }
+        } catch (e) {
+            logger.warn("Could not read file: " + p);
+            logger.warn(e);
+        }
+    }
+};
+
+/**
+ * Return the set of resources found in the current Java file.
+ *
+ * @returns {TranslationSet} The set of resources found in the
+ * current Java file.
+ */
+HTMLFile.prototype.getTranslationSet = function() {
+    return this.set;
+}
+
+//we don't write HTML source files
+HTMLFile.prototype.write = function() {};
+
+/**
+ * Return the location on disk where the version of this file localized
+ * for the given locale should be written.
+ * @param {String] locale the locale spec for the target locale
+ * @returns {String} the localized path name
+ */
+HTMLFile.prototype.getLocalizedPath = function(locale) {
+    var fullPath = this.pathName;
+    var dirName = path.dirname(fullPath);
+    var fileName = path.basename(fullPath);
+
+    var parts = fileName.split(".");
+
+    if (parts.length > 2) {
+        if (parts[parts.length-2] === this.project.sourceLocale) {
+            parts.splice(parts.length-2, 1, locale);
+        }
+    } else if (parts.length > 1) {
+        parts.splice(parts.length-1, 0, locale);
+    } else {
+        parts.splice(parts.length, 0, locale);
+    }
+    return path.join(dirName, parts.join("."));
+};
+
+/**
+ * Localize the text of the current file to the given locale and return
+ * the results.
+ *
+ * @param {TranslationSet} translations the current set of translations
+ * @param {String} locale the locale to translate to
+ * @returns {String} the localized text of this file
+ */
+HTMLFile.prototype.localizeText = function(translations, locale) {
+    this.segments.rewind();
+    var segment = this.segments.current();
+    var output = "";
+    var substitution, replacement;
+
+    while (segment) {
+        if (segment.localizable) {
+            var hashkey = ResourceString.cleanHashKey(this.project.getProjectId(), locale, this.makeKey(escapeInvalidChars(segment.text)), "html");
+            var translated = translations.getClean(hashkey);
+
+            if (segment.attributeSubstitution) {
+                if (locale === this.project.pseudoLocale && this.project.settings.nopseudo) {
+                    substitution = segment.text;
+                } else if (!translated && this.type && this.type.pseudos[locale]) {
+                    var source, sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
+                    if (sourceLocale !== this.project.sourceLocale) {
+                        // translation is derived from a different locale's translation instead of from the source string
+                        var sourceRes = translations.getClean(ResourceString.cleanHashKey(
+                                this.project.getProjectId(), sourceLocale, this.makeKey(escapeInvalidChars(segment.text)), "html"));
+                        source = sourceRes ? sourceRes.getTarget() : segment.text;
+                    } else {
+                        source = segment.text;
+                    }
+                    substitution = this.type.pseudos[locale].getString(source);
+                } else {
+                    substitution = translated ? translated.getTarget() : segment.text;
+                }
+
+                replacement = segment.replacement;
+
+                if (this.project.settings.identify) {
+                    // make it clear what is the resource is for this string
+                    substitution = '<span loclang="html" locid="' + this.makeKey(escapeInvalidChars(segment.text)) + '">' + substitution + '</span>';
+                }
+
+                substitution = utils.escapeQuotes(substitution);
+            } else {
+                if (locale === this.project.pseudoLocale && this.project.settings.nopseudo) {
+                    additional = segment.text;
+                } else if (!translated && this.type && this.type.pseudos[locale]) {
+                    var source, sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
+                    if (sourceLocale !== this.project.sourceLocale) {
+                        // translation is derived from a different locale's translation instead of from the source string
+                        var sourceRes = translations.getClean(ResourceString.cleanHashKey(
+                                this.project.getProjectId(), sourceLocale, this.makeKey(escapeInvalidChars(segment.text)), "html"));
+                        source = sourceRes ? sourceRes.getTarget() : segment.text;
+                    } else {
+                        source = segment.text;
+                    }
+                    additional = this.type.pseudos[locale].getString(source);
+                } else {
+                    var additional;
+                    if (translated) {
+                        additional = translated.getTarget();
+                    } else {
+                        if (this.type && containsActualText(segment.text)) {
+                            logger.trace("New string found: " + segment.text);
+                            this.type.newres.add(new ResourceString({
+                                project: this.project.getProjectId(),
+                                key: this.makeKey(escapeInvalidChars(segment.text)),
+                                sourceLocale: this.project.sourceLocale,
+                                source: escapeInvalidChars(segment.text),
+                                targetLocale: locale,
+                                target: escapeInvalidChars(segment.text),
+                                autoKey: true,
+                                pathName: this.pathName,
+                                state: "new",
+                                datatype: "html",
+                                origin: "target"
+                            }));
+                            additional = this.type && this.type.missingPseudo && !this.project.settings.nopseudo ?
+                                    this.type.missingPseudo.getString(segment.text) : segment.text;
+                        } else {
+                            additional = segment.text;
+                        }
+                    }
+                }
+                if (substitution) {
+                    additional = additional.replace(replacement, substitution);
+                    substitution = undefined;
+                    replacement = undefined;
+                }
+
+                if (this.project.settings.identify) {
+                    // make it clear what is the resource is for this string
+                    additional = '<span loclang="html" locid="' + utils.escapeQuotes(this.makeKey(escapeInvalidChars(segment.text))) + '">' + additional + '</span>';
+                }
+
+                if (segment.escape) {
+                    additional = utils.escapeQuotes(additional);
+                }
+
+                output += additional;
+            }
+        } else {
+            output += segment.text;
+        }
+
+        this.segments.next();
+        segment = this.segments.current();
+    }
+
+    return output;
+};
+
+/**
+ * Localize the contents of this HTML file and write out the
+ * localized HTML file to a different file path.
+ *
+ * @param {TranslationSet} translations the current set of
+ * translations
+ * @param {Array.<String>} locales array of locales to translate to
+ */
+HTMLFile.prototype.localize = function(translations, locales) {
+    // don't localize if there is no text
+    if (this.segments) {
+        for (var i = 0; i < locales.length; i++) {
+            if (!this.project.isSourceLocale(locales[i])) {
+                // skip variants for now until we can handle them properly
+                var l = new Locale(locales[i]);
+                if (!l.getVariant()) {
+                    var pathName = this.getLocalizedPath(locales[i]);
+                    logger.debug("Writing file " + pathName);
+                    var p = path.join(this.project.target, pathName);
+                    var d = path.dirname(p);
+                    utils.makeDirs(d);
+
+                    fs.writeFileSync(p, this.localizeText(translations, locales[i]), "utf-8");
+                }
+            }
+        }
+    } else {
+        logger.debug(this.pathName + ": No segments/no strings, no localize");
+    }
+};
+
+module.exports = HTMLFile;

--- a/lib/HTMLFileType.js
+++ b/lib/HTMLFileType.js
@@ -1,0 +1,97 @@
+/*
+ * HTMLFileType.js - Represents a collection of HTML files
+ *
+ * Copyright © 2018, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var ilib = require("ilib");
+var Locale = require("ilib/lib/Locale.js");
+var ResBundle = require("ilib/lib/ResBundle.js");
+var log4js = require("log4js");
+
+var utils = require("./utils.js");
+var TranslationSet = require("./TranslationSet.js");
+var HTMLFile = require("./HTMLFile.js");
+var FileType = require("./FileType.js");
+var ResourceFactory = require("./ResourceFactory.js");
+var ResourceString = require("./ResourceString.js");
+
+var logger = log4js.getLogger("loctool.lib.HTMLFileType");
+
+var HTMLFileType = function(project) {
+    this.type = "html";
+    this.datatype = "html";
+    this.parent.call(this, project);
+    this.extensions = [ ".html", ".htm" ];
+};
+
+HTMLFileType.prototype = new FileType();
+HTMLFileType.prototype.parent = FileType;
+HTMLFileType.prototype.constructor = HTMLFileType;
+
+var alreadyLoc = new RegExp(/\.([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z](-[A-Z]+)?)?)\.html?$/);
+
+/**
+ * Return true if the given path is an HTML template file and is handled
+ * by the current file type.
+ *
+ * @param {String} pathName path to the file being questions
+ * @returns {boolean} true if the path is a java file, or false
+ * otherwise
+ */
+HTMLFileType.prototype.handles = function(pathName) {
+    logger.debug("HTMLFileType handles " + pathName + "?");
+    ret = ((pathName.length > 4) && (pathName.substring(pathName.length - 4) === ".htm")) ||
+        ((pathName.length > 5) && (pathName.substring(pathName.length - 5) === ".html"));
+    if (ret) {
+        var match = alreadyLoc.exec(pathName);
+        ret = (match && match.length) ? match[1] === this.project.sourceLocale : true;
+    }
+    logger.debug(ret ? "Yes" : "No");
+    return ret;
+};
+
+HTMLFileType.prototype.name = function() {
+    return "HTML File Type";
+};
+
+/**
+ * Write out the aggregated resources for this file type. In
+ * some cases, the string are written out to a common resource
+ * file, and in other cases, to a type-specific resource file.
+ * In yet other cases, nothing is written out, as the each of
+ * the files themselves are localized individually, so there
+ * are no aggregated strings.
+ */
+HTMLFileType.prototype.write = function() {
+    // templates are localized individually, so we don't have to
+    // write out the resources
+};
+
+HTMLFileType.prototype.newFile = function(path) {
+    return new HTMLFile(this.project, path, this);
+};
+
+/**
+ * Register the data types and resource class with the resource factory so that it knows which class
+ * to use when deserializing instances of resource entities.
+ */
+HTMLFileType.prototype.registerDataTypes = function() {
+    ResourceFactory.registerDataType(this.datatype, "string", ResourceString);
+};
+
+module.exports = HTMLFileType;

--- a/lib/WebProject.js
+++ b/lib/WebProject.js
@@ -21,6 +21,7 @@ var fs = require("fs");
 var path = require("path");
 
 var Project = require("./Project.js");
+var HTMLFileType = require("./HTMLFileType.js");
 var HTMLTemplateFileType = require("./HTMLTemplateFileType.js");
 var HamlFileType = require("./HamlFileType.js");
 var OldHamlFileType = require("./OldHamlFileType.js");
@@ -111,6 +112,9 @@ WebProject.prototype.initFileTypes = function() {
         if (this.useFileTypes.YamlResourceFileType) {
             this.fileTypes.push(new YamlResourceFileType(this));
         }
+        if (this.useFileTypes.HTMLFileType) {
+            this.fileTypes.push(new HTMLFileType(this));
+        }
     } else {
         this.fileTypes = [
             new RubyFileType(this),
@@ -120,7 +124,8 @@ WebProject.prototype.initFileTypes = function() {
             new YamlFileType(this),
             this.resourceFileType.js,
             this.hamlType,
-            this.resourceFileType.ruby
+            this.resourceFileType.ruby,
+            new HTMLFileType(this)
         ];
     }
 };

--- a/log4js.json
+++ b/log4js.json
@@ -53,6 +53,22 @@
 			"appenders": [ "default" ],
 			"level": "info"
 		},
+        "loctool.lib.HTMLFile": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
+        "loctool.lib.HTMLFileType": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
+        "loctool.lib.HTMLTemplateFile": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
+        "loctool.lib.HTMLTemplateFileType": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
         "loctool.lib.IosLayoutResourceString": {
 			"appenders": [ "default" ],
 			"level": "info"

--- a/package.json
+++ b/package.json
@@ -51,22 +51,22 @@
         "test": "ant test"
     },
     "dependencies": {
-        "ilib": "13.0.0",
-        "tap": "^7.0.0",
+        "build-gradle-reader": "*",
         "hoek": "^4.2.1",
+        "ilib": "^13.2.0",
         "joi": "^9.0.4",
-        "log4js": "^2.0.0",
-        "mysql2": ">=1.5.0",
-        "pretty-data": ">=0.40.0",
-        "js-yaml": ">=3.10.0",
         "js-stl": ">=0.0.6",
+        "js-yaml": ">=3.10.0",
+        "log4js": "^2.0.0",
+        "micromatch": ">=3.1.0",
+        "mysql2": ">=1.5.0",
         "node-expat": ">=2.3.0",
         "opencc": ">=1.0.5",
-        "build-gradle-reader": "*",
-        "micromatch": ">=3.1.0"
+        "pretty-data": ">=0.40.0",
+        "tap": "^7.0.0"
     },
     "devDependencies": {
-        "nodeunit": "0.11.2"
+        "nodeunit": "^0.11.2"
     },
     "bundledDependencies": [
         "html-parser",

--- a/test/testHTMLFile.js
+++ b/test/testHTMLFile.js
@@ -1,0 +1,2659 @@
+/*
+ * testHTMLFile.js - test the HTML file handler object.
+ *
+ * Copyright © 2018, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var path = require("path");
+var fs = require("fs");
+
+if (!HTMLFile) {
+    var HTMLFile = require("../lib/HTMLFile.js");
+    var HTMLFileType = require("../lib/HTMLFileType.js");
+
+    var WebProject =  require("../lib/WebProject.js");
+    var TranslationSet =  require("../lib/TranslationSet.js");
+    var ResourceString =  require("../lib/ResourceString.js");
+}
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+
+module.exports = {
+    testHTMLFileConstructor: function(test) {
+        test.expect(1);
+
+        var htf = new HTMLFile();
+        test.ok(htf);
+
+        test.done();
+    },
+
+    testHTMLFileConstructorParams: function(test) {
+        test.expect(1);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./testfiles/html/CookieFlow.html");
+
+        test.ok(htf);
+
+        test.done();
+    },
+
+    testHTMLFileConstructorNoFile: function(test) {
+        test.expect(1);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        test.done();
+    },
+
+    testHTMLFileMakeKey: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        test.equal(htf.makeKey("This is a test"), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileMakeKeyNoReturnChars: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        test.equal(htf.makeKey("This is\n a te\nst"), "This is a te st");
+
+        test.done();
+    },
+
+    testHTMLFileMakeKeyCompressWhiteSpace: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        test.equal(htf.makeKey("This \t is\n \t a   test"), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileMakeKeyTrimWhiteSpace: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        test.equal(htf.makeKey("\n\t This \t is\n \t a   test\n\n\n"), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseSimpleGetByKey: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body>This is a test</body></html>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.get(ResourceString.hashKey(undefined, "en-US", "This is a test", "html"));
+        test.ok(r);
+
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseSimpleGetBySource: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body>This is a test</body></html>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseSimpleIgnoreWhitespace: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '<body>\n' +
+                '     This is a test    \n' +
+                '</body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseDontExtractUnicodeWhitespace: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        // contains U+00A0 non-breaking space and other Unicode space characters
+        htf.parse('<div>            ​‌‍ ⁠⁡⁢⁣⁤</div>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testHTMLFileParseDontExtractNbspEntity: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<div>&nbsp; &nnbsp; &mmsp;</div>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testHTMLFileParseDoExtractOtherEntities: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<div>&uuml;</div>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+
+        test.done();
+    },
+
+    testHTMLFileParseNoStrings: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<div class="noheader medrx"></div>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testHTMLFileParseSimpleRightSize: function(test) {
+        test.expect(4);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        var set = htf.getTranslationSet();
+        test.equal(set.size(), 0);
+
+        htf.parse('<html><body>This is a test</body></html>');
+
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+
+        test.done();
+    },
+
+    testHTMLFileParseMultiple: function(test) {
+        test.expect(8);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        r = set.getBySource("This is also a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is also a test");
+        test.equal(r.getKey(), "This is also a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseWithDups: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.equal(set.size(), 2);
+
+        test.done();
+    },
+
+    testHTMLFileParseEscapeInvalidChars: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div id="foo">\n' +
+                '           This is also a \u0003 test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // should use html entities to represent the invalid control chars
+        var r = set.getBySource("This is also a &#3; test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is also a &#3; test");
+        test.equal(r.getKey(), "This is also a &#3; test");
+
+        test.done();
+    },
+
+    testHTMLFileParseDontEscapeWhitespaceChars: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div id="foo">\n' +
+                '           This is also a \u000C test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // leave the whitespace control chars alone
+        var r = set.getBySource("This is also a \u000C test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is also a \u000C test");
+        test.equal(r.getKey(), "This is also a test");
+
+        test.done();
+    },
+
+    testHTMLFileSkipScript: function(test) {
+        test.expect(8);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <head>\n' +
+                '   <script>\n' +
+                '// comment text\n' +
+                'if (locales.contains[thisLocale]) {\n' +
+                '    document.write("<input id=\"locale\" class=\"foo\" title=\"bar\"></input>");\n' +
+                '}\n' +
+                '   </head>\n' +
+                '   </script>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        var r = set.getBySource("// comment text");
+        test.ok(!r);
+
+        var r = set.getBySource("bar");
+        test.ok(!r);
+
+        test.equal(set.size(), 1);
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTags: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a <em>test</em> of the emergency parsing system.  \n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a <em>test</em> of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a <em>test</em> of the emergency parsing system.");
+        test.equal(r.getKey(), "This is a<em>test</em>of the emergency parsing system.");
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsOutside: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <span id="foo" class="bar">  This is a test of the emergency parsing system.  </span>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // should not pick up the span tag because there is no localizable text
+        // before it or after it
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "This is a test of the emergency parsing system.");
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsInside: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the emergency parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // should pick up the span tag because there is localizable text
+        // before it and after it
+        var r = set.getBySource('This is <span id="foo" class="bar"> a test of the emergency parsing </span> system.');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <span id="foo" class="bar"> a test of the emergency parsing </span> system.');
+        test.equal(r.getKey(), 'This is<span id="foo" class="bar">a test of the emergency parsing</span>system.');
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsInsideMultiple: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the <em>emergency</em> parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // tags should be nestable
+        var r = set.getBySource('This is <span id="foo" class="bar"> a test of the <em>emergency</em> parsing </span> system.');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <span id="foo" class="bar"> a test of the <em>emergency</em> parsing </span> system.');
+        test.equal(r.getKey(), 'This is<span id="foo" class="bar">a test of the<em>emergency</em>parsing</span>system.');
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsNotWellFormed: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the <em>emergency parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // the end span tag should automatically end the em tag
+        var r = set.getBySource('This is <span id="foo" class="bar"> a test of the <em>emergency parsing </span> system.');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <span id="foo" class="bar"> a test of the <em>emergency parsing </span> system.');
+        test.equal(r.getKey(), 'This is<span id="foo" class="bar">a test of the<em>emergency parsing</span>system.');
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsNotWellFormedWithTerminatorTag: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div>This is <span id="foo" class="bar"> a test of the <em>emergency parsing </div> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // the end div tag ends all the other tags
+        var r = set.getBySource('This is <span id="foo" class="bar"> a test of the <em>emergency parsing');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <span id="foo" class="bar"> a test of the <em>emergency parsing');
+        test.equal(r.getKey(), 'This is<span id="foo" class="bar">a test of the<em>emergency parsing');
+
+        test.done();
+    },
+
+    testHTMLFileParseNonBreakingTagsTagStackIsReset: function(test) {
+        test.expect(5);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div>This is <span id="foo" class="bar"> a test of the <em>emergency parsing</em> system.</div>\n' +
+                '       <div>This is <b>another test</b> of the emergency parsing </span> system.</div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        // the end div tag ends all the other tags
+        var r = set.getBySource('This is <b>another test</b> of the emergency parsing');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <b>another test</b> of the emergency parsing');
+        test.equal(r.getKey(), 'This is<b>another test</b>of the emergency parsing');
+
+        test.done();
+    },
+
+    testHTMLFileParseLocalizableTitle: function(test) {
+        test.expect(8);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div title="This value is localizable">\n' +
+                '           This is a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        r = set.getBySource("This value is localizable");
+        test.ok(r);
+        test.equal(r.getSource(), "This value is localizable");
+        test.equal(r.getKey(), "This value is localizable");
+
+        test.done();
+    },
+
+    testHTMLFileParseLocalizableAttributes: function(test) {
+        test.expect(11);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <img src="http://www.test.test/foo.png" alt="Alternate text">\n' +
+                '       This is a test\n' +
+                '       <input type="text" placeholder="localizable placeholder here">\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        r = set.getBySource("Alternate text");
+        test.ok(r);
+        test.equal(r.getSource(), "Alternate text");
+        test.equal(r.getKey(), "Alternate text");
+
+        r = set.getBySource("localizable placeholder here");
+        test.ok(r);
+        test.equal(r.getSource(), "localizable placeholder here");
+        test.equal(r.getKey(), "localizable placeholder here");
+
+        test.done();
+    },
+
+    testHTMLFileParseLocalizableAttributesSkipEmpty: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <img src="http://www.test.test/foo.png" alt="">\n' +
+                '       This is a test\n' +
+                '       <input type="text" placeholder="">\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.done();
+    },
+
+    testHTMLFileParseLocalizableAttributesAndNonBreakingTags: function(test) {
+        test.expect(8);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <a href="foo.html" title="localizable title">a test</a> of non-breaking tags.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource('This is <a href="foo.html" title="{title}">a test</a> of non-breaking tags.');
+        test.ok(r);
+        test.equal(r.getSource(), 'This is <a href="foo.html" title="{title}">a test</a> of non-breaking tags.');
+        test.equal(r.getKey(), 'This is<a href="foo.html" title="{title}">a test</a>of non-breaking tags.');
+
+        r = set.getBySource("localizable title");
+        test.ok(r);
+        test.equal(r.getSource(), "localizable title");
+        test.equal(r.getKey(), "localizable title");
+
+        test.done();
+    },
+
+    testHTMLFileParseI18NComments: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <!-- i18n: this describes the text below -->\n' +
+                '       This is a test of the emergency parsing system.  \n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "This is a test of the emergency parsing system.");
+        test.equal(r.getComment(), "this describes the text below");
+
+        test.done();
+    },
+
+    testHTMLFileParseIgnoreTags: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body>\n' +
+            '<script type="javascript">\n' +
+            'if (window) {\n' +
+            '  $(".foo").class("asdf");\n' +
+            '}\n' +
+            '</script>\n' +
+            '<style>\n' +
+            '  .activity_title{\n' +
+            '    font-size: 18px;\n' +
+            '    font-weight: 300;\n' +
+            '    color: #777;\n' +
+            '    line-height: 40px;\n' +
+            '  }\n' +
+            '</style>\n' +
+            '<span class="foo">foo</span>\n' +
+            '</body></html>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+
+        var r = set.getBySource("foo");
+        test.ok(r);
+        test.equal(r.getSource(), "foo");
+        test.equal(r.getKey(), "foo");
+
+        test.done();
+    },
+
+    testHTMLFileExtractFile: function(test) {
+        test.expect(11);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./html/CookieFlow.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 3);
+
+        var r = set.getBySource("Get insurance quotes for free!");
+        test.ok(r);
+        test.equal(r.getSource(), "Get insurance quotes for free!");
+        test.equal(r.getKey(), "Get insurance quotes for free!");
+
+        r = set.getBySource("Send question");
+        test.ok(r);
+        test.equal(r.getSource(), "Send question");
+        test.equal(r.getKey(), "Send question");
+
+        r = set.getBySource("Ask");
+        test.ok(r);
+        test.equal(r.getSource(), "Ask");
+        test.equal(r.getKey(), "Ask");
+
+        test.done();
+    },
+
+    testHTMLFileExtractFile2: function(test) {
+        test.expect(17);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./html/topic_navigation_main.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 5);
+
+        var r = set.getBySource("Description");
+        test.ok(r);
+        test.equal(r.getSource(), "Description");
+        test.equal(r.getKey(), "Description");
+
+        r = set.getBySource('Authored by <a class="actor_link bold" href="#expert_vip/x/">John Smith</a>');
+        test.ok(r);
+        test.equal(r.getSource(), 'Authored by <a class="actor_link bold" href="#expert_vip/x/">John Smith</a>');
+        test.equal(r.getKey(), 'Authored by<a class="actor_link bold" href="#expert_vip/x/">John Smith</a>');
+
+        r = set.getBySource('Agreed');
+        test.ok(r);
+        test.equal(r.getSource(), 'Agreed');
+        test.equal(r.getKey(), 'Agreed');
+
+        r = set.getBySource('and <a class="bold"><span class="friend_agree_count_h">8</span> of your friends agree</a>');
+        test.ok(r);
+        test.equal(r.getSource(), 'and <a class="bold"><span class="friend_agree_count_h">8</span> of your friends agree</a>');
+        test.equal(r.getKey(), 'and<a class="bold"><span class="friend_agree_count_h">8</span>of your friends agree</a>');
+
+        r = set.getBySource("Write a better description &raquo;");
+        test.ok(r);
+        test.equal(r.getSource(), "Write a better description &raquo;");
+        test.equal(r.getKey(), "Write a better description &raquo;");
+
+        test.done();
+    },
+
+    testHTMLFileExtractUndefinedFile: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        // should attempt to read the file and not fail
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testHTMLFileExtractBogusFile: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./html/bogus.html");
+        test.ok(htf);
+
+        // should attempt to read the file and not fail
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeText: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body>This is a test</body></html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var actual = htf.localizeText(translations, "fr-FR");
+        var expected = '<html><body>Ceci est un essai</body></html>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextPreserveWhitespace: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '<body>\n' +
+                '     This is a test    \n' +
+                '</body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '<body>\n' +
+            '     Ceci est un essai    \n' +
+            '</body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextPreserveSelfClosingTags: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            name: "foo",
+            id: "foo",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '<body>\n' +
+                '     <div class="foo"/>\n' +
+                '     This is a test    \n' +
+                '</body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '<body>\n' +
+            '     <div class="foo"/>\n' +
+            '     Ceci est un essai    \n' +
+            '</body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextMultiple: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       Ceci est un essai\n' +
+                '       <div id="foo">\n' +
+                '           Ceci est aussi un essai\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextWithDups: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       Ceci est un essai\n' +
+                '       <div id="foo">\n' +
+                '           Ceci est aussi un essai\n' +
+                '       </div>\n' +
+                '       Ceci est un essai\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextSkipScript: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <head>\n' +
+                '   <script>\n' +
+                '// comment text\n' +
+                'if (locales.contains[thisLocale]) {\n' +
+                '    document.write("<input id=\"locale\" class=\"foo\" title=\"bar\"></input>");\n' +
+                '}\n' +
+                '   </head>\n' +
+                '   </script>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '   <head>\n' +
+            '   <script>\n' +
+            '// comment text\n' +
+            'if (locales.contains[thisLocale]) {\n' +
+            '    document.write("<input id=\"locale\" class=\"foo\" title=\"bar\"></input>");\n' +
+            '}\n' +
+            '   </head>\n' +
+            '   </script>\n' +
+            '   <body>\n' +
+            '       Ceci est un essai\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTags: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a <em>test</em> of the emergency parsing system.  \n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a<em>test</em>of the emergency parsing system.",
+            source: "This is a<em>test</em>of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <em>essai</em> du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '   <body>\n' +
+            '       Ceci est un <em>essai</em> du système d\'analyse syntaxique de l\'urgence.  \n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTagsOutside: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <span id="foo" class="bar">  This is a test of the emergency parsing system.  </span>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test of the emergency parsing system.",
+            source: "This is a test of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '   <body>\n' +
+            '       <span id="foo" class="bar">  Ceci est un essai du système d\'analyse syntaxique de l\'urgence.  </span>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTagsInside: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the emergency parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is<span id="foo" class="bar">a test of the emergency parsing</span>system.',
+            source: 'This is<span id="foo" class="bar">a test of the emergency parsing</span>system.',
+            target: 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de l\'urgence.</span>',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '   <body>\n' +
+            '       Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de l\'urgence.</span>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTagsInsideMultiple: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the <em>emergency</em> parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is<span id="foo" class="bar">a test of the<em>emergency</em>parsing</span>system.',
+            source: 'This is<span id="foo" class="bar">a test of the<em>emergency</em>parsing</span>system.',
+            target: 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence</em>.</span>',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<html>\n' +
+            '   <body>\n' +
+            '       Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence</em>.</span>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTagsNotWellFormed: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <span id="foo" class="bar"> a test of the <em>emergency parsing </span> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is<span id="foo" class="bar">a test of the<em>emergency parsing</span>system.',
+            source: 'This is<span id="foo" class="bar">a test of the<em>emergency parsing</span>system.',
+            target: 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence.</span>',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence.</span>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonBreakingTagsNotWellFormedWithTerminatorTag: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div>This is <span id="foo" class="bar"> a test of the <em>emergency parsing </div> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is<span id="foo" class="bar">a test of the<em>emergency parsing',
+            source: 'This is<span id="foo" class="bar">a test of the<em>emergency parsing',
+            target: 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       <div>Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique </div> system.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextLocalizableTitle: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <div title="This value is localizable">\n' +
+                '           This is a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This value is localizable',
+            source: 'This value is localizable',
+            target: 'Cette valeur est localisable',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is a test',
+            source: 'This is a test',
+            target: 'Ceci est un essai',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       <div title="Cette valeur est localisable">\n' +
+                '           Ceci est un essai\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextLocalizableAttributes: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <img src="http://www.test.test/foo.png" alt="Alternate text">\n' +
+                '       This is a test\n' +
+                '       <input type="text" placeholder="localizable placeholder here">\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'Alternate text',
+            source: 'Alternate text',
+            target: 'Texte alternative',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is a test',
+            source: 'This is a test',
+            target: 'Ceci est un essai',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'localizable placeholder here',
+            source: 'localizable placeholder here',
+            target: 'espace réservé localisable ici',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       <img src="http://www.test.test/foo.png" alt="Texte alternative">\n' +
+                '       Ceci est un essai\n' +
+                '       <input type="text" placeholder="espace réservé localisable ici">\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextLocalizableAttributesAndNonBreakingTags: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is <a href="foo.html" title="localizable title">a test</a> of non-breaking tags.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is<a href="foo.html" title="{title}">a test</a>of non-breaking tags.',
+            source: 'This is<a href="foo.html" title="{title}">a test</a>of non-breaking tags.',
+            target: 'Ceci est <a href="foo.html" title="{title}">un essai</a> des balises non-ruptures.',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'localizable title',
+            source: 'localizable title',
+            target: 'titre localisable',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       Ceci est <a href="foo.html" title="titre localisable">un essai</a> des balises non-ruptures.\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextI18NComments: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <!-- i18n: this describes the text below -->\n' +
+                '       This is a test of the emergency parsing system.  \n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is a test of the emergency parsing system.',
+            source: 'This is a test of the emergency parsing system.',
+            target: 'Ceci est un essai du système d\'analyse syntaxique de l\'urgence.',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '<html>\n' +
+                '   <body>\n' +
+                '       \n' +
+                '       Ceci est un essai du système d\'analyse syntaxique de l\'urgence.  \n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextIdentifyResourceIds: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            identify: true
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var expected =
+            '<html>\n' +
+            '   <body>\n' +
+            '       <span loclang="html" locid="This is a test">Ceci est un essai</span>\n' +
+            '       <div id="foo">\n' +
+            '           <span loclang="html" locid="This is also a test">Ceci est aussi un essai</span>\n' +
+            '       </div>\n' +
+            '       <span loclang="html" locid="This is a test">Ceci est un essai</span>\n' +
+            '   </body>\n' +
+            '</html>\n';
+           var actual = htf.localizeText(translations, "fr-FR");
+
+           diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextIdentifyResourceIdsWithAttributes: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            identify: true
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <area alt="placeholder text">This is a test</area>\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "placeholder text",
+            source: "placeholder text",
+            sourceLocale: "en-US",
+            target: "Texte de l'espace réservé",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This is a test',
+            source: 'This is a test',
+            target: 'Ceci est un essai',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var expected =
+            '<html>\n' +
+            '   <body>\n' +
+            '       <area alt="&lt;span loclang=&quot;html&quot; locid=&quot;placeholder text&quot;&gt;Texte de l&apos;espace réservé&lt;/span&gt;"><span loclang="html" locid="This is a test">Ceci est un essai</span></area>\n' +
+            '       <div id="foo">\n' +
+            '           <span loclang="html" locid="This is also a test">Ceci est aussi un essai</span>\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n';
+           var actual = htf.localizeText(translations, "fr-FR");
+
+           diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextIdentifyResourceIdsWithEmbeddedAttributes: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            identify: true
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       This <span title="placeholder text">is a test</span>\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "placeholder text",
+            source: "placeholder text",
+            sourceLocale: "en-US",
+            target: "Texte de l'espace réservé",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'This<span title="{title}">is a test</span>',
+            source: 'This<span title="{title}">is a test</span>',
+            sourceLocale: "en-US",
+            target: 'Ceci <span title="{title}">est un essai</span>',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var expected =
+            '<html>\n' +
+            '   <body>\n' +
+            '       <span loclang="html" locid="This&lt;span title=&quot;{title}&quot;&gt;is a test&lt;/span&gt;">Ceci <span title="&lt;span loclang=&quot;html&quot; locid=&quot;placeholder text&quot;&gt;Texte de l&apos;espace réservé&lt;/span&gt;">est un essai</span></span>\n' +
+            '       <div id="foo">\n' +
+            '           <span loclang="html" locid="This is also a test">Ceci est aussi un essai</span>\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n';
+           var actual = htf.localizeText(translations, "fr-FR");
+
+           diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testHTMLFileGetLocalizedPathSimple: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "simple.html");
+        test.ok(htf);
+
+        test.equal(htf.getLocalizedPath("fr-FR"), "simple.fr-FR.html");
+
+        test.done();
+    },
+
+    testHTMLFileGetLocalizedPathComplex: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./asdf/bar/simple.html");
+        test.ok(htf);
+
+        test.equal(htf.getLocalizedPath("fr-FR"), "asdf/bar/simple.fr-FR.html");
+
+        test.done();
+    },
+
+    testHTMLFileGetLocalizedPathRegularHTMLFileName: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./asdf/bar/simple.html");
+        test.ok(htf);
+
+        test.equal(htf.getLocalizedPath("fr-FR"), "asdf/bar/simple.fr-FR.html");
+
+        test.done();
+    },
+
+    testHTMLFileGetLocalizedPathNotEnoughParts: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./asdf/bar/simple");
+        test.ok(htf);
+
+        test.equal(htf.getLocalizedPath("fr-FR"), "asdf/bar/simple.fr-FR");
+
+        test.done();
+    },
+
+    testHTMLFileGetLocalizedSourceLocale: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./asdf/bar/simple.en-US.html");
+        test.ok(htf);
+
+        test.equal(htf.getLocalizedPath("fr-FR"), "asdf/bar/simple.fr-FR.html");
+
+        test.done();
+    },
+
+    testHTMLFileLocalize: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"],
+            targetDir: "testfiles"
+        });
+
+        var htf = new HTMLFile(p, "./html/CookieFlow.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Get insurance quotes for free!',
+            source: 'Get insurance quotes for free!',
+            target: 'Obtenez des devis d\'assurance gratuitement!',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Talk',
+            source: 'Talk',
+            target: 'Consultee',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Ask',
+            source: 'Ask',
+            target: 'Poser un question',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Send question',
+            source: 'Send question',
+            target: 'Envoyer la question',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Get insurance quotes for free!',
+            source: 'Get insurance quotes for free!',
+            target: 'Kostenlosen Versicherungs-Angebote erhalten!',
+            targetLocale: "de-DE",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Talk',
+            source: 'Talk',
+            target: 'Beratung',
+            targetLocale: "de-DE",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Ask',
+            source: 'Ask',
+            target: 'Eine Frage stellen',
+            targetLocale: "de-DE",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Send question',
+            source: 'Send question',
+            target: 'Frage abschicken',
+            targetLocale: "de-DE",
+            datatype: "html"
+        }));
+
+        htf.localize(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlowTemplate.fr-FR.html")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlowTemplate.de-DE.html")));
+
+        var content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlowTemplate.fr-FR.html"), "utf-8");
+
+        var expected =
+            '<div class="upsell-ad-item clearfix">  \n' +
+            '    <div class="modal_x"></div>\n' +
+            '    <div class="upsell-ad-content">\n' +
+            '      <div class="upsell-ad-header">\n' +
+            '        <div class="big cookie-flow"></div>\n' +
+            '        <span class="upsell-header-bold"></span>\n' +
+            '        Obtenez des devis d\'assurance gratuitement!\n' +
+            '      </div>\n' +
+            '      <div class="upsell-ad-wrapper" style="padding-left: 0">\n' +
+            '        <a class="specialist-avatar" href="/specialists/234" style="background-image: url(http://foo.com/bar.png);"></a>\n' +
+            '        <input class="askInputArea-cookie desktop" maxlength="150">\n' +
+            '        <span class="askSendArea-cookie">\n' +
+            '          <a class="askSendBtn-cookie" href="/message?from_seo=1">\n' +
+            '            <div class="desktop-btn">Envoyer la question</div>\n' +
+            '            <div class="mobile-btn">Poser un question</div>\n' +
+            '          </a>\n' +
+            '        </span>\n' +
+            '      </div>\n' +
+            '    </div>\n' +
+            '</div>';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlowTemplate.de-DE.html"), "utf-8");
+
+        test.equal(content,
+            '<div class="upsell-ad-item clearfix">  \n' +
+            '    <div class="modal_x"></div>\n' +
+            '    <div class="upsell-ad-content">\n' +
+            '      <div class="upsell-ad-header">\n' +
+            '        <div class="big cookie-flow"></div>\n' +
+            '        <span class="upsell-header-bold"></span>\n' +
+            '        Kostenlosen Versicherungs-Angebote erhalten!\n' +
+            '      </div>\n' +
+            '      <div class="upsell-ad-wrapper" style="padding-left: 0">\n' +
+            '        <a class="specialist-avatar" href="/specialists/234" style="background-image: url(http://foo.com/bar.png);"></a>\n' +
+            '        <input class="askInputArea-cookie desktop" maxlength="150">\n' +
+            '        <span class="askSendArea-cookie">\n' +
+            '          <a class="askSendBtn-cookie" href="/message?from_seo=1">\n' +
+            '            <div class="desktop-btn">Frage abschicken</div>\n' +
+            '            <div class="mobile-btn">Eine Frage stellen</div>\n' +
+            '          </a>\n' +
+            '        </span>\n' +
+            '      </div>\n' +
+            '    </div>\n' +
+            '</div>'
+        );
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeNoStrings: function(test) {
+        test.expect(3);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"],
+            targetDir: "testfiles"
+        });
+
+        var htf = new HTMLFile(p, "./html/nostrings.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Get insurance quotes for free!',
+            source: 'Get insurance quotes for free!',
+            target: 'Obtenez des devis d\'assurance gratuitement!',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Get insurance quotes for free!',
+            source: 'Get insurance quotes for free!',
+            target: 'Kostenlosen Versicherungs-Angebote erhalten!',
+            targetLocale: "de-DE",
+            datatype: "html"
+        }));
+
+        htf.localize(translations, ["fr-FR", "de-DE"]);
+
+        // should produce the files, even if there is nothing to localize in them
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/nostrings.fr-FR.html")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/nostrings.de-DE.html")));
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextNonTemplateTagsInsideTags: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html>\n' +
+                '   <body>\n' +
+                '       <span class="foo" <span class="bar"> Mr. Smith is not available.</span></span>\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource('Mr. Smith is not available.');
+        test.ok(r);
+        test.equal(r.getSource(), 'Mr. Smith is not available.');
+        test.equal(r.getKey(), 'Mr. Smith is not available.');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'Mr. Smith is not available.',
+            source: 'Mr. Smith is not available.',
+            target: 'Mssr. Smith n\'est pas disponible.',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var actual = htf.localizeText(translations, "fr-FR");
+        var expected =
+                '<html>\n' +
+                '   <body>\n' +
+                '       <span class="foo" span="" class="bar"> Mssr. Smith n\'est pas disponible.</span></span>\n' +
+                '   </body>\n' +
+                '</html>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextEscapeDoubleQuotes: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('  <span class="foo" onclick=\'javascript:var a = "foo", b = "bar";\'>foo</span>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'foo',
+            source: 'foo',
+            target: 'asdf',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        diff(htf.localizeText(translations, "fr-FR"),
+                '  <span class="foo" onclick=\'javascript:var a = &quot;foo&quot;, b = &quot;bar&quot;;\'>asdf</span>');
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+                '  <span class="foo" onclick=\'javascript:var a = &quot;foo&quot;, b = &quot;bar&quot;;\'>asdf</span>');
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextIgnoreScriptTags: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body><script type="javascript">\n' +
+               '  foo\n' +
+            '</script>\n' +
+            '<span class="foo">foo</span>\n' +
+            '<div></div><script>foo</script><div></div>\n' +
+            '</body></html>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'foo',
+            source: 'foo',
+            target: 'asdf',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var expected =
+            '<html><body><script type="javascript">\n' +
+            '  foo\n' +
+            '</script>\n' +
+            '<span class="foo">asdf</span>\n' +
+            '<div></div><script>foo</script><div></div>\n' +
+            '</body></html>';
+
+        diff(htf.localizeText(translations, "fr-FR"), expected);
+
+        test.equal(htf.localizeText(translations, "fr-FR"), expected);
+
+        test.done();
+    },
+
+    testHTMLFileLocalizeTextIgnoreStyleTags: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            id: "webapp",
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse('<html><body><style>\n' +
+               '  foo\n' +
+            '</style>\n' +
+            '<span class="foo">foo</span>\n' +
+            '<div></div><style>foo</style><div></div>\n' +
+            '</body></html>');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'foo',
+            source: 'foo',
+            target: 'asdf',
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var expected =
+            '<html><body><style>\n' +
+            '  foo\n' +
+            '</style>\n' +
+            '<span class="foo">asdf</span>\n' +
+            '<div></div><style>foo</style><div></div>\n' +
+            '</body></html>';
+
+        diff(htf.localizeText(translations, "fr-FR"), expected);
+
+        test.equal(htf.localizeText(translations, "fr-FR"), expected);
+
+        test.done();
+    },
+
+    testHTMLFileExtractFileFullyExtracted: function(test) {
+        test.expect(17);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./html/meeting_panel.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 5);
+
+        var r = set.getBySource("Upcoming Appointments");
+        test.ok(r);
+        test.equal(r.getSource(), "Upcoming Appointments");
+        test.equal(r.getKey(), "Upcoming Appointments");
+
+        r = set.getBySource("Completed Meetings");
+        test.ok(r);
+        test.equal(r.getSource(), "Completed Meetings");
+        test.equal(r.getKey(), "Completed Meetings");
+
+        r = set.getBySource("Get help");
+        test.ok(r);
+        test.equal(r.getSource(), "Get help");
+        test.equal(r.getKey(), "Get help");
+
+        r = set.getBySource("Colleagues are standing by to help");
+        test.ok(r);
+        test.equal(r.getSource(), "Colleagues are standing by to help");
+        test.equal(r.getKey(), "Colleagues are standing by to help");
+
+        r = set.getBySource("Ask your co-workers now");
+        test.ok(r);
+        test.equal(r.getSource(), "Ask your co-workers now");
+        test.equal(r.getKey(), "Ask your co-workers now");
+
+        test.done();
+    },
+
+    testHTMLFileExtractFileFullyExtracted2: function(test) {
+        test.expect(11);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p, "./html/mode.html");
+        test.ok(htf);
+
+        // should read the file
+        htf.extract();
+
+        var set = htf.getTranslationSet();
+
+        test.equal(set.size(), 3);
+
+        var r = set.getBySource("Choose a meeting method");
+        test.ok(r);
+        test.equal(r.getSource(), "Choose a meeting method");
+        test.equal(r.getKey(), "Choose a meeting method");
+
+        r = set.getBySource("Test phrase");
+        test.ok(r);
+        test.equal(r.getSource(), "Test phrase");
+        test.equal(r.getKey(), "Test phrase");
+
+        r = set.getBySource("In Person Mode");
+        test.ok(r);
+        test.equal(r.getSource(), "In Person Mode");
+        test.equal(r.getKey(), "In Person Mode");
+
+        test.done();
+    },
+
+    testHTMLFileExtractFileNewResources: function(test) {
+        test.expect(16);
+
+        var base = path.dirname(module.id);
+
+        var p = new WebProject({
+            id: "foo",
+            sourceLocale: "en-US"
+        }, path.join(base, "testfiles"), {
+            locales:["en-GB"]
+        });
+
+        var t = new HTMLFileType(p);
+
+        var htf = new HTMLFile(p, "./html/mode.html", t);
+        test.ok(htf);
+
+        htf.extract();
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "Choose a meeting method",
+            source: "Choose a meeting method",
+            sourceLocale: "en-US",
+            target: "Choisissez une méthode de réunion d'affaires",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        var actual = htf.localizeText(translations, "fr-FR");
+        var expected =
+            '<div class="askHeader">\n' +
+            '  <h3>Choisissez une méthode de réunion d\'affaires</h3>\n' +
+            '</div>\n' +
+            '<div id="chooseMode">\n' +
+            '  <div class="askContent">\n' +
+            '    <div class="specialistInfo">\n' +
+            '      <div class="portraitContainer">\n' +
+            '        <div class="portrait">\n' +
+            '          <img src="http://foo.com/photo.png" height="86px" width="86px"/>\n' +
+            '        </div>\n' +
+            '        <div class="dot on"></div>\n' +
+            '      </div>\n' +
+            '      <div class="rating">\n' +
+            '      </div>\n' +
+            '      <div class="name"></div>\n' +
+            '      <div class="specialty"></div>\n' +
+            '      Ťëšţ þĥŕàšë543210\n' +
+            '    </div>\n' +
+            '    <div class="modeSelection">\n' +
+            '      <div class="modeContents">\n' +
+            '        <h4>Ïñ Pëŕšõñ Mõðë6543210</h4>\n' +
+            '        <p class="description"></p>\n' +
+            '      </div>\n' +
+            '    </div><div class="divider"></div>\n' +
+            '  </div>\n' +
+            '</div>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        var set = t.newres;
+        var resources = set.getAll();
+
+        test.equal(resources.length, 2);
+
+        var r = set.getBySource("Choose a meeting method");
+        test.ok(!r);
+
+        r = set.getBySource("Test phrase");
+        test.ok(r);
+        test.equal(resources[0].getKey(), "Test phrase");
+        test.equal(resources[0].getSource(), "Test phrase");
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.equal(resources[0].getTarget(), "Test phrase");
+        test.equal(resources[0].getTargetLocale(), "fr-FR");
+
+        r = set.getBySource("In Person Mode");
+        test.ok(r);
+        test.equal(resources[1].getKey(), "In Person Mode");
+        test.equal(resources[1].getSource(), "In Person Mode");
+        test.equal(resources[1].getSourceLocale(), "en-US");
+        test.equal(resources[1].getTarget(), "In Person Mode");
+        test.equal(resources[1].getTargetLocale(), "fr-FR");
+
+        test.done();
+    }
+};

--- a/test/testHTMLFile.js
+++ b/test/testHTMLFile.js
@@ -2192,10 +2192,10 @@ module.exports = {
 
         htf.localize(translations, ["fr-FR", "de-DE"]);
 
-        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlowTemplate.fr-FR.html")));
-        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlowTemplate.de-DE.html")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlow.fr-FR.html")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/html/CookieFlow.de-DE.html")));
 
-        var content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlowTemplate.fr-FR.html"), "utf-8");
+        var content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlow.fr-FR.html"), "utf-8");
 
         var expected =
             '<div class="upsell-ad-item clearfix">  \n' +
@@ -2222,7 +2222,7 @@ module.exports = {
         diff(content, expected);
         test.equal(content, expected);
 
-        content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlowTemplate.de-DE.html"), "utf-8");
+        content = fs.readFileSync(path.join(base, "testfiles/html/CookieFlow.de-DE.html"), "utf-8");
 
         test.equal(content,
             '<div class="upsell-ad-item clearfix">  \n' +

--- a/test/testHTMLFileType.js
+++ b/test/testHTMLFileType.js
@@ -1,0 +1,196 @@
+/*
+ * testHTMLFileType.js - test the HTML file type handler object.
+ *
+ * Copyright © 2018, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!HTMLFileType) {
+    var HTMLFileType = require("../lib/HTMLFileType.js");
+    var WebProject =  require("../lib/WebProject.js");
+}
+
+module.exports = {
+    testHTMLFileTypeConstructor: function(test) {
+        test.expect(1);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+
+        test.ok(htf);
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesTrue: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(htf.handles("foo.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesFalseClose: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(!htf.handles("foo.tml"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesTrue: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(htf.handles("foo.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesAlternateExtensionTrue: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(htf.handles("foo.htm"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesTrueWithDir: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(htf.handles("a/b/c/foo.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesAlreadyLocalizedGB: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(!htf.handles("a/b/c/foo.en-GB.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesAlreadyLocalizedCN: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(!htf.handles("a/b/c/foo.zh-Hans-CN.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandlesAlreadyLocalizedWithFlavor: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(!htf.handles("a/b/c/foo.en-ZA-ASDF.html"));
+
+        test.done();
+    },
+
+    testHTMLFileTypeHandleszhHKAlreadyLocalizedWithFlavor: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var htf = new HTMLFileType(p);
+        test.ok(htf);
+
+        test.ok(!htf.handles("a/b/c/foo.zh-Hant-HK-ASDF.html"));
+
+        test.done();
+    }
+};

--- a/test/testfiles/html/CookieFlow.html
+++ b/test/testfiles/html/CookieFlow.html
@@ -1,0 +1,20 @@
+<div class="upsell-ad-item clearfix">  
+    <div class="modal_x"></div>
+    <div class="upsell-ad-content">
+      <div class="upsell-ad-header">
+        <div class="big cookie-flow"></div>
+        <span class="upsell-header-bold"></span>
+        Get insurance quotes for free!
+      </div>
+      <div class="upsell-ad-wrapper" style="padding-left: 0">
+        <a class="specialist-avatar" href="/specialists/234" style="background-image: url(http://foo.com/bar.png);"></a>
+        <input class="askInputArea-cookie desktop" maxlength="150">
+        <span class="askSendArea-cookie">
+          <a class="askSendBtn-cookie" href="/message?from_seo=1">
+            <div class="desktop-btn">Send question</div>
+            <div class="mobile-btn">Ask</div>
+          </a>
+        </span>
+      </div>
+    </div>
+</div>

--- a/test/testfiles/html/meeting_panel.html
+++ b/test/testfiles/html/meeting_panel.html
@@ -1,0 +1,41 @@
+  <div class="meeting-list generic-list-module">
+    <div class="module-header" >
+      <div class="sprite-icon calendar-icon-black"></div>
+      Upcoming Appointments
+      <span class="number"></span>
+   </div>
+    <div class="module-content">
+      <div class="list-container">
+      </div>
+    </div>
+  </div>
+  <div class="meeting-list generic-list-module">
+    <div class="module-header" >
+      <div class="sprite-icon video-icon-black"></div>
+      Completed Meetings
+    </div>
+    <div class="module-content">
+      <div class="list-container">
+      </div>
+    </div>
+  </div>
+
+  <div class="suggested-colleagues-container">
+  </div>
+
+<div class="get-help-container" style="display: block;">
+  <div class="header">
+    <div class="get-help">
+      Get help
+    </div>
+    <div class="explanation">
+    </div>
+  </div>
+  <div class="content">
+    <div class="doc-icon-huge"></div>
+    <div class="online-now">
+      Colleagues are standing by to help
+    </div>
+    <a class="btn wide" href="/ask_colleagues" track_event='menu_meetings_talk_ad' track_data='{"type": "in_app_referrer"}' ><i class="askcolleagues-icon"></i> Ask your co-workers now</a>
+  </div>
+</div>

--- a/test/testfiles/html/mode.html
+++ b/test/testfiles/html/mode.html
@@ -1,0 +1,27 @@
+<div class="askHeader">
+  <h3>Choose a meeting method</h3>
+</div>
+<div id="chooseMode">
+  <div class="askContent">
+    <div class="specialistInfo">
+      <div class="portraitContainer">
+        <div class="portrait">
+          <img src="http://foo.com/photo.png" height="86px" width="86px"/>
+        </div>
+        <div class="dot on"></div>
+      </div>
+      <div class="rating">
+      </div>
+      <div class="name"></div>
+      <div class="specialty"></div>
+      Test phrase
+    </div>
+    <div class="modeSelection">
+      <div class="modeContents">
+        <h4>In Person Mode</h4>
+        <p class="description"></p>
+      </div>
+    </div><!--
+    --><div class="divider"></div>
+  </div>
+</div>

--- a/test/testfiles/html/nostrings.html
+++ b/test/testfiles/html/nostrings.html
@@ -1,0 +1,1 @@
+<div class="noheader"></div>

--- a/test/testfiles/html/topic_navigation_main.html
+++ b/test/testfiles/html/topic_navigation_main.html
@@ -1,0 +1,35 @@
+            <div class="toggle_description_h toggle_description" style="margin-bottom:5px">
+                <div class="topic_icon description" style="pointer-events:none"></div>
+                <div class="topic_name" style="pointer-events:none; margin-top:9px;font-size: 13px;">Description</div>
+            </div>
+            <div class="decription_box_h" style="padding: 10px 5px 10px 17px;font: 100% Open Sans, Helvetica; color: #333; display: none; ">
+                    <div class="feed_item no_bg" style="border: none;">
+                        <div class="feed_item_content" style="padding: 7px 10px 0 54px;">
+                            <div class="avatar_wrapper" style="margin: 0 0px 0px -55px;">
+                                <div class="avatar_mask_div"></div>
+                                <img class="person_avatar wrapped" src="imgs/masks/avatar_no_border.png" alt="">
+                            </div>
+                            <div class="actor_info left" style="width: 93%;margin-top:7px;">
+                                <div class="actor_text expert red ellip left" style="width:93%;line-height:16px;">
+                                    Authored by <a class="actor_link bold" href="#expert_vip/x/">John Smith</a>
+                                </div>
+                                    <div style="margin-left:16px;" class="agrees_layer_h">
+                                        <div class="left" style="margin:2px 6px 0 0 ;">
+                                            and <a class="bold"><span class="friend_agree_count_h">8</span> of your friends agree</a>
+                                        </div>
+                                        <div class="image_div" style="background:url(imgs/masks/actor_avatar.png), url(imgs/masks/top_bar_avatar.png);"></div>
+                                    </div>
+                            </div>
+                        </div>
+                    </div>
+                        <div class="better_discription_con">
+                            <div class="btn grey">
+                                <span class="agree agree_h" style="color:#aaa">Agreed</span>
+                            </div>
+                            <div class="better_discription">
+                                <a class="write_desc_h">Write a better description &raquo;</a>
+                            </div>
+                        </div>
+                <div class="cb10"></div>
+            </div>
+ 

--- a/test/testfiles/html/topic_types.html
+++ b/test/testfiles/html/topic_types.html
@@ -1,0 +1,51 @@
+<div class="topicTypes">
+    <div class="topbarContainer">
+        <div class="topbar">
+            <a class="item description" topic_chooser="#description">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Description</div>
+            </a>
+            <a class="item conditions" topic_chooser="#participants">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Participants (<span class="number"></span>)</div>
+            </a>
+            <a class="item symptoms" topic_chooser="#visitors">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Visitors (<span class="number"></span>)</div>
+            </a>
+            <a class="item treatments" topic_chooser="#spectators">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Spectators (<span class="number"></span>)</div>
+            </a>
+            <a class="item tests" topic_chooser="#tests">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Tests (<span class="number"></span>)</div>
+            </a>
+            <a class="item riskFactors" topic_chooser="#activities">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Activities (<span class="number"></span>)</div>
+            </a>
+            <a class="item resolution" topic_chooser="#solutions">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>Solutions (<span class="number"></span>)</div>
+            </a>
+        </div>
+        <a href="#" class="left arrow"></a>
+        <a href="#" class="right arrow"></a>
+    </div>
+
+    <div class="content">
+        <div class="section devices" id="devices">
+                    <div class="subcatTitle"><div class="icon subcat "></div></div>
+                    <a href="https://foo.com/bar/" class="topicBasic more">
+                        <div class="name"></div>
+                        <div class="salesContainer">
+                            <div class="salesBullet item"></div>
+                            <div class="sales"></div>
+                        </div>
+                    </a>
+                    <a href="#" class="seemoreButton">See more</a>
+        </div>
+
+    </div>
+</div>


### PR DESCRIPTION
Add support for localization of plain html files. The HTML template is added to the web project first, so if the loctool finds a template file, the HTMLTemplateFileType will handle it first. Otherwise, HTMLFileType will handle it as plain HTML and assume it is not a template file.