### PR TITLE
Fix order again

### DIFF
--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -44,7 +44,7 @@ MarkdownFileType.prototype = new FileType();
 MarkdownFileType.prototype.parent = FileType;
 MarkdownFileType.prototype.constructor = MarkdownFileType;
 
-var alreadyLoc = new RegExp(/(^|\/)([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z](-[A-Z]+)?)?)\//);
+var alreadyLoc = new RegExp(/(^|\/)(([a-z][a-z])(-[A-Z][a-z][a-z][a-z])?(-([A-Z][A-Z])(-[A-Z]+)?)?)\//);
 
 /**
  * Return true if the given path is an Markdown template file and is handled
@@ -61,7 +61,16 @@ MarkdownFileType.prototype.handles = function(pathName) {
 
     if (ret) {
         var match = alreadyLoc.exec(pathName);
-        ret = (match && match.length > 2) ? match[2] === this.project.sourceLocale : true;
+        if (match && match.length > 2) {
+            if (utils.iso639[match[3]]) {
+                if (match.length < 6 || !match[6] || !utils.iso3166[match[6]]) {
+                    return true;
+                }
+                return match[2] === this.project.sourceLocale;
+            } else {
+                return true;
+            }
+        }
     }
     logger.debug(ret ? "Yes" : "No");
     return ret;

--- a/lib/ResourceArray.js
+++ b/lib/ResourceArray.js
@@ -484,7 +484,7 @@ ResourceArray.prototype.isInstance = function(resource) {
 
     // now check the properties specific to this resource subclass
     return this.sourceArray.every(function(str, i) {
-        return str === resource.sourceArray[i];
+        return utils.cleanString(str) === utils.cleanString(resource.sourceArray[i]);
     }.bind(this));
 };
 

--- a/lib/ResourcePlural.js
+++ b/lib/ResourcePlural.js
@@ -424,7 +424,7 @@ ResourcePlural.prototype.isInstance = function(resource) {
 
     // now check the properties specific to this resource subclass
     return Object.keys(this.sourceStrings).every(function(prop) {
-        return this.sourceStrings[prop] === resource.sourceStrings[prop];
+        return utils.cleanString(this.sourceStrings[prop]) === utils.cleanString(resource.sourceStrings[prop]);
     }.bind(this));
 };
 

--- a/lib/ResourceString.js
+++ b/lib/ResourceString.js
@@ -289,7 +289,7 @@ ResourceString.prototype.isInstance = function(resource) {
     }
 
     // now check the properties specific to this resource subclass
-    return this.source === resource.source;
+    return utils.cleanString(this.source) === utils.cleanString(resource.source);
 };
 
 module.exports = ResourceString;

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -114,11 +114,8 @@ TranslationSet.prototype.add = function(resource) {
     var cleanKey = resource.cleanHashKey();
     logger.trace("Add a resource. Hash: " + hashKey + " clean: " + cleanKey + " resource:" + JSON.stringify(resource));
 
-    //if (resource.pathName === "res/values/strings.xml") {
-    //    logger.trace("found it");
-    //}
     existing = this.byKey[hashKey];
-    existingClean = this.byCleanKey[cleanKey];
+    var existingClean = this.byCleanKey[cleanKey];
 
     if (existing) {
         logger.trace("Same key as existing resource: " + JSON.stringify(existing));

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -244,7 +244,7 @@ module.exports.markdownfiletype = {
 
         test.done();
     },
-    
+
     testMarkdownFileTypeHandlesSourceDirIsNotLocalized: function(test) {
         test.expect(2);
 
@@ -261,6 +261,43 @@ module.exports.markdownfiletype = {
         test.ok(htf.handles("en-US/a/b/c/foo.md"));
 
         test.done();
-    }
+    },
 
+    testMarkdownFileTypeHandlesSourceDirNotLocalizedWithMD: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var htf = new MarkdownFileType(p);
+        test.ok(htf);
+
+        // md has the form of an iso language name, but it is not a real language
+        test.ok(htf.handles("md/a/b/c/foo.md"));
+
+        test.done();
+    },
+
+    testMarkdownFileTypeHandlesSourceDirNotLocalizedWithLocaleLookingDir: function(test) {
+        test.expect(2);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var htf = new MarkdownFileType(p);
+        test.ok(htf);
+
+        // en-AA looks like a real locale, but it is not because XX is not a country code
+        test.ok(htf.handles("en-XX/a/b/c/foo.md"));
+
+        test.done();
+    }
 };

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -1380,6 +1380,42 @@ module.exports.resourcearray = {
         test.done();
     },
 
+    testResourceArrayIsInstanceDifferingOnlyInWhitespace: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: ["a b c", "b", "c"]
+        });
+        test.ok(rs);
+
+        var dup = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceArray: [" a   b\t\tc  \t", " b", "c "]
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
     testResourceArrayIsInstanceDifferingInSource: function(test) {
         test.expect(3);
 

--- a/test/testResourcePlural.js
+++ b/test/testResourcePlural.js
@@ -1654,6 +1654,48 @@ module.exports.resourceplural = {
         test.done();
     },
 
+    testResourcePluralIsInstanceDifferingOnlyInWhitespace: function(test) {
+        test.expect(3);
+
+        var rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a test ",
+                other: " These are tests"
+            }
+        });
+        test.ok(rs);
+
+        var dup = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            sourceStrings: {
+                one: "This is a \ttest    ",
+                other: " These  are tests "
+            }
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
     testResourcePluralIsInstanceDifferingInSource: function(test) {
         test.expect(3);
 

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1153,6 +1153,42 @@ module.exports.resourcestring = {
         test.done();
     },
 
+    testResourceStringIsInstanceDifferingOnlyInWhitespace: function(test) {
+        test.expect(3);
+
+        var rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This is a test "
+        });
+        test.ok(rs);
+
+        var dup = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "This \tis a   test    "
+        });
+        test.ok(dup);
+
+        test.ok(rs.isInstance(dup));
+
+        test.done();
+    },
+
     testResourceStringIsInstanceDifferingInSource: function(test) {
         test.expect(3);
 


### PR DESCRIPTION
- Now differences in whitespace do not affect whether a resource is an instance of another resource. This means that instances that differ only in whitespace will appear in the extracted xliff as expected.
- Make sure markdown file type accepts non-locale dirs that happen to have the form of a locale spec (eg. two lower case letters, or two lower case plus dash plus two upper case letters where the letters are not ISO codes for languages or countries)