### PR TITLE
Fix loading of plugins

### DIFF
--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -67,40 +67,32 @@ CustomProject.prototype = new Project({noInstance: true});
 CustomProject.prototype.parent = Project;
 CustomProject.prototype.constructor = CustomProject;
 
-CustomProject.prototype.loadPlugin = function(plugin, API) {
-    var filetype, filetypeClass;
-
+/**
+ * @private
+ */
+CustomProject.prototype._attemptLoad = function (name, API) {
     try {
-        logger.trace("Trying module " + plugin);
-        filetypeClass = require(plugin);
+        logger.trace("Trying module " + name);
+        filetypeClass = require(name);
         filetype = new filetypeClass(this, API);
         this.fileTypes.push(filetype);
         return filetype;
     } catch (e) {
-        logger.trace(e);
-        try {
-            // didn't work... okay, so try with the standard prefix
-            logger.trace("Trying module ilib-loctool-" + plugin);
-            filetypeClass = require("ilib-loctool-" + plugin);
-            filetype = new filetypeClass(this, API);
-            this.fileTypes.push(filetype);
-            return filetype;
-        } catch (e2) {
-            logger.trace(e2);
-            // didn't work again... okay, so it's not a node module or path to a file.
-            // try names of things in the plugins directory
-
-            var pathName = path.join("..", "plugins", plugin + ".js");
-            try {
-                filetypeClass = require(pathName);
-                filetype = new filetypeClass(this, API);
-                this.fileTypes.push(filetype);
-                return filetype;
-            } catch (e3) {
-                throw new Error("Could not load plugin " + plugin);
-            }
-        }
+        logger.trace(e.message);
     }
+};
+
+CustomProject.prototype.loadPlugin = function(plugin, API) {
+    var ret = this._attemptLoad(plugin, API) ||
+        this._attemptLoad("ilib-loctool-" + plugin, API) ||
+        this._attemptLoad(path.join(process.env.PWD, "node_modules", plugin), API) ||
+        this._attemptLoad(path.join(process.env.PWD, "node_modules", "ilib-loctool-" + plugin), API) ||
+        this._attemptLoad(path.join("..", "plugins", plugin + ".js"), API) ||
+        this._attemptLoad(path.join("..", "plugins", "ilib-loctool-" + plugin + ".js"), API);
+
+    if (!ret) throw new Error("Could not load plugin " + plugin);
+
+    return ret;
 };
 
 CustomProject.prototype.getAPI = function() {
@@ -142,7 +134,7 @@ CustomProject.prototype.initFileTypes = function() {
 
     this.plugins.forEach(function(pluginName) {
         var plugin = this.loadPlugin(pluginName, this.getAPI());
-        if (plugin) {
+        if (plugin && typeof(plugin.getResourceFileType) === "function") {
             var resFileType = plugin.getResourceFileType();
             if (resFileType) {
                 this.resourceFileMap[plugin.type] = new resFileType(this, this.getAPI());


### PR DESCRIPTION
- Make sure to try the current directory when loading plugins because
the project you are localizing may have the plugin packages installed
instead of the place where the loctool is installed
- Added some safety code in case getResourceFileType is not implemented
by the plugin