### PR TITLE
Support x-key usage in xliff file

### DIFF
--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -816,6 +816,11 @@ Xliff.prototype.deserialize = function(xml) {
                             tu.resname = tu.source["$t"];
                         }
 
+                        if (tu.source["x-key"]) {
+                             tu.source["$t"]= tu.source["x-key"];
+                             tu.resname = tu.source["x-key"];
+                        }
+
                             try {
                                 var unit = new TranslationUnit({
                                     file: fileSettings.pathName,

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -813,12 +813,12 @@ Xliff.prototype.deserialize = function(xml) {
                             }
 
                         if (!tu.resname) {
-                            tu.resname = tu.source["$t"];
-                        }
-
-                        if (tu.source["x-key"]) {
-                             tu.source["$t"]= tu.source["x-key"];
-                             tu.resname = tu.source["x-key"];
+                            if (tu.source["x-key"]) {
+                                tu.source["$t"]= tu.source["x-key"];
+                                tu.resname = tu.source["x-key"];
+                            } else {
+                                tu.resname = tu.source["$t"];
+                            }
                         }
 
                             try {

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -1850,7 +1850,7 @@ module.exports.xliff = {
 
         test.ok(reslist);
 
-        test.equal(reslist.length, 3);
+        test.equal(reslist.length, 4);
 
         test.done();
     },

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -1850,7 +1850,7 @@ module.exports.xliff = {
 
         test.ok(reslist);
 
-        test.equal(reslist.length, 2);
+        test.equal(reslist.length, 3);
 
         test.done();
     },

--- a/test/testfiles/test.xliff
+++ b/test/testfiles/test.xliff
@@ -16,6 +16,11 @@
         <target>bebe bebe</target>
         <note annotates="source">come &amp; enjoy it with us</note>
       </trans-unit>
+      <trans-unit id="3" resname="ohhuzzah" restype="string" datatype="plaintext">
+        <source x-key="oh">baby baby</source>
+        <target>oh bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/testfiles/test.xliff
+++ b/test/testfiles/test.xliff
@@ -21,6 +21,11 @@
         <target>oh bebe bebe</target>
         <note annotates="source">come &amp; enjoy it with them</note>
       </trans-unit>
+      <trans-unit id="4">
+        <source>Hello</source>
+        <target>Hallo</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Related PR: https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/3

webOS has additional xliff usage. it is `x-key` property. if xliff has it, it has to be the source.
Following cases, the source has to be `pictureModeSetting` instead `Customize`. I've updated code to match the source with x-key value in this case.

Example)
* xliff:
`<source x-key="pictureModeSetting">Customize</source>`

* js:
`<SettingsDivider>{$L({key:'pictureModeSettings', value:'Customize'})}</SettingsDivider>`
