### PR TITLE
Various markdown fixes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,9 @@ Build 006
 
 Bug Fixes:
 * Fixed a problem parsing/localizing valueless HTML attributes in markdown files
+* now ignores whitespace before html comments
+* now uses remark-frontmatter to parse the headers
+* now parses linkreferences properly when the text is not the default
 
 Build 005
 -------

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -34,6 +34,7 @@ var remark2rehype = require('remark-rehype');
 var highlight = require('remark-highlight.js');
 var raw = require('rehype-raw');
 var stringify = require('remark-stringify');
+var frontmatter = require('remark-frontmatter');
 var he = require("he");
 var unistFilter = require('unist-util-filter');
 var unistMap = require('unist-util-map');
@@ -55,6 +56,7 @@ var mdparser = unified().
         commonmark: true,
         gfm: true
     }).
+    use(frontmatter, ['yaml']).
     use(highlight).
     use(remark2rehype).
     use(raw);
@@ -67,7 +69,8 @@ var mdstringify = unified().
         ruleSpaces: false,
         bullet: '*',
         listItemIndent: 1
-    })();
+    }).
+    use(frontmatter, ['yaml'])();
 
 function escapeQuotes(str) {
     var ret = "";
@@ -449,7 +452,6 @@ MarkdownFile.prototype._walk = function(node) {
             break;
 
         case 'definition':
-            node.label && this._addTransUnit(node.label);
             node.title && this._addTransUnit(node.title);
             // definitions are breaking nodes
             this._emitText();
@@ -465,16 +467,29 @@ MarkdownFile.prototype._walk = function(node) {
         case 'inlineCode':
             // inline code nodes and link references are non-breaking and self-closing
             // Also, pass true to the push so that this node is never optimized out of a string.
-            if (this.message.getTextLength()) {
+            if (this.message.getTextLength() || (node.children && node.children.length)) {
                 node.localizable = true;
                 this.message.push(node, true);
+                if (node.children &&
+                        node.children.length &&
+                        node.children[0].type === "text" &&
+                        node.children[0].value !== node.label) {
+                    // only record the text children when the text is different than the label
+                    // of this reference
+                    node.children.forEach(function(child) {
+                        this._walk(child);
+                    }.bind(this));
+                } else {
+                    // don't need the children where the text is the same as the label
+                    node.children = [];
+                }
                 this.message.pop();
             }
             break;
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.substring(0, 4) === '<!--') {
+            if (node.value.trim().substring(0, 4) === '<!--') {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {
@@ -539,14 +554,6 @@ MarkdownFile.prototype._walk = function(node) {
                         } else if (child.identifier.substring(0, 6) === "/block") {
                             valid = true;
                             return;
-                        } else if (child.children &&
-                                child.children.length &&
-                                child.children[0].type === "text") {
-                            // Don't need to localize the text nodes inside of linkReferences
-                            // because that text should correspond with the text in the
-                            // references below. So just avoid it and recreate it later during
-                            // the localization step if necessary
-                            child.children = [];
                         }
                     } else if (child.type === 'thematicBreak') {
                         if (index+1 < array.length && array[index+1]) {
@@ -755,12 +762,18 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
 
         case 'linkReference':
             if (node.localizable) {
-                node.add(new Node({
-                    type: 'text',
-                    value: node.label
-                }));
-                message.push(node, true);
-                message.pop();
+                if (node.use === "start") {
+                    message.push(node, true);
+                } else if (node.use === "startend") {
+                    node.add(new Node({
+                        type: 'text',
+                        value: node.label
+                    }));
+                    message.push(node, true);
+                    message.pop();
+                } else {
+                    message.pop();
+                }
             }
             break;
 
@@ -803,7 +816,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.substring(0, 4) === '<!--') {
+            if (node.value.trim().substring(0, 4) === '<!--') {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {
@@ -871,13 +884,6 @@ function flattenHtml(node) {
 
 function mapToAst(node) {
     var children = [];
-
-    if (node.type === "linkReference") {
-        node.add(new Node({
-            type: 'text',
-            value: node.label
-        }));
-    }
 
     for (var i = 0; i < node.children.length; i++) {
         var child = mapToAst(node.children[i]);

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "opencc": ">=1.0.5",
         "pretty-data": ">=0.40.0",
         "rehype-raw": "^4.0.1",
+        "remark-frontmatter": "^1.3.2",
         "remark-highlight.js": "^5.1.1",
         "remark-html": "^9.0.1",
         "remark-parse": "^6.0.3",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2783,7 +2783,7 @@ module.exports.markdown = {
 
         test.done();
     },
-    
+
     testMarkdownFileLocalizeWithReferenceLinks: function(test) {
         test.expect(3);
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -804,7 +804,7 @@ module.exports.markdown = {
         test.ok(mf);
 
         mf.parse('This is a test of the emergency parsing system.\n\n' +
-                '[C1] As referenced before.\n');
+                '[C1]: As referenced before.\n');
 
         var set = mf.getTranslationSet();
         test.ok(set);
@@ -814,10 +814,10 @@ module.exports.markdown = {
         test.equal(r.getSource(), "This is a test of the emergency parsing system.");
         test.equal(r.getKey(), "r699762575");
 
-        r = set.getBySource("As referenced before.");
+        r = set.getBySource("<c0/>: As referenced before.");
         test.ok(r);
-        test.equal(r.getSource(), "As referenced before.");
-        test.equal(r.getKey(), "r335185216");
+        test.equal(r.getSource(), "<c0/>: As referenced before.");
+        test.equal(r.getKey(), "r650576171");
 
         test.done();
     },
@@ -2715,6 +2715,201 @@ module.exports.markdown = {
         test.ok(r);
         test.equal(r.getSource(), "<c0><c1>File Workflow with Webhooks</c1></c0>: Creating file task automation with webhooks.");
         test.equal(r.getKey(), "r663481768");
+
+        test.done();
+    },
+
+    testMarkdownFileParseWithLinkReferenceWithText: function(test) {
+        test.expect(6);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getSource(), "For developer support, please reach out to us via one of our channels:");
+
+        test.equal(resources[1].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
+
+        test.done();
+    },
+
+    testMarkdownFileParseWithMultipleLinkReferenceWithText: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '- [Ask in email][email]: For specific questions and support.\n' +
+            '- [Ask on stack overflow][so]: For community answers and support.\n' +
+            '\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n' +
+            '[email]: mailto:support@ourplatform\n' +
+            '[so]: http://ourplatform.stackoverflow.com/'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 4);
+
+        test.equal(resources[0].getSource(), "For developer support, please reach out to us via one of our channels:");
+        test.equal(resources[1].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
+        test.equal(resources[2].getSource(), "<c0>Ask in email</c0>: For specific questions and support.");
+        test.equal(resources[3].getSource(), "<c0>Ask on stack overflow</c0>: For community answers and support.");
+
+        test.done();
+    },
+    
+    testMarkdownFileLocalizeWithReferenceLinks: function(test) {
+        test.expect(3);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n'
+        );
+        test.ok(mf);
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r816306377',
+            source: 'For developer support, please reach out to us via one of our channels:',
+            target: 'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r293599939',
+            source: '<c0>Ask on Twitter</c0>: For general questions and support.',
+            target: '<c0>Auf Twitter stellen</c0>: Für allgemeine Fragen und Unterstützung.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
+            '\n' +
+            '* [Auf Twitter stellen][twitter]: Für allgemeine Fragen und Unterstützung.\n' +
+            '\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileParseHTMLComments: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <!-- comment -->test of the emergency parsing system.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        test.done();
+    },
+
+    testMarkdownFileParseHTMLCommentsWithIndent: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n  <!-- comment -->\nA second string\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        var r = set.getBySource("A second string");
+        test.ok(r);
+        test.equal(r.getSource(), "A second string");
+        test.equal(r.getKey(), "r772298159");
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeHTMLCommentsWithIndent: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n  <!-- comment -->\nA second string\n');
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r699762575',
+            source: 'This is a test of the emergency parsing system.',
+            target: 'This is a test of the emergency parsing system... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r772298159',
+            source: 'A second string',
+            target: 'A second string... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            'This is a test of the emergency parsing system... in GERMAN!\n\n  <!-- comment -->\n\nA second string... in GERMAN!\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
 
         test.done();
     }


### PR DESCRIPTION
Fixes from the ghfm plugin:

- now ignores whitespace before html comments
- now uses remark-frontmatter
- now parses linkreferences properly when the text is not the default