### PR TITLE
Fix  generated pseudo locales

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-leap-day

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,8 @@ New Features:
 Bug Fixes:
 
 * Fix a few bugs related to figuring out which file types are resource file types in custom projects
+* Many file types were not producing any translated output for the generated pseudo locales.
+Now they do!
 
 Build 003
 -------

--- a/lib/AndroidLayoutFileType.js
+++ b/lib/AndroidLayoutFileType.js
@@ -123,7 +123,7 @@ AndroidLayoutFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
     logger.trace("Adding resources to resource files");

--- a/lib/AndroidResourceFileType.js
+++ b/lib/AndroidResourceFileType.js
@@ -132,7 +132,7 @@ AndroidResourceFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));;
 
     logger.trace("There are " + resources.length + " resources to add.");

--- a/lib/IosStringsFileType.js
+++ b/lib/IosStringsFileType.js
@@ -102,7 +102,7 @@ IosStringsFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
     logger.trace("There are " + resources.length + " resources to add.");

--- a/lib/JavaFileType.js
+++ b/lib/JavaFileType.js
@@ -84,7 +84,7 @@ JavaFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
     for (var i = 0; i < resources.length; i++) {

--- a/lib/JavaScriptFileType.js
+++ b/lib/JavaScriptFileType.js
@@ -104,7 +104,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));;
 
     for (var i = 0; i < resources.length; i++) {

--- a/lib/JsxFileType.js
+++ b/lib/JsxFileType.js
@@ -101,7 +101,7 @@ JsxFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));;
 
     for (var i = 0; i < resources.length; i++) {

--- a/lib/ObjectiveCFileType.js
+++ b/lib/ObjectiveCFileType.js
@@ -83,7 +83,7 @@ ObjectiveCFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
     for (var i = 0; i < resources.length; i++) {

--- a/lib/RubyFileType.js
+++ b/lib/RubyFileType.js
@@ -134,7 +134,7 @@ RubyFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !PseudoFactory.isPseudoLocale(locale);
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
     for (var i = 0; i < resources.length; i++) {


### PR DESCRIPTION
Resource files for locales such as English for Great Britain were not written out to disk because they were pseudo locales. This occurred for many different types of files. Now they are written out properly.