### PR TITLE
MOJI-832: allow duplicate resources in the *-extracted.xliff files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -135,6 +135,14 @@ limitations under the License.
 		</sequential>
 	</macrodef>
 
+    <target name="test.resource" description="Run only the resource tests">
+        <run script="${build.test}/testResource.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
+
+    <target name="debug.resource" description="Debug only the resource tests">
+        <debug script="${build.test}/testResource.js" dir="${build.test}"/>
+    </target>
+
 	<target name="test.resourcestring" description="Run only the resource string tests">
 		<run script="${build.test}/testResourceString.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
 	</target>
@@ -559,7 +567,7 @@ limitations under the License.
         <debug script="${build.test}/testJsxFileType.js" dir="${build.test}"/>
     </target>
 
-	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile">
+	<target name="test" depends="test.translationset,test.set,test.resource,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile">
 	</target>
 
 	<macrodef name="runsql">

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -439,7 +439,8 @@ Project.prototype.close = function(cb) {
 
     logger.info("Writing out the extracted strings to " + extractedPath);
     var extractedXliff = new Xliff({
-        pathName: extractedPath
+        pathName: extractedPath,
+        allowDups: true
     });
     extractedXliff.addSet(extracted);
     fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -1,7 +1,7 @@
 /*
  * Resource.js - super class that represents an a resource
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2019 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ var Resource = function(props) {
         this.flavor = props.flavor;
     }
 
+    this.instances = [];
     this.pathName = this.pathName || "";
 };
 
@@ -310,6 +311,95 @@ Resource.prototype.escapeText = function(str) {
         }
         return str.toString();
     }
+};
+
+var translationImportant = [
+    "context",
+    "datatype",
+    "dnt",
+    "flavor",
+    "project",
+    "reskey",
+    "resType",
+    "sourceLocale",
+    "targetLocale"
+];
+
+/**
+ * Add an instance of the same resource to the list of
+ * instances. If the given resource matches the
+ * current instance in all properties that affect the
+ * possible translation, and differs from the current
+ * instance by some property that does not affect
+ * its translation, it will be added as an instance of
+ * the same string. The following properties affect the
+ * translation:
+ *
+ * <ul>
+ * <li>context</li>
+ * <li>datatype</li>
+ * <li>dnt</li>
+ * <li>flavor</li>
+ * <li>project</li>
+ * <li>reskey</li>
+ * <li>resType</li>
+ * <li>source</li>
+ * <li>sourceHash</li>
+ * <li>sourceArray</li>
+ * <li>sourceLocale</li>
+ * <li>targetLocale</li>
+ * </ul>
+ *
+ * Differences in other properties, such as "comment" or
+ * "origin" are considered instances of the same resource.
+ *
+ * If this method is given a resource that differs from
+ * the current one by one of the above translation affecting
+ * properties, it is not added to the list of instances. This
+ * can be checked easily by calling the isInstance() method.
+ *
+ * @param {Resource} an instance of the current resource to
+ * record
+ * @returns {boolean} true if the instance was added, and
+ * and false otherwise
+ */
+Resource.prototype.addInstance = function(resource) {
+    if (!this.isInstance(resource)) {
+        return false;
+    }
+
+    this.instances.push(resource);
+    return true;
+};
+
+/**
+ * Check if the given resource is an instance of the current
+ * resource. This method returns true if all properties which
+ * affect the possible translation match between the given and
+ * the current resource.
+ *
+ * @param {Resource} a resource to check
+ * @returns {boolean} true if this is an instance of
+ * the current resource, false otherwise.
+ */
+Resource.prototype.isInstance = function(resource) {
+    if (typeof(resource) !== 'object' || !(resource instanceof Resource)) {
+        return false;
+    }
+
+    return translationImportant.every(function(prop) {
+        return this[prop] === resource[prop];
+    }.bind(this));
+};
+
+/**
+ * Return the list of instances of the current resource.
+ *
+ * @returns {Array.<Resource>} the list of instances of
+ * the current resource
+ */
+Resource.prototype.getInstances = function() {
+    return this.instances;
 };
 
 module.exports = Resource;

--- a/lib/ResourceArray.js
+++ b/lib/ResourceArray.js
@@ -468,4 +468,24 @@ ResourceArray.prototype.cleanHashKeyForTranslation = function(locale) {
     return ResourceArray.hashKey(this.project, this.context, locale, cleaned);
 };
 
+/**
+ * Check if the given resource is an instance of the current
+ * resource.
+ *
+ * @override
+ * @param {Resource} a resource to check
+ * @returns {boolean} true if this is an instance of
+ * the current resource, false otherwise.
+ */
+ResourceArray.prototype.isInstance = function(resource) {
+    if (!Resource.prototype.isInstance.call(this, resource)) {
+        return false;
+    }
+
+    // now check the properties specific to this resource subclass
+    return this.sourceArray.every(function(str, i) {
+        return str === resource.sourceArray[i];
+    }.bind(this));
+};
+
 module.exports = ResourceArray;

--- a/lib/ResourcePlural.js
+++ b/lib/ResourcePlural.js
@@ -408,4 +408,24 @@ ResourcePlural.prototype.cleanhashKeyForTranslation = function(locale) {
     return ResourcePlural.hashKey(this.project, this.context, locale, cleaned);
 };
 
+/**
+ * Check if the given resource is an instance of the current
+ * resource.
+ *
+ * @override
+ * @param {Resource} a resource to check
+ * @returns {boolean} true if this is an instance of
+ * the current resource, false otherwise.
+ */
+ResourcePlural.prototype.isInstance = function(resource) {
+    if (!Resource.prototype.isInstance.call(this, resource)) {
+        return false;
+    }
+
+    // now check the properties specific to this resource subclass
+    return Object.keys(this.sourceStrings).every(function(prop) {
+        return this.sourceStrings[prop] === resource.sourceStrings[prop];
+    }.bind(this));
+};
+
 module.exports = ResourcePlural;

--- a/lib/ResourceString.js
+++ b/lib/ResourceString.js
@@ -274,4 +274,22 @@ ResourceString.prototype.cleanHashKeyForTranslation = function(locale) {
     return ResourceString.cleanHashKey(this.project, locale, this.reskey, this.datatype, this.flavor);
 };
 
+/**
+ * Check if the given resource is an instance of the current
+ * resource.
+ *
+ * @override
+ * @param {Resource} a resource to check
+ * @returns {boolean} true if this is an instance of
+ * the current resource, false otherwise.
+ */
+ResourceString.prototype.isInstance = function(resource) {
+    if (!Resource.prototype.isInstance.call(this, resource)) {
+        return false;
+    }
+
+    // now check the properties specific to this resource subclass
+    return this.source === resource.source;
+};
+
 module.exports = ResourceString;

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -30,10 +30,17 @@ var logger = log4js.getLogger("loctool.lib.TranslationSet");
  * @class A class that represents a set of translations used in
  * a project.
  *
+ * The options parameter may contain any of the following properties:
+ * 
+ * <ul>
+ * <li>allowDupsBySourceFile - if true, allow the same resource to exist
+ * in multiple source files</li>
+ * </ul>
  * @constructor
  * @param {String} sourceLocale the source locale for this set
+ * @param {Object=} options options controlling this set
  */
-var TranslationSet = function(sourceLocale) {
+var TranslationSet = function(sourceLocale, options) {
     this.sourceLocale = sourceLocale || "zxx-XX";
 
     this.resources = [];
@@ -41,6 +48,8 @@ var TranslationSet = function(sourceLocale) {
     this.byCleanKey = {};
     this.dirty = false;
     this.stringsBySource = {};
+    
+    this.dedupBySourceFile = options && options.dedupBySourceFile;
 };
 
 /**

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -40,7 +40,7 @@ var logger = log4js.getLogger("loctool.lib.TranslationSet");
  * @param {String} sourceLocale the source locale for this set
  * @param {Object=} options options controlling this set
  */
-var TranslationSet = function(sourceLocale, options) {
+var TranslationSet = function(sourceLocale) {
     this.sourceLocale = sourceLocale || "zxx-XX";
 
     this.resources = [];
@@ -49,7 +49,7 @@ var TranslationSet = function(sourceLocale, options) {
     this.dirty = false;
     this.stringsBySource = {};
 
-    this.dedupBySourceFile = options && options.dedupBySourceFile;
+    //this.dedupBySourceFile = options && options.dedupBySourceFile;
 };
 
 /**
@@ -268,9 +268,10 @@ TranslationSet.prototype._select = function(criteria) {
     return this.resources.filter(function(res) {
         return fields.every(function(field) {
             return ilib.isArray(criteria[field]) ?
+                (criteria[field].length === 0 ||
                 criteria[field].some(function(value) {
                     return res[field] === value;
-                }) :
+                })) :
                 res[field] === criteria[field];
         });
     });

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -129,7 +129,9 @@ TranslationSet.prototype.add = function(resource) {
 
     if (existing) {
         logger.trace("Same key as existing resource: " + JSON.stringify(existing));
-        if (resource.resType === "string") {
+        if (existing.isInstance(resource)) {
+            existing.addInstance(resource);
+        } else if (resource.resType === "string") {
             if (resource.getSource() !== existing.getSource() ||
                     resource.getComment() !== existing.getComment() ||
                     resource.getState() !== existing.getState() ||

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -31,7 +31,7 @@ var logger = log4js.getLogger("loctool.lib.TranslationSet");
  * a project.
  *
  * The options parameter may contain any of the following properties:
- * 
+ *
  * <ul>
  * <li>allowDupsBySourceFile - if true, allow the same resource to exist
  * in multiple source files</li>
@@ -48,7 +48,7 @@ var TranslationSet = function(sourceLocale, options) {
     this.byCleanKey = {};
     this.dirty = false;
     this.stringsBySource = {};
-    
+
     this.dedupBySourceFile = options && options.dedupBySourceFile;
 };
 

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -106,7 +106,7 @@ TranslationUnit.prototype.clone = function() {
  * <li><i>tool-company</i> - the name of the company that made this tool
  * <li><i>copyright</i> - a copyright notice that you would like included into the xliff file
  * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
- * <li><i>allowdups</i> - allow duplicate resources in the xliff. By default, dups are
+ * <li><i>allowDups</i> - allow duplicate resources in the xliff. By default, dups are
  * filtered out. This option allows you to have trans-units that represent instances of the
  * same resource in the file with different metadata. For example, two instances of a
  * resource may have different comments which may both be useful to translators or
@@ -127,7 +127,7 @@ var Xliff = function Xliff(options) {
         this.path = options.path;
         this.sourceLocale = options.sourceLocale;
         this.project = options.project;
-        this.allowdups = options.allowdups;
+        this.allowDups = options.allowDups;
     }
 
     this.sourceLocale = this.sourceLocale || "en-US";
@@ -204,7 +204,7 @@ Xliff.prototype.addTranslationUnit = function(unit) {
     }
 
     var oldUnit = this.tuhash[hashKeyTarget];
-    if (oldUnit) {
+    if (oldUnit && !this.allowDups) {
         logger.trace("Merging unit");
         // update the old unit with this new info
         JSUtils.shallowCopy(unit, oldUnit);
@@ -230,8 +230,11 @@ Xliff.prototype.addTranslationUnits = function(units) {
 /**
  * Add a resource to this xliff file. If a resource
  * with the same file, locale, context, and key already
- * exists in this xliff file, it will be
- * replaced instead of adding this unit to the file.
+ * exists in this xliff file, what happens to it is
+ * determined by the allowDups option. If this is false,
+ * the existing resource will be replaced, and if it
+ * is true, this new resource will be added as an
+ * instance of the existing resource.
  *
  * @param {Resource} res a resource to add
  */
@@ -450,13 +453,14 @@ function unescapeAttr(str) {
 }
 
 /**
- * Convert a resource into translation units.
+ * Convert a resource into one or more translation units.
  *
+ * @private
  * @param {Resource} res the resource to convert
  * @returns {Array.<TranslationUnit>} an array of translation units
  * that represent the resource
  */
-Xliff.prototype.convertResource = function(res) {
+Xliff.prototype._convertResource = function(res) {
     var units = [], tu;
 
     try {
@@ -570,6 +574,28 @@ Xliff.prototype.convertResource = function(res) {
 };
 
 /**
+ * Convert a resource into translation units.
+ *
+ * @param {Resource} res the resource to convert
+ * @returns {Array.<TranslationUnit>} an array of translation units
+ * that represent the resource
+ */
+Xliff.prototype.convertResource = function(res) {
+    var ret = this._convertResource(res);
+
+    if (this.allowDups) {
+        var instances = res.getInstances();
+        if (instances && instances.length) {
+            instances.forEach(function(instance) {
+                ret = ret.concat(this._convertResource(instance));
+            }.bind(this));
+        }
+    }
+
+    return ret;
+};
+
+/**
  * Serialize this xliff instance to a string that contains
  * the xliff format xml text.
  *
@@ -603,12 +629,6 @@ Xliff.prototype.serialize = function(untranslated) {
             var res = resources[i];
             if (res.getTargetLocale() !== this.sourceLocale) {
                 units = units.concat(this.convertResource(res));
-            }
-
-            if (this.allowdups) {
-                res.getInstances().forEach(function(resource) {
-                    units = units.concat(this.convertResource(resource));
-                }.bind(this));
             }
         }
     }

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -106,6 +106,11 @@ TranslationUnit.prototype.clone = function() {
  * <li><i>tool-company</i> - the name of the company that made this tool
  * <li><i>copyright</i> - a copyright notice that you would like included into the xliff file
  * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
+ * <li><i>allowdups</i> - allow duplicate resources in the xliff. By default, dups are
+ * filtered out. This option allows you to have trans-units that represent instances of the
+ * same resource in the file with different metadata. For example, two instances of a
+ * resource may have different comments which may both be useful to translators or
+ * two instances of the same resource may have been extracted from different source files.
  * </ul>
  *
  * @constructor
@@ -122,6 +127,7 @@ var Xliff = function Xliff(options) {
         this.path = options.path;
         this.sourceLocale = options.sourceLocale;
         this.project = options.project;
+        this.allowdups = options.allowdups;
     }
 
     this.sourceLocale = this.sourceLocale || "en-US";
@@ -428,7 +434,7 @@ Xliff.prototype.size = function() {
 /**
  * Return a string that can be used as an HTML attribute value.
  * @param {string} str the string to escape
- * @returns the escaped string
+ * @returns {string} the escaped string
  */
 function escapeAttr(str) {
     return str.replace(/\n/g, "\\n");
@@ -437,11 +443,131 @@ function escapeAttr(str) {
 /**
  * Return the original string based on the one that was used as an attribute value.
  * @param {string} str the string to unescape
- * @returns the unescaped string
+ * @returns {string} the unescaped string
  */
 function unescapeAttr(str) {
     return str.replace("/\\n/g", "\n");
 }
+
+/**
+ * Convert a resource into translation units.
+ *
+ * @param {Resource} res the resource to convert
+ * @returns {Array.<TranslationUnit>} an array of translation units
+ * that represent the resource
+ */
+Xliff.prototype.convertResource = function(res) {
+    var units = [], tu;
+
+    try {
+        switch (res.resType) {
+        case "string":
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                sourceLocale: res.getSourceLocale(),
+                source: res.getSource(),
+                targetLocale: res.getTargetLocale(),
+                target: res.getTarget(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+            units.push(tu);
+            break;
+
+        case "array":
+            var sarr = res.getSourceArray();
+            var tarr = res.getTargetArray();
+
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                source: " ",
+                sourceLocale: res.getSourceLocale(),
+                targetLocale: res.getTargetLocale(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+
+            for (var j = 0; j < sarr.length; j++) {
+                // only output array items that have a translation
+                if (sarr[j]) {
+                    var newtu = tu.clone();
+                    newtu.source = sarr[j];
+                    newtu.ordinal = j;
+
+                    if (tarr && j < tarr.length && tarr[j]) {
+                        newtu.target = tarr[j];
+                    }
+
+                    newtu.ordinal = j;
+                    units.push(newtu);
+                } else if (tarr[j]) {
+                    logger.warn("Translated array  " + res.getKey() + " has no source string at index " + j + ". Cannot translate. Resource is: " + JSON.stringify(res, undefined, 4));
+                }
+            }
+            break;
+
+        case "plural":
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                source: " ",
+                sourceLocale: res.getSourceLocale(),
+                targetLocale: res.getTargetLocale(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+
+            var sp = res.getSourcePlurals();
+            var tp = res.getTargetPlurals();
+
+            for (var p in sp) {
+                if (sp[p]) {
+                    var newtu = tu.clone();
+                    newtu.source = sp[p];
+
+                    if (tp && tp[p]) {
+                        newtu.target = tp[p];
+                        newtu.quantity = p;
+                    }
+                    newtu.quantity = p;
+                    units.push(newtu);
+                } else {
+                    logger.warn("Translated plural  " + res.getKey() + " has no source plural, quantity " + p + ": " + JSON.stringify(res, undefined, 4));
+                }
+            }
+            break;
+        }
+    } catch (e) {
+        logger.warn(e);
+        logger.warn(JSON.stringify(res));
+        logger.warn("Skipping that resource.");
+    }
+
+    return units;
+};
 
 /**
  * Serialize this xliff instance to a string that contains
@@ -476,112 +602,13 @@ Xliff.prototype.serialize = function(untranslated) {
         for (var i = 0; i < resources.length; i++) {
             var res = resources[i];
             if (res.getTargetLocale() !== this.sourceLocale) {
-                try {
-                    switch (res.resType) {
-                    case "string":
-                        tu = new TranslationUnit({
-                            project: res.project,
-                            key: res.getKey(),
-                            file: res.getPath(),
-                            sourceLocale: res.getSourceLocale(),
-                            source: res.getSource(),
-                            targetLocale: res.getTargetLocale(),
-                            target: res.getTarget(),
-                            state: res.getState(),
-                            id: res.getId(),
-                            translated: true,
-                            context: res.context,
-                            comment: res.comment,
-                            resType: res.resType,
-                            datatype: res.datatype,
-                            flavor: res.getFlavor ? res.getFlavor() : undefined
-                        });
-                        units.push(tu);
-                        break;
+                units = units.concat(this.convertResource(res));
+            }
 
-                    case "array":
-                        var sarr = res.getSourceArray();
-                        var tarr = res.getTargetArray();
-
-                        tu = new TranslationUnit({
-                            project: res.project,
-                            key: res.getKey(),
-                            file: res.getPath(),
-                            source: " ",
-                            sourceLocale: res.getSourceLocale(),
-                            targetLocale: res.getTargetLocale(),
-                            state: res.getState(),
-                            id: res.getId(),
-                            translated: true,
-                            context: res.context,
-                            comment: res.comment,
-                            resType: res.resType,
-                            datatype: res.datatype,
-                            flavor: res.getFlavor ? res.getFlavor() : undefined
-                        });
-
-                        for (var j = 0; j < sarr.length; j++) {
-                            // only output array items that have a translation
-                            if (sarr[j]) {
-                                var newtu = tu.clone();
-                                newtu.source = sarr[j];
-                                newtu.ordinal = j;
-
-                                if (tarr && j < tarr.length && tarr[j]) {
-                                    newtu.target = tarr[j];
-                                }
-
-                                newtu.ordinal = j;
-                                units.push(newtu);
-                            } else if (tarr[j]) {
-                                logger.warn("Translated array  " + res.getKey() + " has no source string at index " + j + ". Cannot translate. Resource is: " + JSON.stringify(res, undefined, 4));
-                            }
-                        }
-                        break;
-
-                    case "plural":
-                        tu = new TranslationUnit({
-                            project: res.project,
-                            key: res.getKey(),
-                            file: res.getPath(),
-                            source: " ",
-                            sourceLocale: res.getSourceLocale(),
-                            targetLocale: res.getTargetLocale(),
-                            state: res.getState(),
-                            id: res.getId(),
-                            translated: true,
-                            context: res.context,
-                            comment: res.comment,
-                            resType: res.resType,
-                            datatype: res.datatype,
-                            flavor: res.getFlavor ? res.getFlavor() : undefined
-                        });
-
-                        var sp = res.getSourcePlurals();
-                        var tp = res.getTargetPlurals();
-
-                        for (var p in sp) {
-                            if (sp[p]) {
-                                var newtu = tu.clone();
-                                newtu.source = sp[p];
-
-                                if (tp && tp[p]) {
-                                    newtu.target = tp[p];
-                                    newtu.quantity = p;
-                                }
-                                newtu.quantity = p;
-                                units.push(newtu);
-                            } else {
-                                logger.warn("Translated plural  " + res.getKey() + " has no source plural, quantity " + p + ": " + JSON.stringify(res, undefined, 4));
-                            }
-                        }
-                        break;
-                    }
-                } catch (e) {
-                    logger.warn(e);
-                    logger.warn(JSON.stringify(res));
-                    logger.warn("Skipping that resource.");
-                }
+            if (this.allowdups) {
+                res.getInstances().forEach(function(resource) {
+                    units = units.concat(this.convertResource(resource));
+                }.bind(this));
             }
         }
     }

--- a/test/testResource.js
+++ b/test/testResource.js
@@ -1,0 +1,716 @@
+/*
+ * testResource.js - test the resource object.
+ *
+ * Copyright © 2019, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!Resource) {
+    var Resource = require("../lib/Resource.js");
+}
+
+module.exports.resource = {
+    testResourceConstructorEmpty: function(test) {
+        test.expect(1);
+
+        var rs = new Resource();
+        test.ok(rs);
+
+        test.done();
+    },
+
+    testResourceConstructorNoProps: function(test) {
+        test.expect(1);
+
+        var rs = new Resource({});
+        test.ok(rs);
+
+        test.done();
+    },
+
+    testResourceConstructor: function(test) {
+        test.expect(1);
+
+        var rs = new Resource({
+            key: "asdf",
+            source: "This is a test",
+            sourceLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(rs);
+
+        test.done();
+    },
+
+    testResourceGetAllFields: function(test) {
+        test.expect(16);
+
+        var rs = new Resource({
+            project: "x",
+            context: "y",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            reskey: "z",
+            pathName: "a",
+            autoKey: true,
+            state: "new",
+            id: 4,
+            formatted: true,
+            comment: "c",
+            dnt: true,
+            datatype: "d",
+            localize: true,
+            flavor: "e"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getProject(), "x");
+        test.equal(rs.getContext(), "y");
+        test.equal(rs.getSourceLocale(), "en-US");
+        test.equal(rs.getTargetLocale(), "ja-JP");
+        test.equal(rs.getKey(), "z");
+        test.equal(rs.getPath(), "a");
+        test.ok(rs.getAutoKey());
+        test.equal(rs.getState(), "new");
+        test.equal(rs.getId(), 4);
+        test.ok(rs.formatted);
+        test.equal(rs.getComment(), "c");
+        test.ok(rs.dnt);
+        test.equal(rs.getDataType(), "d");
+        test.ok(rs.localize);
+        test.equal(rs.getFlavor(), "e");
+        test.done();
+    },
+
+    testResourceIsInstanceSame: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP"
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceIsInstanceDifferInTranslationAffectingProperty: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "de-DE"
+        });
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceIsInstanceMissingProperty: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US"
+        });
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceIsInstanceDifferInTranslationNotAffectingProperty: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "e/f/g.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceIsInstanceEmpty: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({});
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceIsInstanceUndefined: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isInstance(undefined));
+
+        test.done();
+    },
+
+    testResourceIsInstanceNull: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isInstance(null));
+
+        test.done();
+    },
+
+    testResourceIsInstanceNotObject: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isInstance("foo"));
+
+        test.done();
+    },
+
+    testResourceAddInstance: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        test.done();
+    },
+
+    testResourceAddInstanceNotInstance: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "de-DE",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(!rs.addInstance(dup));
+
+        test.done();
+    },
+
+    testResourceAddInstanceUndefined: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.addInstance(undefined));
+
+        test.done();
+    },
+
+    testResourceAddInstanceNull: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.addInstance(null));
+
+        test.done();
+    },
+
+    testResourceAddInstanceNotObject: function(test) {
+        test.expect(2);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.addInstance("asdf"));
+
+        test.done();
+    },
+
+    testResourceGetInstancesRightNumber: function(test) {
+        test.expect(5);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        var instances = rs.getInstances();
+
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.done();
+    },
+
+    testResourceGetInstancesRightContent: function(test) {
+        test.expect(5);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        var instances = rs.getInstances();
+
+        test.ok(instances);
+        test.deepEqual(instances[0], dup);
+
+        test.done();
+    },
+
+    testResourceGetInstancesNone: function(test) {
+        test.expect(3);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var instances = rs.getInstances();
+
+        test.ok(instances);
+        test.equal(instances.length, 0);
+
+        test.done();
+    },
+
+    testResourceGetInstancesMultipleRightNumber: function(test) {
+        test.expect(9);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "g/h/i.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "j/k/l.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        var instances = rs.getInstances();
+
+        test.ok(instances);
+        test.equal(instances.length, 3);
+
+        test.done();
+    },
+
+    testResourceGetInstancesMultipleRightContent: function(test) {
+        test.expect(9);
+
+        var rs = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        var dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "d/e/f.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "g/h/i.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        dup = new Resource({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "j/k/l.md"
+        });
+        test.ok(dup);
+
+        test.ok(rs.addInstance(dup));
+
+        var instances = rs.getInstances();
+
+        test.ok(instances);
+        test.deepEqual(instances[2], dup);
+
+        test.done();
+    },
+
+};

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -1342,5 +1342,77 @@ module.exports.resourcearray = {
         test.equal(ra.hashKey(), "ra_foo_blah_de-DE_asdf");
 
         test.done();
+    },
+
+    testResourceArrayIsInstanceSame: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: ["a", "b", "c"]
+        });
+        test.ok(rs);
+
+        var dup = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: ["a", "b", "c"]
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceArrayIsInstanceDifferingInSource: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: ["a", "b", "c"]
+        });
+        test.ok(rs);
+
+        var dup = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: ["a", "b", "cd"]
+        });
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
     }
 };

--- a/test/testResourcePlural.js
+++ b/test/testResourcePlural.js
@@ -1610,5 +1610,89 @@ module.exports.resourceplural = {
         test.equal(rp.hashKey(), "rp_foo_blah_de-DE_asdf");
 
         test.done();
+    },
+
+    testResourcePluralIsInstanceSame: function(test) {
+        test.expect(3);
+
+        var rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a test",
+                other: "These are tests"
+            }
+        });
+        test.ok(rs);
+
+        var dup = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a test",
+                other: "These are tests"
+            }
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourcePluralIsInstanceDifferingInSource: function(test) {
+        test.expect(3);
+
+        var rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a test",
+                other: "These are tests"
+            }
+        });
+        test.ok(rs);
+
+        var dup = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a test",
+                other: "These are tests."
+            }
+        });
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
     }
 };

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1115,6 +1115,78 @@ module.exports.resourcestring = {
         test.equal(rs.hashKey(), "irs_iosapp_en-US_a/b/es.lproj/foo.xib_This is a test_");
 
         test.done();
-    }
+    },
+
+    testResourceStringIsInstanceSame: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This is a test"
+        });
+        test.ok(rs);
+
+        var dup = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This is a test"
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceStringIsInstanceDifferingInSource: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This is a test"
+        });
+        test.ok(rs);
+
+        var dup = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This is a test."
+        });
+        test.ok(dup);
+
+        test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
 
 };

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -56,6 +56,7 @@ module.exports.files = [
     "testPseudoFactory.js",
     "testPseudoHant.js",
     "testPseudoNewZealand.js",
+    "testResource.js",
     "testResourceArray.js",
     "testResourcePlural.js",
     "testResourceString.js",

--- a/test/testSwiftFile.js
+++ b/test/testSwiftFile.js
@@ -467,7 +467,7 @@ module.exports.swiftfile = {
     },
 
     testSwiftFileExtractFile: function(test) {
-        test.expect(26);
+        test.expect(31);
 
         var j = new SwiftFile(p, "./swift/MyproductStrings.swift", sft);
         test.ok(j);
@@ -483,7 +483,14 @@ module.exports.swiftfile = {
         test.ok(r);
         test.equal(r.getSource(), "Options");
         test.equal(r.getKey(), "Options");
-        test.equal(r.getComment(), "Add Action sheet message");
+        test.equal(r.getComment(), "Add Action sheet title");
+
+        var instances = r.getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+        test.equal(instances[0].getSource(), "Options");
+        test.equal(instances[0].getKey(), "Options");
+        test.equal(instances[0].getComment(), "Add Action sheet message");
 
         r = set.getBySource("Error logging out");
         test.ok(r);

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -1,7 +1,7 @@
 /*
  * testXliff.js - test the Xliff object.
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2019 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2881,6 +2881,233 @@ module.exports.xliff = {
                 '    </body>\n' +
                 '  </file>\n' +
                 '</xliff>');
+
+        test.done();
+    },
+    
+    testXliffAddResourcesWithInstances: function(test) {
+        test.expect(9);
+
+        var x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+        
+        var res2 = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "special translators note"
+        });
+        res.addInstance(res2);
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getcomment());
+        
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesAddInstances: function(test) {
+        test.expect(17);
+
+        var x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getComment());
+        
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+        
+        test.equal(instances[0].getSource(), "baby baby");
+        test.equal(instances[0].getSourceLocale(), "en-US");
+        test.equal(instances[0].getKey(), "foobar");
+        test.equal(instances[0].getPath(), "foo/bar/asdf.java");
+        test.equal(instances[0].getProject(), "webapp");
+        test.equal(instances[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliffSerializeWithTranslationUnitsWithInstances: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a different comment"
+        }));
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffDeserializeCreateInstances: function(test) {
+        test.expect(21);
+
+        var x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), "ababab");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "asdf");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].context, "asdfasdf");
+        test.equal(reslist[0].comment, "this is a comment");
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getTarget(), "ababab");
+        test.equal(instances[0].getTargetLocale(), "fr-FR");
+        test.equal(instances[0].getKey(), "asdf");
+        test.equal(instances[0].getPath(), "/a/b/asdf.js");
+        test.equal(instances[0].getProject(), "iosapp");
+        test.equal(instances[0].resType, "string");
+        test.equal(instances[0].context, "asdfasdf");
+        test.equal(instances[0].comment, "this is a different comment");
 
         test.done();
     }

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -2925,7 +2925,7 @@ module.exports.xliff = {
         test.equal(reslist[0].getKey(), "foobar");
         test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
         test.equal(reslist[0].getProject(), "webapp");
-        test.ok(!reslist[0].getcomment());
+        test.ok(!reslist[0].getComment());
         
         test.done();
     },
@@ -2951,7 +2951,7 @@ module.exports.xliff = {
         // this one has the same source, locale, key, and file
         // so it should create an instance of the first one
         res = new ResourceString({
-            source: "baby baby",
+            source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
             pathName: "foo/bar/asdf.java",
@@ -2968,7 +2968,7 @@ module.exports.xliff = {
         test.ok(reslist);
 
         test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSource(), "Asdf asdf");
         test.equal(reslist[0].getSourceLocale(), "en-US");
         test.equal(reslist[0].getKey(), "foobar");
         test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
@@ -2979,12 +2979,67 @@ module.exports.xliff = {
         test.ok(instances);
         test.equal(instances.length, 1);
         
-        test.equal(instances[0].getSource(), "baby baby");
+        test.equal(instances[0].getSource(), "Asdf asdf");
         test.equal(instances[0].getSourceLocale(), "en-US");
         test.equal(instances[0].getKey(), "foobar");
         test.equal(instances[0].getPath(), "foo/bar/asdf.java");
         test.equal(instances[0].getProject(), "webapp");
         test.equal(instances[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliffSerializeWithResourcesWithInstances: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <note annotates="source">blah blah blah</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
 
         test.done();
     },


### PR DESCRIPTION
- duplicates are now saved internally as instances of the first resource, and are saved in a chain on that first resource
- instances have the same core properties, and only differ in properties that do not affect the translation, like the path to the source file where the string came from
- add an "allowDups" option to the xliff object which tells it to save instances when reading an xliff, and to write out the instances when writing an xliff
- modify the project class to use the "allowDups" options when instantiating the extracted strings xliff
- unit tests for everything! All pass.