### PR TITLE
Support schema property in project configuration

### DIFF
--- a/lib/Project.js
+++ b/lib/Project.js
@@ -79,6 +79,10 @@ var Project = function(options, root, settings) {
     this.root = root;  // where localizable files live
     this.target = this.settings.targetDir || this.root; // where localized stuff is written
 
+    if (typeof options.schema !== "undefined") {
+        this.schema = options.schema;
+    }
+
     // where the translation xliff files are read from
     this.xliffsDir = (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || this.root;
 

--- a/test/testfiles/project.json
+++ b/test/testfiles/project.json
@@ -1,19 +1,20 @@
 {
-	"name": "HT Test",
-	"id": "ht-test",
-	"projectType": "web",
-	"pseudoLocale": "de-DE",
-	"resourceDirs": {
-		"yml": "config/locales",
-		"js": "public/localized_js"
-	},
-	"excludes": [
-		".*"
-	],
-	"includes": [
-		"config/notifications.yml"
-	],
-	"settings": {
-		"locales": ["en-GB", "es-US", "zh-Hans-CN"]
-	}
+    "name": "HT Test",
+    "id": "ht-test",
+    "projectType": "web",
+    "pseudoLocale": "de-DE",
+    "resourceDirs": {
+        "yml": "config/locales",
+        "js": "public/localized_js"
+    },
+    "schema": "./appinfo.schema.json",
+    "excludes": [
+        ".*"
+    ],
+    "includes": [
+        "config/notifications.yml"
+    ],
+    "settings": {
+        "locales": ["en-GB", "es-US", "zh-Hans-CN"]
+    }
 }


### PR DESCRIPTION
`ilib-loctool-webos-appinfo-json` module use schema file before start json file localization.
In order to support various schema path, I added code to set scheme properties.
something like:
```
    "schema": "./appinfo.schema.json",
```
If it's not defined, Use the path defined in the module itself.
Additionally, I converted tab to spaces  `test/testfiles/project.json ` file.