### PR TITLE
Keep inline code snippets in the source strings

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,17 +10,20 @@ New Features:
 
 * Added support for link references in markdown
     * link references do not create a break in the translatable
-	  string any more, and are hidden from the translators using
-	  xml-like tags
+      string any more, and are hidden from the translators using
+      xml-like tags
 
 Bug Fixes:
 
 * Markdown fixes
     * filter out strings that only contain URLs
-	* filter out strings that do not contain localizable text (only whitespace and/or punctuation)
-	* make sure that the text on the lines after the last bullet in a list does not get added to that last list item
+    * filter out strings that do not contain localizable text (only whitespace and/or punctuation)
+    * make sure that the text on the lines after the last bullet in a list does not get added to that last list item
 * Fix dependency on ilib-tree-node
 * Added test/testResourceFactory.js to verify the ResourceFactory code
+* Added the ability to keep reference links and inline code snippets with the string, even when
+  they are at the beginning or end of the string. They are not optimized out. Other components that
+  appear at the beginning or end of the string are still optimized out as normal.
 
 
 Build 002

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -459,9 +459,10 @@ MarkdownFile.prototype._walk = function(node) {
         case 'linkReference':
         case 'inlineCode':
             // inline code nodes and link references are non-breaking and self-closing
+            // Also, pass true to the push so that this node is never optimized out of a string.
             if (this.message.getTextLength()) {
                 node.localizable = true;
-                this.message.push(node);
+                this.message.push(node, true);
                 this.message.pop();
             }
             break;
@@ -753,7 +754,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                     type: 'text',
                     value: node.label
                 }));
-                message.push(node);
+                message.push(node, true);
                 message.pop();
             }
             break;
@@ -761,7 +762,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
         case 'inlineCode':
             // inline code is a non-breaking, self-closing node
             if (node.localizable) {
-                message.push(node);
+                message.push(node, true);
                 message.pop();
             }
             break;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "js-stl": ">=0.0.6",
         "js-yaml": "^3.12.1",
         "log4js": "^2.0.0",
-        "message-accumulator": "^2.0.2",
+        "message-accumulator": "^2.2.0",
         "micromatch": "^3.1.0",
         "mysql2": "^1.6.5",
         "node-expat": ">=2.3.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1605,6 +1605,33 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeTextWithInlineCodeAtTheEnd: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('Delete the file with this command: `git rm filename`\n');
+
+        // should not optimize out inline code at the end of strings so that it can be
+        // part of the text that is translated
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r66239583",
+            source: "Delete the file with this command: <c0/>",
+            sourceLocale: "en-US",
+            target: "Avec cette commande <c0/>, vous pouvez supprimer le fichier.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Avec cette commande `git rm filename`, vous pouvez supprimer le fichier.\n');
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeTextWithLinkReference: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
Added the ability to keep reference links and inline code snippets with the string, even when
they are at the beginning or end of the string. They are not optimized out. Other components that
appear at the beginning or end of the string are still optimized out as normal.