### PR TITLE
Added to fill the default value if there are no values in xliff file

### DIFF
--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -440,6 +440,7 @@ Xliff.prototype.size = function() {
  * @returns {string} the escaped string
  */
 function escapeAttr(str) {
+    if (!str) return;
     return str.replace(/\n/g, "\\n");
 }
 
@@ -449,6 +450,7 @@ function escapeAttr(str) {
  * @returns {string} the unescaped string
  */
 function unescapeAttr(str) {
+    if (!str) return;
     return str.replace("/\\n/g", "\n");
 }
 
@@ -767,7 +769,7 @@ Xliff.prototype.deserialize = function(xml) {
     this.ts = new TranslationSet(this.sourceLocale);
 
     if (json.xliff) {
-        if (!json.xliff.version || json.xliff.version !== "1.2") {
+        if (!json.xliff.version || !(json.xliff.version.startsWith("1"))) {
             logger.error("Unknown xliff version " + json.xliff.version + ". Cannot continue parsing.");
             return;
         }
@@ -782,7 +784,7 @@ Xliff.prototype.deserialize = function(xml) {
                 fileSettings = {
                     pathName: file.original,
                     locale: file["source-language"],
-                    project: file["product-name"],
+                    project: file["product-name"] || file["original"],
                     targetLocale: file["target-language"],
                     flavor: file["x-flavor"]
                 };
@@ -809,6 +811,10 @@ Xliff.prototype.deserialize = function(xml) {
                                     }
                                 }
                             }
+
+                        if (!tu.resname) {
+                            tu.resname = tu.source["$t"];
+                        }
 
                             try {
                                 var unit = new TranslationUnit({


### PR DESCRIPTION
The Xliff files used in webOS are missing many property values. so I modified Xliff.js to fill them. 
When using version 1.x on webOS, it was "1.0". and now  2.0.
webOS xliff files still have been missing `datetype' value. (i.e ```<trans-unit datatype="javascript" id="settings_396">```
