### PR TITLE
Fixes to support Readme.io markdown

### DIFF
--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -62,8 +62,53 @@ var mdparser = unified().
 var mdstringify = unified().
     use(stringify, {
         commonmark: true,
-        gfm: true
+        gfm: true,
+        rule: '-',
+        ruleSpaces: false,
+        bullet: '*',
+        listItemIndent: 1
     })();
+
+function escapeQuotes(str) {
+    var ret = "";
+    if (str.length < 1) {
+        return '';
+    }
+    var inQuote = false;
+
+    for (var i = 0; i < str.length; i++) {
+        switch (str[i]) {
+        case '"':
+            if (inQuote) {
+                if (i+1 < str.length-1 && str[i+1] !== '\n') {
+                    ret += '\\';
+                }
+            } else {
+                inQuote = true;
+            }
+            ret += '"';
+            break;
+        case '\n':
+            inQuote = false;
+            ret += '\n';
+            break;
+        case '\\':
+            ret += '\\';
+            if (i+1 < str.length-1) {
+                i++;
+                if (str[i] !== '\\') {
+                    ret += str[i];
+                }
+            }
+            break;
+        default:
+            ret += str[i];
+            break;
+        }
+    }
+
+    return ret;
+};
 
 /**
  * Create a new Markdown file with the given path name and within
@@ -493,6 +538,11 @@ MarkdownFile.prototype._walk = function(node) {
 MarkdownFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
 
+    // massage the broken headers a bit first so that the parser works
+    data = data.
+        replace(/\[block:/g, "\n[block:").
+        replace(/(^|\n)(#+)([^#\s])/g, "\n$2 $3");
+
     this.ast = mdparser.parse(data);
 
     // accumulates characters in text segments
@@ -872,8 +922,15 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
         } else if (nodeArray[i].type === 'thematicBreak') {
             if (i+2 < nodeArray.length && nodeArray[i+1] && nodeArray[i+2]) {
                 if (nodeArray[i+1].type === 'paragraph' &&
-                    nodeArray[i+2].type === "text" &&
-                    nodeArray[i+2].value.substring(0, 6) === "title:") {
+                        nodeArray[i+2].type === "text" &&
+                        nodeArray[i+2].value.substring(0, 6) === "title:") {
+                    // glue all the subsequent contiguous text nodes together as one
+                    var tmpStr = "";
+                    for (var j = i+2; j < nodeArray.length && nodeArray[j].type === "text"; j++) {
+                        tmpStr += nodeArray[j].value;
+                    }
+                    nodeArray[i+2].value = escapeQuotes(tmpStr);
+                    nodeArray.splice(i+2, j-i-2, nodeArray[i+2]);
                     valid = false;
                 } else {
                     valid = true;
@@ -919,6 +976,14 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     ast = mapToAst(Node.fromArray(nodeArray));
 
     var str = mdstringify.stringify(ast);
+
+    // make sure the thematic breaks don't have blank lines after them and they
+    // don't erroneously escape the backslash chars
+    str = str.
+        replace(/---\n\n/g, "---\n").
+        replace(/\n\n---/g, "\n---").
+        replace(/\\\\n/g, "\\n").
+        replace(/\\\\"/g, '\\"');
 
     return str;
 };

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -93,12 +93,18 @@ function escapeQuotes(str) {
             ret += '\n';
             break;
         case '\\':
-            ret += '\\';
             if (i+1 < str.length-1) {
                 i++;
-                if (str[i] !== '\\') {
+                if (str[i] === '[') {
                     ret += str[i];
+                } else {
+                    ret += '\\';
+                    if (str[i] !== '\\') {
+                        ret += str[i];
+                    }
                 }
+            } else {
+                ret += '\\';
             }
             break;
         default:
@@ -287,7 +293,7 @@ MarkdownFile.prototype._findAttributes = function(tagName, tag) {
     reAttrNameAndValue.lastIndex = 0;
     while ((match = reAttrNameAndValue.exec(tag)) !== null) {
         var name = match[1],
-            value = match[5].trim();
+            value = (match[5] && match[5].trim()) || "";
         if (value && name === "title" || (utils.localizableAttributes[tagName] && utils.localizableAttributes[tagName][name])) {
             this._addTransUnit(value);
         }
@@ -369,13 +375,10 @@ MarkdownFile.prototype._walk = function(node) {
             // this.text += '<c' + thisComponent + '>';
             node.title && this._addTransUnit(node.title);
             if (node.children && node.children.length) {
-                var doPushPop = (this.message.getTextLength() > 0);
-                if (doPushPop) {
-                    this.message.push({
-                        name: node.type,
-                        node: node
-                    });
-                }
+                this.message.push({
+                    name: node.type,
+                    node: node
+                });
                 valid = true;
                 node.children.forEach(function(child) {
                     if (child.type === 'linkReference') {
@@ -391,11 +394,9 @@ MarkdownFile.prototype._walk = function(node) {
                         this._walk(child);
                     }
                 }.bind(this));
-                if (doPushPop) {
-                    this.message.pop();
-                }
+                this.message.pop();
 
-                node.localizable = doPushPop && node.children.every(function(child) {
+                node.localizable = node.children.every(function(child) {
                     return child.localizable;
                 });
             }
@@ -538,9 +539,11 @@ MarkdownFile.prototype._walk = function(node) {
 MarkdownFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
 
-    // massage the broken headers a bit first so that the parser works
+    // massage the broken headers and code blocks a bit first so that the parser
+    // works as expected
     data = data.
-        replace(/\[block:/g, "\n[block:").
+        replace(/\[block:/g, "```\n[block:").
+        replace(/\[\/block\]/g, "[/block]\n```").
         replace(/(^|\n)(#+)([^#\s])/g, "\n$2 $3");
 
     this.ast = mdparser.parse(data);
@@ -821,6 +824,9 @@ function mapToAst(node) {
             children.push(child);
         }
     }
+    if (node.type === "code" && node.value.startsWith("[block:")) {
+        node.type = "html";
+    }
     if (node.extra) {
         node.extra.children = children;
         return node.extra;
@@ -839,7 +845,7 @@ MarkdownFile.prototype._getTranslationNodes = function(locale, translations, ma)
 
     var key = this.makeKey(utils.escapeInvalidChars(trimmed.text));
     var translation = this._localizeString(trimmed.text, locale, translations);
-    
+
     if (translation) {
         // preserve the whitespace that the source used to preserve indentation, etc.
         var translated = (trimmed.pre || "") + translation + (trimmed.post || "");
@@ -961,6 +967,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
             start = -1;
             ma = new MessageAccumulator();
         }
+        if (!valid && nodeArray[i] && nodeArray[i].value) nodeArray[i].value = escapeQuotes(nodeArray[i].value);
     }
 
     // in case any is left over at the end
@@ -981,9 +988,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     // don't erroneously escape the backslash chars
     str = str.
         replace(/---\n\n/g, "---\n").
-        replace(/\n\n---/g, "\n---").
-        replace(/\\\\n/g, "\\n").
-        replace(/\\\\"/g, '\\"');
+        replace(/\n\n---/g, "\n---");
 
     return str;
 };

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -801,12 +801,11 @@ module.exports.markdown = {
         var set = mf.getTranslationSet();
         test.ok(set);
 
-        // should not pick up the emphasis marker because there is no localizable text
-        // before it or after it
-        var r = set.getBySource("This is a test of the emergency parsing system.");
+        // should pick up the emphasis markers
+        var r = set.getBySource("<c0>This is a test of the emergency parsing system.</c0>");
         test.ok(r);
-        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
-        test.equal(r.getKey(), "r699762575");
+        test.equal(r.getSource(), "<c0>This is a test of the emergency parsing system.</c0>");
+        test.equal(r.getKey(), "r49032733");
 
         test.done();
     },
@@ -1411,10 +1410,10 @@ module.exports.markdown = {
         var translations = new TranslationSet();
         translations.add(new ResourceString({
             project: "foo",
-            key: "r699762575",
-            source: "This is a test of the emergency parsing system.",
+            key: "r49032733",
+            source: "<c0>This is a test of the emergency parsing system.</c0>",
             sourceLocale: "en-US",
-            target: "Ceci est un essai du système d'analyse syntaxique de l'urgence.",
+            target: "<c0>Ceci est un essai du système d'analyse syntaxique de l'urgence.</c0>",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
@@ -1869,8 +1868,7 @@ module.exports.markdown = {
             '---\n' +
             '# Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n' +
             '\n' +
-            'Ceci est du texte. C\'est plus de texte. Joli, joli texte.\n' +
-            '\n' +
+            'Ceci est du texte. C\'est plus de texte. Joli, joli texte.\n\n' +
             '[block:code]\n' +
             '{\n' +
             '  "codes": [\n' +
@@ -1881,7 +1879,7 @@ module.exports.markdown = {
             '    }\n' +
             '  ]\n' +
             '}\n' +
-            '[/block]\n' +
+            '[/block]\n\n' +
             'Ceci est de la texte localisable. Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n\n' +
             '[block:parameters]\n' +
             '{\n' +
@@ -1894,7 +1892,7 @@ module.exports.markdown = {
             '  "cols": 3,\n' +
             '  "rows": 5\n' +
             '}\n' +
-            '[/block]\n' +
+            '[/block]\n\n' +
             'C\'est le dernier morceau de texte localisable.\n' +
             '\n' +
             'Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n';
@@ -1911,8 +1909,7 @@ module.exports.markdown = {
             '---\n' +
             '# Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n' +
             '\n' +
-            'Dies ist ein Text. Dies ist mehr Text. Hübscher, hübscher Text.\n' +
-            '\n' +
+            'Dies ist ein Text. Dies ist mehr Text. Hübscher, hübscher Text.\n\n' +
             '[block:code]\n' +
             '{\n' +
             '  "codes": [\n' +
@@ -1923,7 +1920,7 @@ module.exports.markdown = {
             '    }\n' +
             '  ]\n' +
             '}\n' +
-            '[/block]\n' +
+            '[/block]\n\n' +
             'Dies ist ein lokalisierbarer Text. Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n\n' +
             '[block:parameters]\n' +
             '{\n' +
@@ -1936,7 +1933,7 @@ module.exports.markdown = {
             '  "cols": 3,\n' +
             '  "rows": 5\n' +
             '}\n' +
-            '[/block]\n' +
+            '[/block]\n\n' +
             'Dies ist der letzte Teil des lokalisierbaren Textes.\n' +
             '\n' +
             'Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n';
@@ -2093,14 +2090,12 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
             '* article du liste No. 1\n' +
-            '* article du liste No. 2\n' +
-            '\n' +
+            '* article du liste No. 2\n\n' +
             '[block:callout]\n' +
             '{\n' +
             '  "type": "test"\n' +
             '}\n' +
-            '[/block]\n' +
-            '\n' +
+            '[/block]\n\n' +
             '## Entête du Teste\n');
 
         test.done();
@@ -2155,7 +2150,7 @@ module.exports.markdown = {
             '{\n' +
             '  "codes": [\n' +
             '    {\n' +
-            '      "code": "aws cloudformation describe-stacks \\\n    --stack-name boxskill \\\n    --query \'Stacks[].Outputs\'\n# Your URL should look something like this:\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
+            '      "code": "aws cloudformation describe-stacks \\\\\\n    --stack-name boxskill \\\\\\n    --query \'Stacks[].Outputs\'\\n# Your URL should look something like this:\\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
             '      "language": "shell"\n' +
             '    }\n' +
             '  ]\n' +
@@ -2173,22 +2168,53 @@ module.exports.markdown = {
             datatype: "markdown"
         }));
 
-        test.equal(mf.localizeText(translations, "fr-FR"),
+        var actual = mf.localizeText(translations, "fr-FR");
+        var expected =
             'Teste\n\n' +
             '[block:code]\n' +
             '{\n' +
             '  "codes": [\n' +
             '    {\n' +
-            '      "code": "aws cloudformation describe-stacks \\\n    --stack-name boxskill \\\n    --query \'Stacks[].Outputs\'\n# Your URL should look something like this:\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
+            '      "code": "aws cloudformation describe-stacks \\\\\\n    --stack-name boxskill \\\\\\n    --query \'Stacks[].Outputs\'\\n# Your URL should look something like this:\\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
             '      "language": "shell"\n' +
             '    }\n' +
             '  ]\n' +
             '}\n' +
-            '[/block]\n' +
-            'Teste\n');
+            '[/block]\n\n' +
+            'Teste\n';
+
+        diff(actual, expected);
+
+        test.equal(actual, expected);
 
         test.done();
     },
+
+    testMarkdownFileParseMultipleMDComponents: function(test) {
+        test.expect(9);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'Integration samples include: \n' +
+            '* **[File Workflow with Webhooks](/docs/file-workflow-with-webhooks)**: Creating file task automation with webhooks.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        var r = set.getBySource("Integration samples include:");
+        test.ok(r);
+        test.equal(r.getSource(), "Integration samples include:");
+        test.equal(r.getKey(), "r537538527");
+
+        r = set.getBySource("<c0><c1>File Workflow with Webhooks</c1></c0>: Creating file task automation with webhooks.");
+        test.ok(r);
+        test.equal(r.getSource(), "<c0><c1>File Workflow with Webhooks</c1></c0>: Creating file task automation with webhooks.");
+        test.equal(r.getKey(), "r663481768");
+
+        test.done();
+    }
 };
-
-

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2141,7 +2141,54 @@ module.exports.markdown = {
             '# Entête mal\n');
 
         test.done();
-    }
+    },
+
+    testMarkdownFileLocalizeTextDontEscapeCode: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'test\n' +
+            '[block:code]\n' +
+            '{\n' +
+            '  "codes": [\n' +
+            '    {\n' +
+            '      "code": "aws cloudformation describe-stacks \\\n    --stack-name boxskill \\\n    --query \'Stacks[].Outputs\'\n# Your URL should look something like this:\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
+            '      "language": "shell"\n' +
+            '    }\n' +
+            '  ]\n' +
+            '}\n' +
+            '[/block]\n' +
+            'test\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r852587715',
+            source: 'test',
+            target: 'Teste',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Teste\n\n' +
+            '[block:code]\n' +
+            '{\n' +
+            '  "codes": [\n' +
+            '    {\n' +
+            '      "code": "aws cloudformation describe-stacks \\\n    --stack-name boxskill \\\n    --query \'Stacks[].Outputs\'\n# Your URL should look something like this:\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
+            '      "language": "shell"\n' +
+            '    }\n' +
+            '  ]\n' +
+            '}\n' +
+            '[/block]\n' +
+            'Teste\n');
+
+        test.done();
+    },
 };
 
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1863,10 +1863,10 @@ module.exports.markdown = {
         var content = fs.readFileSync(path.join(base, p.root, "fr-FR/md/test1.md"), "utf-8");
 
         var expected =
-            '* * *\n\n' +
+            '---\n' +
             'title: "This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself."\n' +
-            'excerpt: ""\n\n' +
-            '* * *\n\n' +
+            'excerpt: ""\n' +
+            '---\n' +
             '# Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n' +
             '\n' +
             'Ceci est du texte. C\'est plus de texte. Joli, joli texte.\n' +
@@ -1882,7 +1882,7 @@ module.exports.markdown = {
             '  ]\n' +
             '}\n' +
             '[/block]\n' +
-            'Ceci est de la texte localisable. Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n' +
+            'Ceci est de la texte localisable. Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n\n' +
             '[block:parameters]\n' +
             '{\n' +
             '  "data": {\n' +
@@ -1905,10 +1905,10 @@ module.exports.markdown = {
         var content = fs.readFileSync(path.join(base, p.root, "de-DE/md/test1.md"), "utf-8");
 
         var expected =
-            '* * *\n\n' +
+            '---\n' +
             'title: "This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself."\n' +
-            'excerpt: ""\n\n' +
-            '* * *\n\n' +
+            'excerpt: ""\n' +
+            '---\n' +
             '# Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n' +
             '\n' +
             'Dies ist ein Text. Dies ist mehr Text. Hübscher, hübscher Text.\n' +
@@ -1924,7 +1924,7 @@ module.exports.markdown = {
             '  ]\n' +
             '}\n' +
             '[/block]\n' +
-            'Dies ist ein lokalisierbarer Text. Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n' +
+            'Dies ist ein lokalisierbarer Text. Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n\n' +
             '[block:parameters]\n' +
             '{\n' +
             '  "data": {\n' +
@@ -2045,6 +2045,100 @@ module.exports.markdown = {
         test.equal(resources[1].getSourceLocale(), "en-US");
         test.equal(resources[1].getTarget(), "In Person Mode");
         test.equal(resources[1].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithListAndBlockWithNoSpace: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            '* list item 1\n' +
+            '* list item 2\n' +
+            '[block:callout]\n' +
+            '{\n' +
+            '  "type": "test"\n' +
+            '}\n' +
+            '[/block]\n' +
+            '## Test Header\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r970090275',
+            source: 'list item 1',
+            target: 'article du liste No. 1',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r970155796',
+            source: 'list item 2',
+            target: 'article du liste No. 2',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r34696891',
+            source: 'Test Header',
+            target: 'Entête du Teste',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            '* article du liste No. 1\n' +
+            '* article du liste No. 2\n' +
+            '\n' +
+            '[block:callout]\n' +
+            '{\n' +
+            '  "type": "test"\n' +
+            '}\n' +
+            '[/block]\n' +
+            '\n' +
+            '## Entête du Teste\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextHeaderWithNoSpace: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            '#Bad Header\n' +
+            '##Other Bad Header\n' +
+            '# Bad Header\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r868915655',
+            source: 'Bad Header',
+            target: 'Entête mal',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r836504731',
+            source: 'Other Bad Header',
+            target: 'Autre entête mal',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            '# Entête mal\n\n' +
+            '## Autre entête mal\n\n' +
+            '# Entête mal\n');
 
         test.done();
     }


### PR DESCRIPTION
- Fix the header spacing for the thematic breaks, which apparently readme.io is very sensitive about
- Make sure there is a space before each [block:] so that the parser works correctly
- Make sure there is a space after the hash sign header so that the parser works correctly when parsing headings
- Don't touch any code between [block:...] and [/block]
- Include any outer components. The translators can deal with them.
- Make sure we don't get rid of components that start out as outer components but end mid way through the string