### PR TITLE
Support resourceFileName property in project configuration

### DIFF
--- a/lib/Project.js
+++ b/lib/Project.js
@@ -83,6 +83,10 @@ var Project = function(options, root, settings) {
         this.schema = options.schema;
     }
 
+    if (typeof options.resourceFileName !== "undefined") {
+        this.resourceFileName = options.resourceFileName;
+    }
+
     // where the translation xliff files are read from
     this.xliffsDir = (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || this.root;
 

--- a/test/testfiles/project.json
+++ b/test/testfiles/project.json
@@ -7,6 +7,7 @@
         "yml": "config/locales",
         "js": "public/localized_js"
     },
+    "resourceFileName": "strings.json",
     "schema": "./appinfo.schema.json",
     "excludes": [
         ".*"


### PR DESCRIPTION
A module can have various resource file name depends on requirements,  To support that, I created resourceFileName property in a project configuration

something like:
    "resourceFileName": "./cstring.json",
If it's not defined, It will be used as a default name defined in the module itself.
