### PR TITLE
Fix crash when there are more components in the translation than the source string

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,8 +17,10 @@ Bug Fixes:
 
 * Markdown fixes
     * filter out strings that only contain URLs
-	* filter out strings that do not contain localizable text (only whitespace and/or punctuation)
-	* make sure that the text on the lines after the last bullet in a list does not get added to that last list item
+    * filter out strings that do not contain localizable text (only whitespace and/or punctuation)
+    * make sure that the text on the lines after the last bullet in a list does not get added to that last list item
+    * Fixed a crash that happens when there are more components in the translation than the source string. Now it
+      just gives a warning and proceeds as if that extra component were not there.
 * Fix dependency on ilib-tree-node
 * Added test/testResourceFactory.js to verify the ResourceFactory code
 

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -911,6 +911,21 @@ MarkdownFile.prototype._getTranslationNodes = function(locale, translations, ma)
         // don't return the "root" start and end nodes
         nodes = nodes.slice(1, -1);
 
+        // warn about components in the target that don't exist in the source,
+        // and remove them from the node array as if they didn't exist
+        var maxIndex = Object.keys(ma.getMapping()).length;
+        var mismatch = false;
+
+        for (i = 0; i < nodes.length; i++) {
+           if (nodes[i].type == 'component' && (!nodes[i].extra || nodes[i].index > maxIndex)) {
+               nodes.splice(i, 1);
+               mismatch = true;
+           }
+        }
+        if (mismatch) {
+            logger.warn("Warning! Translation of\n'" + text + "' (key: " + key + ")\nto locale " + locale + " is\n'" + translation + "'\nwhich has a more components in it than the source.");
+        }
+
         if (this.project.settings.identify) {
             var tmp = [];
             tmp.push(new Node({

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1802,6 +1802,60 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeTextMismatchedNumberOfComponents: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <em>test</em> of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        // there is no c1 in the source, so this better not throw an exception
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r306365966",
+            source: "This is a <c0>test</c0> of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0>essai</c0> du système d'analyse <c1>syntaxique</c1> de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        // Should ignore the c1 as if it weren't there
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <em>essai</em> du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextMismatchedNumberOfComponentsSelfClosing: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <em>test</em> of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        // there is no c1 in the source, so this better not throw an exception
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r306365966",
+            source: "This is a <c0>test</c0> of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0>essai</c0> du système d'analyse <c1/> syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        // Should ignore the c1 as if it weren't there
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <em>essai</em> du système d\'analyse  syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeTextLocalizableTitle: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
Fixed a crash that happens when there are more components in the translation than the source string. Now it just gives a warning and proceeds as if that extra component were not there.