### PR TITLE
Now works properly with full and shortcut link references.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,12 @@ Build 007
 New Features:
 * Added -v (--version) command-line parameter. Prints out the version from the package.json
   and then exits.
-  * Updated the usage to print that as well
+    * Updated the usage to print that as well
+
+Bug Fixes:
+* Fixed the link reference support in markdown to support both full and shortcut references
+    * Shortcut references are converted to full so that the title can be translated without
+      changing the label.
 
 Build 006
 -------

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -369,7 +369,6 @@ MarkdownFile.prototype._localizeAttributes = function(tagName, tag, locale, tran
         } else {
             attributes[name] = "true";
         }
-
     }
 
     for (var attr in attributes) {
@@ -407,8 +406,6 @@ MarkdownFile.prototype._walk = function(node) {
         case 'link':
         case 'emphasis':
         case 'strong':
-            // var thisComponent = this.componentIndex++;
-            // this.text += '<c' + thisComponent + '>';
             node.title && this._addTransUnit(node.title);
             if (node.children && node.children.length) {
                 this.message.push({
@@ -452,39 +449,46 @@ MarkdownFile.prototype._walk = function(node) {
             break;
 
         case 'definition':
-            node.title && this._addTransUnit(node.title);
             // definitions are breaking nodes
             this._emitText();
             break;
 
         case 'footnoteDefinition':
-            node.label && this._addTransUnit(node.label);
             // definitions are breaking nodes
             this._emitText();
             break;
 
         case 'linkReference':
-        case 'inlineCode':
-            // inline code nodes and link references are non-breaking and self-closing
-            // Also, pass true to the push so that this node is never optimized out of a string.
-            if (this.message.getTextLength() || (node.children && node.children.length)) {
-                node.localizable = true;
-                this.message.push(node, true);
-                if (node.children &&
-                        node.children.length &&
-                        node.children[0].type === "text" &&
-                        node.children[0].value !== node.label) {
-                    // only record the text children when the text is different than the label
-                    // of this reference
-                    node.children.forEach(function(child) {
-                        this._walk(child);
-                    }.bind(this));
-                } else {
-                    // don't need the children where the text is the same as the label
-                    node.children = [];
+            // inline code nodes and link references are non-breaking
+            // Also, pass true to the push so that this node is never optimized out of a string,
+            // even at the beginning or end.
+            node.localizable = true;
+            if (node.referenceType === "shortcut") {
+                // convert to a full reference with a text child
+                // so that we can have a separate label and translated title
+                if (!node.children || !node.children.length) {
+                    var child = new Node({
+                        type: "text",
+                        value: node.label,
+                        children: []
+                    });
+                    node.children.push(child);
                 }
-                this.message.pop();
+                node.referenceType = "full";
             }
+            this.message.push(node, true);
+            if (node.children && node.children.length) {
+                node.children.forEach(function(child) {
+                    this._walk(child);
+                }.bind(this));
+            }
+            this.message.pop();
+            break;
+
+        case 'inlineCode':
+            node.localizable = true;
+            this.message.push(node, true);
+            this.message.pop();
             break;
 
         case 'html':
@@ -675,7 +679,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
     } else if (translatedResource) {
         translation = translatedResource.getTarget();
     } else if (this.type) {
-        if (source && this.type.pseudos[locale]) {
+        if (source && this.type.pseudos && this.type.pseudos[locale]) {
             var sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
             if (sourceLocale !== this.project.sourceLocale) {
                 // translation is derived from a different locale's translation instead of from the source string
@@ -765,10 +769,6 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 if (node.use === "start") {
                     message.push(node, true);
                 } else if (node.use === "startend") {
-                    node.add(new Node({
-                        type: 'text',
-                        value: node.label
-                    }));
                     message.push(node, true);
                     message.pop();
                 } else {
@@ -786,12 +786,6 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             break;
 
         case 'definition':
-            if (node.label) {
-                node.label = this._localizeString(node.label, locale, translations);
-            }
-            if (node.title) {
-                node.title = this._localizeString(node.title, locale, translations);
-            }
             if (node.localizable) {
                 if (node.use === "start") {
                     message.push(node);
@@ -802,9 +796,6 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             break;
 
         case 'footnoteDefinition':
-            if (node.label) {
-                node.label = this._localizeString(node.label, locale, translations);
-            }
             if (node.localizable) {
                 if (node.use === "start") {
                     message.push(node);
@@ -1008,25 +999,6 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
             if (nodeArray[i].identifier.substring(0, 6) === "block:") {
                 valid = false;
             } else if (nodeArray[i].identifier.substring(0, 6) === "/block" && nodeArray[i].use === "end") {
-                valid = true;
-            }
-        } else if (nodeArray[i].type === 'thematicBreak') {
-            if (i+2 < nodeArray.length && nodeArray[i+1] && nodeArray[i+2]) {
-                if (nodeArray[i+1].type === 'paragraph' &&
-                        nodeArray[i+2].type === "text" &&
-                        nodeArray[i+2].value.substring(0, 6) === "title:") {
-                    // glue all the subsequent contiguous text nodes together as one
-                    var tmpStr = "";
-                    for (var j = i+2; j < nodeArray.length && nodeArray[j].type === "text"; j++) {
-                        tmpStr += nodeArray[j].value;
-                    }
-                    nodeArray[i+2].value = escapeQuotes(tmpStr);
-                    nodeArray.splice(i+2, j-i-2, nodeArray[i+2]);
-                    valid = false;
-                } else {
-                    valid = true;
-                }
-            } else {
                 valid = true;
             }
         }

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -731,6 +731,46 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseReferenceLinksWithTitle: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a test of the [emergency parsing][emer_sys] system.\n\n' +
+            '[emer_sys]: http://www.test.com/\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the <c0>emergency parsing</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0>emergency parsing</c0> system.");
+        test.equal(r.getKey(), "r848003676");
+
+        test.done();
+    },
+
+    testMarkdownFileParseReferenceLinksWithoutTitle: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a test of the [emergency parsing] system.\n\n' +
+            '[emergency parsing]: http://www.test.com/\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the <c0>emergency parsing</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0>emergency parsing</c0> system.");
+        test.equal(r.getKey(), "r848003676");
+
+        test.done();
+    },
+
     testMarkdownFileParseDontExtractURLOnlyLinks: function(test) {
         test.expect(7);
 
@@ -784,40 +824,15 @@ module.exports.markdown = {
         test.ok(mf);
 
         mf.parse('This is a test of the emergency parsing [C1] system.\n\n' +
-                '[C1] http://www.box.com/foobar\n');
+                '[C1]: http://www.box.com/foobar\n');
 
         var set = mf.getTranslationSet();
         test.ok(set);
 
-        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        var r = set.getBySource("This is a test of the emergency parsing <c0>C1</c0> system.");
         test.ok(r);
-        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
-        test.equal(r.getKey(), "r1010312382");
-
-        test.done();
-    },
-
-    testMarkdownFileParseNotOnlyReference: function(test) {
-        test.expect(8);
-
-        var mf = new MarkdownFile(p);
-        test.ok(mf);
-
-        mf.parse('This is a test of the emergency parsing system.\n\n' +
-                '[C1]: As referenced before.\n');
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-
-        var r = set.getBySource("This is a test of the emergency parsing system.");
-        test.ok(r);
-        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
-        test.equal(r.getKey(), "r699762575");
-
-        r = set.getBySource("<c0/>: As referenced before.");
-        test.ok(r);
-        test.equal(r.getSource(), "<c0/>: As referenced before.");
-        test.equal(r.getKey(), "r650576171");
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0>C1</c0> system.");
+        test.equal(r.getKey(), "r475244008");
 
         test.done();
     },
@@ -1690,16 +1705,16 @@ module.exports.markdown = {
         var translations = new TranslationSet();
         translations.add(new ResourceString({
             project: "foo",
-            key: "r858031024",
-            source: "This is a test of the emergency <c0/> parsing system.",
+            key: "r1017266258",
+            source: "This is a test of the emergency <c0>C1</c0> parsing system.",
             sourceLocale: "en-US",
-            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0/>.",
+            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0>C1</c0>.",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
 
         test.equal(mf.localizeText(translations, "fr-FR"),
-            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1].\n');
+            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1][C1].\n');
 
         test.done();
     },
@@ -1710,21 +1725,21 @@ module.exports.markdown = {
         var mf = new MarkdownFile(p);
         test.ok(mf);
 
-        mf.parse('This is a test of the emergency [C1] parsing system [R1].\n\n[C1] https://www.box.com/test1\n[R1] http://www.box.com/about.html\n');
+        mf.parse('This is a test of the emergency [C1] parsing system [R1].\n\n[C1]: https://www.box.com/test1\n[R1]: http://www.box.com/about.html\n');
 
         var translations = new TranslationSet();
         translations.add(new ResourceString({
             project: "foo",
-            key: "r90710505",
-            source: "This is a test of the emergency <c0/> parsing system <c1/>.",
+            key: "r817759238",
+            source: "This is a test of the emergency <c0>C1</c0> parsing system <c1>R1</c1>.",
             sourceLocale: "en-US",
-            target: "Ceci est un test du système d'analyse syntaxique <c1/> de l'urgence <c0/>.",
+            target: "Ceci est un test du système d'analyse syntaxique <c1>Reponse1</c1> de l'urgence <c0>teste</c0>.",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
 
         test.equal(mf.localizeText(translations, "fr-FR"),
-            'Ceci est un test du système d\'analyse syntaxique [R1] de l\'urgence [C1].\n\n[C1] <https://www.box.com/test1>\n[R1] <http://www.box.com/about.html>\n');
+            'Ceci est un test du système d\'analyse syntaxique [Reponse1][R1] de l\'urgence [teste][C1].\n\n[C1]: https://www.box.com/test1\n\n[R1]: http://www.box.com/about.html\n');
 
         test.done();
     },
@@ -2445,6 +2460,128 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeFileWithFrontMatter: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        var mf = new MarkdownFile(p, "./md/test3.md");
+        test.ok(mf);
+
+        // should read the file
+        mf.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r548615397',
+            source: 'This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.',
+            target: 'Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r777006502',
+            source: 'This is some text. This is more text. Pretty, pretty text.',
+            target: 'Ceci est du texte. C\'est plus de texte. Joli, joli texte.',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r112215756',
+            source: 'This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.',
+            target: 'Ceci est de la texte localisable. Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r260813817',
+            source: 'This is the last bit of localizable text.',
+            target: 'C\'est le dernier morceau de texte localisable.',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r548615397',
+            source: 'This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.',
+            target: 'Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r777006502',
+            source: 'This is some text. This is more text. Pretty, pretty text.',
+            target: 'Dies ist ein Text. Dies ist mehr Text. Hübscher, hübscher Text.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r112215756',
+            source: 'This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.',
+            target: 'Dies ist ein lokalisierbarer Text. Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r260813817',
+            source: 'This is the last bit of localizable text.',
+            target: 'Dies ist der letzte Teil des lokalisierbaren Textes.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        mf.localize(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, p.root, "fr-FR/md/test3.md")));
+        test.ok(fs.existsSync(path.join(base, p.root, "de-DE/md/test3.md")));
+
+        var content = fs.readFileSync(path.join(base, p.root, "fr-FR/md/test3.md"), "utf-8");
+
+        var expected =
+            '---\n' +
+            'title: This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.\n' +
+            'status: this front matter should remain unlocalized\n' +
+            '---\n' +
+            '# Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n' +
+            '\n' +
+            'Ceci est du texte. C\'est plus de texte. Joli, joli texte.\n\n' +
+            'Ceci est de la texte localisable. Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n\n' +
+            'C\'est le dernier morceau de texte localisable.\n' +
+            '\n' +
+            'Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        var content = fs.readFileSync(path.join(p.root, "de-DE/md/test3.md"), "utf-8");
+
+        var expected =
+            '---\n' +
+            'title: This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.\n' +
+            'status: this front matter should remain unlocalized\n' +
+            '---\n' +
+            '# Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n' +
+            '\n' +
+            'Dies ist ein Text. Dies ist mehr Text. Hübscher, hübscher Text.\n\n' +
+            'Dies ist ein lokalisierbarer Text. Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n\n' +
+            'Dies ist der letzte Teil des lokalisierbaren Textes.\n' +
+            '\n' +
+            'Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeNoStrings: function(test) {
         test.expect(3);
 
@@ -2784,7 +2921,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileLocalizeWithReferenceLinks: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithTitle: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile(p);
@@ -2826,6 +2963,56 @@ module.exports.markdown = {
             '* [Auf Twitter stellen][twitter]: Für allgemeine Fragen und Unterstützung.\n' +
             '\n' +
             '[twitter]: https://twitter.com/OurPlatform\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeReferenceLinksWithoutTitle: function(test) {
+        test.expect(3);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter] For general questions and support.\n' +
+            '\n' +
+            '[Ask on Twitter]: https://twitter.com/OurPlatform\n'
+        );
+        test.ok(mf);
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r816306377',
+            source: 'For developer support, please reach out to us via one of our channels:',
+            target: 'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r1030328207',
+            source: '<c0>Ask on Twitter</c0> For general questions and support.',
+            target: '<c0>Auf Twitter stellen</c0> für allgemeine Fragen und Unterstützung.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        // DON'T localize the label. Instead, add a title that is translated
+        var expected =
+            'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
+            '\n' +
+            '* [Auf Twitter stellen][Ask on Twitter] für allgemeine Fragen und Unterstützung.\n' +
+            '\n' +
+            '[Ask on Twitter]: https://twitter.com/OurPlatform\n';
 
         diff(actual, expected);
         test.equal(actual, expected);

--- a/test/testfiles/md/test3.md
+++ b/test/testfiles/md/test3.md
@@ -1,0 +1,15 @@
+---
+title: This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+status: this front matter should remain unlocalized
+---
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+==================================
+
+This is some text. This is more text. Pretty, pretty text.
+
+This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+
+This is the last bit of localizable text.
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.


### PR DESCRIPTION
Shortcut references are converted back to full so that the title of the reference can be translated to something different than the [possibly] English label of the shortcut.