### PR TITLE
Fix html doctype bug

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,7 +6,7 @@ Build 006
 Published as version 1.1.2
 
 Bug Fixes:
-* HTML files were not localized properly when there is a &lt;!DOCTYPE&gt; tag in the text.
+* HTML and HTML template files were not localized properly when there is a &lt;!DOCTYPE&gt; tag in the text.
 The output included the attributes of the tag, but not the tag itself. This is corrected now.
 
 Build 003

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,14 @@
 Release Notes for Version 1
 ============================
 
+Build 006
+-------
+Published as version 1.1.2
+
+Bug Fixes:
+* HTML files were not localized properly when there is a &lt;!DOCTYPE&gt; tag in the text.
+The output included the attributes of the tag, but not the tag itself. This is corrected now.
+
 Build 003
 -------
 Published as version 1.1.1

--- a/lib/HTMLFile.js
+++ b/lib/HTMLFile.js
@@ -353,7 +353,7 @@ HTMLFile.prototype.parse = function(data) {
         }.bind(this),
         docType: function(value) {
             logger.trace('doctype: %s', value);
-            this.accumulator += value;
+            this.accumulator += "<!DOCTYPE " + value + ">";
         }.bind(this),
         text: function(value) {
             logger.trace('text: value is "' + value + '"');

--- a/lib/HTMLTemplateFile.js
+++ b/lib/HTMLTemplateFile.js
@@ -353,7 +353,7 @@ HTMLTemplateFile.prototype.parse = function(data) {
         }.bind(this),
         docType: function(value) {
             logger.trace('doctype: %s', value);
-            this.accumulator += value;
+            this.accumulator += "<!DOCTYPE " + value + ">";
         }.bind(this),
         text: function(value) {
             logger.trace('text: value is "' + value + '"');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testHTMLFile.js
+++ b/test/testHTMLFile.js
@@ -453,6 +453,43 @@ module.exports.htmlfile = {
         test.done();
     },
 
+    testHTMLFileParseIgnoreDoctypeTag: function(test) {
+        test.expect(6);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse(
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+                '<html>\n' +
+                '   <body>\n' +
+                '       This is a test\n' +
+                '       <div id="foo">\n' +
+                '           This is also a test\n' +
+                '       </div>\n' +
+                '       This is a test\n' +
+                '   </body>\n' +
+                '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        test.equal(set.size(), 2);
+
+        test.done();
+    },
+
     testHTMLFileParseDontEscapeWhitespaceChars: function(test) {
         test.expect(5);
 

--- a/test/testHTMLFile.js
+++ b/test/testHTMLFile.js
@@ -1365,6 +1365,64 @@ module.exports.htmlfile = {
         test.done();
     },
 
+    testHTMLFileLocalizeTextWithDoctypeTag: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLFile(p);
+        test.ok(htf);
+
+        htf.parse(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       This is a test\n' +
+            '       <div id="foo">\n' +
+            '           This is also a test\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       Ceci est un essai\n' +
+            '       <div id="foo">\n' +
+            '           Ceci est aussi un essai\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        test.done();
+    },
+
     testHTMLFileLocalizeTextSkipScript: function(test) {
         test.expect(2);
 

--- a/test/testHTMLFile.js
+++ b/test/testHTMLFile.js
@@ -466,16 +466,16 @@ module.exports.htmlfile = {
         test.ok(htf);
 
         htf.parse(
-                '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
-                '<html>\n' +
-                '   <body>\n' +
-                '       This is a test\n' +
-                '       <div id="foo">\n' +
-                '           This is also a test\n' +
-                '       </div>\n' +
-                '       This is a test\n' +
-                '   </body>\n' +
-                '</html>\n');
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       This is a test\n' +
+            '       <div id="foo">\n' +
+            '           This is also a test\n' +
+            '       </div>\n' +
+            '       This is a test\n' +
+            '   </body>\n' +
+            '</html>\n');
 
         var set = htf.getTranslationSet();
         test.ok(set);

--- a/test/testHTMLTemplateFile.js
+++ b/test/testHTMLTemplateFile.js
@@ -453,6 +453,45 @@ module.exports.htmltemplatefile = {
         test.done();
     },
 
+    testHTMLTemplateFileParseIgnoreDoctypeTag: function(test) {
+        test.expect(8);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLTemplateFile(p);
+        test.ok(htf);
+
+        htf.parse(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       This is a test\n' +
+            '       <div id="foo">\n' +
+            '           This is also a test\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        var set = htf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "This is a test");
+
+        r = set.getBySource("This is also a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is also a test");
+        test.equal(r.getKey(), "This is also a test");
+
+        test.done();
+    },
+
     testHTMLTemplateFileParseDontEscapeWhitespaceChars: function(test) {
         test.expect(5);
 
@@ -1709,6 +1748,64 @@ module.exports.htmltemplatefile = {
                 '       Ceci est un essai\n' +
                 '   </body>\n' +
                 '</html>\n');
+
+        test.done();
+    },
+
+    testHTMLTemplateFileLocalizeTextWithDoctypeTag: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US",
+            id: "foo"
+        }, "./testfiles", {
+            locales:["en-GB"]
+        });
+
+        var htf = new HTMLTemplateFile(p);
+        test.ok(htf);
+
+        htf.parse(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       This is a test\n' +
+            '       <div id="foo">\n' +
+            '           This is also a test\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "This is also a test",
+            source: "This is also a test",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai",
+            targetLocale: "fr-FR",
+            datatype: "html"
+        }));
+
+        test.equal(htf.localizeText(translations, "fr-FR"),
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+            '<html>\n' +
+            '   <body>\n' +
+            '       Ceci est un essai\n' +
+            '       <div id="foo">\n' +
+            '           Ceci est aussi un essai\n' +
+            '       </div>\n' +
+            '   </body>\n' +
+            '</html>\n');
 
         test.done();
     },


### PR DESCRIPTION
HTML files were not localized properly when there is a &lt;!DOCTYPE&gt; tag in the text.
The output included the attributes of the tag, but not the tag itself. This is corrected now.