### PR TITLE
Moved the resource index calculation to the source file...

### DIFF
--- a/lib/AndroidLayoutFile.js
+++ b/lib/AndroidLayoutFile.js
@@ -230,7 +230,8 @@ AndroidLayoutFile.prototype.walkLayout = function(node) {
                         comment: comment,
                         dnt: utils.isDNT(comment),
                         datatype: this.type.datatype,
-                        flavor: this.flavor
+                        flavor: this.flavor,
+                        index: this.resourceIndex++
                     });
                     this.set.add(res);
                     this.dirty = true;
@@ -254,6 +255,8 @@ AndroidLayoutFile.prototype.walkLayout = function(node) {
 AndroidLayoutFile.prototype.parse = function(data) {
     this.xml = data;
     this.contents = xml2json.toJson(data, {object: true});
+    this.resourceIndex = 0;
+
     /*
     if (!this.contents ||
             (!this.contents.FrameLayout &&

--- a/lib/AndroidResourceFile.js
+++ b/lib/AndroidResourceFile.js
@@ -97,7 +97,8 @@ AndroidResourceFile.prototype.parse = function(data) {
                     dnt: utils.isDNT(strArr[i].i18n),
                     datatype: this.type.datatype,
                     flavor: this.flavor,
-                    state: "new"
+                    state: "new",
+                    index: this.resourceIndex++
                 };
                 if (locale === this.project.sourceLocale) {
                     params.source = strArr[i].$t;
@@ -138,7 +139,8 @@ AndroidResourceFile.prototype.parse = function(data) {
                     dnt: utils.isDNT(strArr.i18n),
                     datatype: this.type.datatype,
                     flavor: this.flavor,
-                    state: "new"
+                    state: "new",
+                    index: this.resourceIndex++
                 };
                 if (locale === this.project.sourceLocale) {
                     params.sourceArray = strArr.item;
@@ -176,7 +178,8 @@ AndroidResourceFile.prototype.parse = function(data) {
                     dnt: utils.isDNT(strArr.i18n),
                     datatype: this.type.datatype,
                     flavor: this.flavor,
-                    state: "new"
+                    state: "new",
+                    index: this.resourceIndex++
                 };
                 if (locale === this.project.sourceLocale) {
                     params.sourceArray = strArr.item;
@@ -220,7 +223,8 @@ AndroidResourceFile.prototype.parse = function(data) {
                     dnt: utils.isDNT(strArr.i18n),
                     datatype: this.type.datatype,
                     flavor: this.flavor,
-                    state: "new"
+                    state: "new",
+                    index: this.resourceIndex++
                 };
                 if (locale === this.project.sourceLocale) {
                     params.sourceStrings = items;

--- a/lib/HTMLFile.js
+++ b/lib/HTMLFile.js
@@ -160,7 +160,8 @@ HTMLFile.prototype._emitText = function(escape) {
             lineNumber: this.lineNumber,
             state: "new",
             comment: this.comment,
-            datatype: "html"
+            datatype: "html",
+            index: this.resourceIndex++
         }));
     }
 
@@ -231,6 +232,12 @@ HTMLFile.prototype.parse = function(data) {
 
     // accumulates characters in text segments
     this.message = new MessageAccumulator();
+
+    // Each resource is given a serial number to indicate its position within
+    // the source file. This can be used later to make sure trans-units appear
+    // in the xliff files in the same order as the source strings appear in the
+    // source file.
+    this.resourceIndex = 0;
 
     // Whether or not to ignore this text for localization.
     // This is turned on by HTML tags where the content of
@@ -353,7 +360,8 @@ HTMLFile.prototype.parse = function(data) {
                     pathName: this.pathName,
                     state: "new",
                     comment: this.comment,
-                    datatype: "html"
+                    datatype: "html",
+                    index: this.resourceIndex++
                 }));
 
                 if (this.tagtext) {
@@ -504,6 +512,8 @@ HTMLFile.prototype.localizeText = function(translations, locale) {
     var output = "";
     var substitution, replacement;
 
+    this.resourceIndex = 0;
+    
     while (segment) {
         if (segment.localizable) {
             var text = (segment.message && segment.message.getMinimalString()) || segment.text;
@@ -562,7 +572,8 @@ HTMLFile.prototype.localizeText = function(translations, locale) {
                                 autoKey: true,
                                 pathName: this.pathName,
                                 state: "new",
-                                datatype: "html"
+                                datatype: "html",
+                                index: this.resourceIndex++
                             }));
                             additional = this.type && this.type.missingPseudo && !this.project.settings.nopseudo ?
                                     this.type.missingPseudo.getString(text) : text;

--- a/lib/HTMLTemplateFile.js
+++ b/lib/HTMLTemplateFile.js
@@ -128,7 +128,8 @@ HTMLTemplateFile.prototype._emitText = function(escape) {
             pathName: this.pathName,
             state: "new",
             comment: this.comment,
-            datatype: "html"
+            datatype: "html",
+            index: this.resourceIndex++
         }));
     }
 
@@ -153,6 +154,12 @@ HTMLTemplateFile.prototype.parse = function(data) {
 
     // accumulates characters in non-text segments
     this.accumulator = "";
+
+    // Each resource is given a serial number to indicate its position within
+    // the source file. This can be used later to make sure trans-units appear
+    // in the xliff files in the same order as the source strings appear in the
+    // source file.
+    this.resourceIndex = 0;
 
     // accumulates characters in text segments
     this.text = "";
@@ -267,7 +274,8 @@ HTMLTemplateFile.prototype.parse = function(data) {
                     pathName: this.pathName,
                     state: "new",
                     comment: this.comment,
-                    datatype: "html"
+                    datatype: "html",
+                    index: this.resourceIndex++
                 }));
 
                 if (this.tagtext) {
@@ -469,6 +477,8 @@ HTMLTemplateFile.prototype.localizeText = function(translations, locale) {
     var segment = this.segments.current();
     var output = "";
     var substitution, replacement;
+    this.resourceIndex = 0;
+
 
     while (segment) {
         if (segment.localizable) {
@@ -533,7 +543,8 @@ HTMLTemplateFile.prototype.localizeText = function(translations, locale) {
                                 pathName: this.pathName,
                                 state: "new",
                                 datatype: "html",
-                                origin: "target"
+                                origin: "target",
+                                index: this.resourceIndex++
                             }));
                             additional = this.type && this.type.missingPseudo && !this.project.settings.nopseudo ?
                                     this.type.missingPseudo.getString(segment.text) : segment.text;

--- a/lib/HamlFile.js
+++ b/lib/HamlFile.js
@@ -551,7 +551,8 @@ HamlFile.prototype.emitNonLocalized = function(data) {
                 autoKey: true,
                 pathName: this.pathName,
                 state: "new",
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             }));
             this.nonLocalizedBuffer += '\n';
         } else {
@@ -615,6 +616,7 @@ HamlFile.prototype.parse = function(data) {
     this.localizedBuffer = ""; // localizable text buffer
     this.originalBuffer = "";  // original lines containing that same localizable text
     this.nonLocalizedBuffer = ""; // non localized text buffer
+    this.resourceIndex = 0;
 
     this.lines = data.split('\n');
 
@@ -944,7 +946,8 @@ HamlFile.prototype.assembleTranslation = function(segment, translations, locale)
             pathName: this.pathName,
             state: "new",
             datatype: this.type.datatype,
-            origin: "target"
+            origin: "target",
+            index: this.resourceIndex++
         });
         if (all) {
             this.type.modern.add(target);
@@ -978,6 +981,7 @@ HamlFile.prototype.localizeText = function(translations, locale) {
     var segment = this.segments.current();
     var output = "";
     var dirty = false;
+    this.resourceIndex = 0;
 
     while (segment) {
         if (segment.localizable) {
@@ -1017,7 +1021,8 @@ HamlFile.prototype.localizeText = function(translations, locale) {
                             autoKey: true,
                             pathName: this.pathName,
                             state: "new",
-                            datatype: this.type.datatype
+                            datatype: this.type.datatype,
+                            index: this.resourceIndex++
                         }));
                         additional = this.type && this.type.missingPseudo && !this.project.settings.nopseudo ?
                                 this.type.missingPseudo.getString(segment.text) : segment.text;

--- a/lib/IosStringsFile.js
+++ b/lib/IosStringsFile.js
@@ -76,6 +76,7 @@ var lineRE = new RegExp(/"((\\"|[^"])*)"\s*=\s*"((\\"|[^"])*)"/);
 IosStringsFile.prototype.parse = function(str) {
     var lines = str.split('\n');
     var comment, match;
+    this.resourceIndex = 0;
 
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
@@ -96,7 +97,8 @@ IosStringsFile.prototype.parse = function(str) {
                     pathName: this.sourcePath,
                     comment: comment,
                     datatype: this.type.datatype,
-                    flavor: this.flavor
+                    flavor: this.flavor,
+                    index: this.resourceIndex++
                 };
                 if (this.locale === this.project.sourceLocale) {
                     params.source = match[3];

--- a/lib/JavaFile.js
+++ b/lib/JavaFile.js
@@ -143,6 +143,7 @@ var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
  */
 JavaFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     reGetString.lastIndex = 0; // for safety
     var result = reGetString.exec(data);
@@ -166,7 +167,8 @@ JavaFile.prototype.parse = function(data) {
                 state: "new",
                 comment: comment,
                 datatype: this.type.datatype,
-                flavor: this.flavor
+                flavor: this.flavor,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {
@@ -197,7 +199,8 @@ JavaFile.prototype.parse = function(data) {
                 state: "new",
                 comment: comment,
                 datatype: this.type.datatype,
-                flavor: this.flavor
+                flavor: this.flavor,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {

--- a/lib/JavaScriptFile.js
+++ b/lib/JavaScriptFile.js
@@ -120,6 +120,7 @@ var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
  */
 JavaScriptFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     var comment, match, key;
 
@@ -147,7 +148,8 @@ JavaScriptFile.prototype.parse = function(data) {
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {
@@ -184,7 +186,8 @@ JavaScriptFile.prototype.parse = function(data) {
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {

--- a/lib/JsxFile.js
+++ b/lib/JsxFile.js
@@ -127,6 +127,7 @@ var reBadContents = new RegExp(/\{[^}]+\}/g);
  */
 JsxFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     var comment, match, key, autoKey;
 
@@ -188,7 +189,8 @@ JsxFile.prototype.parse = function(data) {
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -204,7 +204,8 @@ MarkdownFile.prototype._addTransUnit = function(text, comment) {
             pathName: this.pathName,
             state: "new",
             comment: comment,
-            datatype: "markdown"
+            datatype: "markdown",
+            index: this.resourceIndex++
         }));
     }
 };
@@ -566,7 +567,8 @@ MarkdownFile.prototype.parse = function(data) {
     // accumulates characters in text segments
     // this.text = "";
     this.message = new MessageAccumulator();
-
+    this.resourceIndex = 0;
+    
     this._walk(this.ast);
 
     // in case any is left over at the end
@@ -660,7 +662,8 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
                 autoKey: true,
                 pathName: this.pathName,
                 state: "new",
-                datatype: "markdown"
+                datatype: "markdown",
+                index: this.resourceIndex++
             }));
 
             translation = source;
@@ -916,6 +919,7 @@ function mapToNodes(astNode) {
  */
 MarkdownFile.prototype.localizeText = function(translations, locale) {
     var output = "";
+    this.resourceIndex = 0;
 
     logger.debug("Localizing strings for locale " + locale);
 

--- a/lib/ObjectiveCFile.js
+++ b/lib/ObjectiveCFile.js
@@ -98,6 +98,7 @@ var reNSLocalizedStringComment = /\s*(@"((\\"|[^"])*)")\s*\)/;
  */
 ObjectiveCFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     reNSLocalizedString.lastIndex = 0; // for safety
     var comment, result = reNSLocalizedString.exec(data);
@@ -119,7 +120,8 @@ ObjectiveCFile.prototype.parse = function(data) {
             pathName: this.pathName,
             state: "new",
             comment: comment ? ObjectiveCFile.unescapeString(comment) : undefined,
-            datatype: this.type.datatype
+            datatype: this.type.datatype,
+            index: this.resourceIndex++
         });
         this.set.add(r);
         result = reNSLocalizedString.exec(data);

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -62,6 +62,7 @@ var Resource = function(props) {
         this.sourceHash = props.sourceHash;
         this.localize = typeof(props.localize) === "boolean" ? props.localize : true; // some files have resources we do not want to localize/translate
         this.flavor = props.flavor;
+        this.index = props.index;
     }
 
     this.instances = [];

--- a/lib/RubyFile.js
+++ b/lib/RubyFile.js
@@ -180,6 +180,7 @@ var reGetStringPluralSingle = /:?(\w+)\s*(=>|:)\s*'((\\'|[^'])*)'(\s|,)*/g;
  */
 RubyFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     reGetStringWithId.lastIndex = 0; // for safety
     var result = reGetStringWithId.exec(data);
@@ -212,7 +213,8 @@ RubyFile.prototype.parse = function(data) {
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {
@@ -250,7 +252,8 @@ RubyFile.prototype.parse = function(data) {
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
-                datatype: this.type.datatype
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             this.set.add(r);
         } else {
@@ -281,10 +284,12 @@ RubyFile.prototype.parse = function(data) {
                 project: this.project.getProjectId(),
                 key: this.makeKey(preResource['one']),
                 sourceLocale: this.project.sourceLocale,
-                pathName: this.pathName,
                 autoKey: true,
+                pathName: this.pathName,
                 state: "new",
-                datatype: this.type.datatype
+                comment: comment,
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
             });
             for (var quantity in preResource) {
                 if (ResourcePlural.validPluralClasses.indexOf(quantity) > -1) {

--- a/lib/SwiftFile.js
+++ b/lib/SwiftFile.js
@@ -134,6 +134,7 @@ var reNSLocalizedStringComment = /\s*comment:\s*("((\\"|[^"])*)")\s*\)/;
  */
 SwiftFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
 
     reNSLocalizedString.lastIndex = 0; // for safety
     var comment, result = reNSLocalizedString.exec(data);
@@ -155,7 +156,8 @@ SwiftFile.prototype.parse = function(data) {
             pathName: this.pathName,
             state: "new",
             comment: comment ? SwiftFile.unescapeString(comment) : undefined,
-            datatype: this.type.datatype
+            datatype: this.type.datatype,
+            index: this.resourceIndex++
         });
         this.set.add(r);
         result = reNSLocalizedString.exec(data);

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -119,7 +119,6 @@ TranslationSet.prototype.add = function(resource) {
     //}
     existing = this.byKey[hashKey];
     existingClean = this.byCleanKey[cleanKey];
-    resource.index = this.resourceIndex++; // keep track of the order they were added to the set
 
     if (existing) {
         logger.trace("Same key as existing resource: " + JSON.stringify(existing));

--- a/lib/YamlFile.js
+++ b/lib/YamlFile.js
@@ -207,7 +207,8 @@ YamlFile.prototype._parseResources = function(prefix, obj, set, localize) {
                     pathName: this.pathName,
                     datatype: this.type.datatype,
                     context: prefix,
-                    localize: localize
+                    localize: localize,
+                    index: this.resourceIndex++
                 };
                 if (locale === this.project.sourceLocale || this.flavor) {
                     params.sourceLocale = locale;
@@ -266,6 +267,7 @@ YamlFile.prototype._mergeOutput = function(prefix, obj, set) {
  * @param {String} str the string to parse
  */
 YamlFile.prototype.parse = function(str) {
+    this.resourceIndex = 0;
     this.json = jsyaml.safeLoad(str);
     this._parseResources(undefined, this.json, this.set, true);
 };
@@ -529,6 +531,7 @@ YamlFile.prototype.getLocalizedPath = function(locale) {
  */
 YamlFile.prototype._localizeContent = function(prefix, obj, translations, locale, localize) {
     var ret = {};
+    this.resourceIndex = 0;
 
     for (var key in obj) {
         if (typeof(obj[key]) === "object") {
@@ -580,7 +583,8 @@ YamlFile.prototype._localizeContent = function(prefix, obj, translations, locale
                                 context: prefix,
                                 state: "new",
                                 flavor: this.flavor,
-                                comment: note
+                                comment: note,
+                                index: this.resourceIndex++
                             }));
                         }
                         logger.trace("Missing translation");

--- a/lib/YamlResourceFile.js
+++ b/lib/YamlResourceFile.js
@@ -80,7 +80,8 @@ YamlResourceFile.prototype._parseResources = function(prefix, obj, set) {
                 pathName: this.pathName,
                 datatype: this.type.datatype,
                 context: prefix,
-                flavor: this.flavor
+                flavor: this.flavor,
+                index: this.resourceIndex++
             };
             if (this.project.isSourceLocale(this.locale)) {
                 params.source = resource;
@@ -144,6 +145,8 @@ var localeSpec = /^[a-z][a-z][a-z]?(-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z](-[A-Z]+)
  * @param {String} str the string to parse
  */
 YamlResourceFile.prototype.parse = function(str) {
+    this.resourceIndex = 0;
+
     var parsed = jsyaml.safeLoad(str);
     var top = parsed;
     for (var key in parsed) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "url": "https://github.com/iLib-js/loctool.git"
     },
     "engines": {
-        "node": ">=0.12 <=7.2.1"
+        "node": ">=6.0.0"
     },
     "scripts": {
         "test": "cd test; node testSuite.js",


### PR DESCRIPTION
... instead of in the translation set, because resources can be added to multiple translation sets. This way, resources come out sorted properly because the index of the resources extracted from the source file doesn't change after the resource is created.