### PR TITLE
Support to handle multiple group tags in an xliff file

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,7 +4,7 @@ Release Notes for Version 2
 Build 008
 -------
 
-Published as version 2.4.1
+Published as version 2.5.0
 
 New Features:
 * Added support to handle multiple group tags in an xliff file

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 008
+-------
+
+Published as version 2.4.1
+
+New Features:
+* Added support to handle multiple group tags in an xliff file
+    * loctool considersed only one group tag in an xliff file. but now we can support a case to have multiple groups in a xliff file
+
 Build 007
 -------
 

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -1032,27 +1032,27 @@ Xliff.prototype.parse2 = function(xliff) {
 
             for (var j=0; j < unitsElement.length; j++) {
                 if (unitsElement[j].unit) {
-                    var xliffUnits = makeArray(unitsElement[j].unit);
+                    var transUnits = makeArray(unitsElement[j].unit);
 
-                    for (var k=0; k < xliffUnits.length; k++) {
+                    for (var k=0; k < transUnits.length; k++) {
                         var comment = "", state;
-                        var datatype = xliffUnits[k]["l:datatype"] || unitsElement[j].name;
+                        var datatype = transUnits[k]["l:datatype"] || unitsElement[j].name;
                         var source = "", target = "";
 
-                        if (xliffUnits[k].notes && xliffUnits[k].notes.note) {
-                            comment = ilib.isArray(xliffUnits[k].notes.note) ?
-                                xliffUnits[k].notes.note[0]["$t"] :
-                                xliffUnits[k].notes.note["$t"];
+                        if (transUnits[k].notes && transUnits[k].notes.note) {
+                            comment = ilib.isArray(transUnits[k].notes.note) ?
+                                transUnits[k].notes.note[0]["$t"] :
+                                transUnits[k].notes.note["$t"];
                         }
 
-                        var resname = xliffUnits[k].name;
+                        var resname = transUnits[k].name;
                         var restype = "string";
-                        if (xliffUnits[k].type && xliffUnits[k].type.startsWith("res:")) {
-                            restype = xliffUnits[k].type.substring(4);
+                        if (transUnits[k].type && transUnits[k].type.startsWith("res:")) {
+                            restype = transUnits[k].type.substring(4);
                         }
 
-                        if (xliffUnits[k].segment) {
-                            var segments = makeArray(xliffUnits[k].segment);
+                        if (transUnits[k].segment) {
+                            var segments = makeArray(transUnits[k].segment);
                             for (var m = 0; m < segments.length; m++) {
                                 var segment = segments[m];
 
@@ -1079,10 +1079,10 @@ Xliff.prototype.parse2 = function(xliff) {
                                     file: fileSettings.pathName,
                                     sourceLocale: fileSettings.locale,
                                     project: fileSettings.project,
-                                    id: xliffUnits[k].id,
+                                    id: transUnits[k].id,
                                     key: unescapeAttr(resname),
                                     source: source,
-                                    context: xliffUnits[k]["l:context"],
+                                    context: transUnits[k]["l:context"],
                                     comment: comment,
                                     targetLocale: targetLocale,
                                     target: target,
@@ -1093,10 +1093,10 @@ Xliff.prototype.parse2 = function(xliff) {
                                 });
                                 switch (restype) {
                                 case "array":
-                                    unit.ordinal = xliffUnits[k]["l:index"] && Number(xliffUnits[k]["l:index"]).valueOf();
+                                    unit.ordinal = transUnits[k]["l:index"] && Number(transUnits[k]["l:index"]).valueOf();
                                     break;
                                 case "plural":
-                                    unit.quantity = xliffUnits[k]["l:category"];
+                                    unit.quantity = transUnits[k]["l:category"];
                                     break;
                                 }
                                 this.tu.push(unit);
@@ -1104,7 +1104,7 @@ Xliff.prototype.parse2 = function(xliff) {
                                 logger.warn("Skipping invalid translation unit found in xliff file.\n" + e);
                             }
                         } else {
-                            logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + xliffUnits[k].resname);
+                            logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + transUnits[k].resname);
                         }
                     }
                 }

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -1028,33 +1028,33 @@ Xliff.prototype.parse2 = function(xliff) {
             };
 
             unitsElement = file.group || file;
-            unitsElement = ilib.isArray(unitsElement) ? unitsElement : [unitsElement];
+            unitsElement = makeArray(unitsElement);
 
             for (var j=0; j < unitsElement.length; j++) {
                 if (unitsElement[j].unit) {
                     var transUnits = makeArray(unitsElement[j].unit);
-
-                    for (var k=0; k < transUnits.length; k++) {
-                        var comment = "", state;
-                        var datatype = transUnits[k]["l:datatype"] || unitsElement[j].name;
+                    var unitElementName = unitsElement[j].name;
+                    transUnits.forEach(function(tu) {
+                        var comment, state;
+                        var datatype = tu["l:datatype"] || unitElementName;
                         var source = "", target = "";
 
-                        if (transUnits[k].notes && transUnits[k].notes.note) {
-                            comment = ilib.isArray(transUnits[k].notes.note) ?
-                                transUnits[k].notes.note[0]["$t"] :
-                                transUnits[k].notes.note["$t"];
+                        if (tu.notes && tu.notes.note) {
+                            comment = ilib.isArray(tu.notes.note) ?
+                                tu.notes.note[0]["$t"] :
+                                tu.notes.note["$t"];
                         }
 
-                        var resname = transUnits[k].name;
+                        var resname = tu.name;
                         var restype = "string";
-                        if (transUnits[k].type && transUnits[k].type.startsWith("res:")) {
-                            restype = transUnits[k].type.substring(4);
+                        if (tu.type && tu.type.startsWith("res:")) {
+                            restype = tu.type.substring(4);
                         }
 
-                        if (transUnits[k].segment) {
-                            var segments = makeArray(transUnits[k].segment);
-                            for (var m = 0; m < segments.length; m++) {
-                                var segment = segments[m];
+                        if (tu.segment) {
+                            var segments = makeArray(tu.segment);
+                            for (var j = 0; j < segments.length; j++) {
+                                var segment = segments[j];
 
                                 if (segment.source["$t"]) {
                                     source += segment.source["$t"];
@@ -1079,10 +1079,10 @@ Xliff.prototype.parse2 = function(xliff) {
                                     file: fileSettings.pathName,
                                     sourceLocale: fileSettings.locale,
                                     project: fileSettings.project,
-                                    id: transUnits[k].id,
+                                    id: tu.id,
                                     key: unescapeAttr(resname),
                                     source: source,
-                                    context: transUnits[k]["l:context"],
+                                    context: tu["l:context"],
                                     comment: comment,
                                     targetLocale: targetLocale,
                                     target: target,
@@ -1093,10 +1093,10 @@ Xliff.prototype.parse2 = function(xliff) {
                                 });
                                 switch (restype) {
                                 case "array":
-                                    unit.ordinal = transUnits[k]["l:index"] && Number(transUnits[k]["l:index"]).valueOf();
+                                    unit.ordinal = tu["l:index"] && Number(tu["l:index"]).valueOf();
                                     break;
                                 case "plural":
-                                    unit.quantity = transUnits[k]["l:category"];
+                                    unit.quantity = tu["l:category"];
                                     break;
                                 }
                                 this.tu.push(unit);
@@ -1104,9 +1104,9 @@ Xliff.prototype.parse2 = function(xliff) {
                                 logger.warn("Skipping invalid translation unit found in xliff file.\n" + e);
                             }
                         } else {
-                            logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + transUnits[k].resname);
+                            logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu.resname);
                         }
-                    }
+                    }.bind(this));
                 }
             }
         }

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -1017,7 +1017,7 @@ Xliff.prototype.parse2 = function(xliff) {
         for (var i = 0; i < files.length; i++) {
             var fileSettings = {};
             var file = files[i];
-            var unitsElement, datatype;
+            var unitsElement = [], datatype;
 
             fileSettings = {
                 pathName: file.original,
@@ -1028,83 +1028,86 @@ Xliff.prototype.parse2 = function(xliff) {
             };
 
             unitsElement = file.group || file;
+            unitsElement = ilib.isArray(unitsElement) ? unitsElement : [unitsElement];
 
-            if (unitsElement.unit) {
-                var units = makeArray(unitsElement.unit);
+            for (var j=0; j < unitsElement.length; j++) {
+                if (unitsElement[j].unit) {
+                    var xliffUnits = makeArray(unitsElement[j].unit);
 
-                units.forEach(function(tu) {
-                    var comment, state;
-                    var datatype = tu["l:datatype"] || unitsElement.name;
-                    var source = "", target = "";
+                    for (var k=0; k < xliffUnits.length; k++) {
+                        var comment = "", state;
+                        var datatype = xliffUnits[k]["l:datatype"] || unitsElement[j].name;
+                        var source = "", target = "";
 
-                    if (tu.notes && tu.notes.note) {
-                        comment = ilib.isArray(tu.notes.note) ?
-                            tu.notes.note[0]["$t"] :
-                            tu.notes.note["$t"];
-                    }
+                        if (xliffUnits[k].notes && xliffUnits[k].notes.note) {
+                            comment = ilib.isArray(xliffUnits[k].notes.note) ?
+                                xliffUnits[k].notes.note[0]["$t"] :
+                                xliffUnits[k].notes.note["$t"];
+                        }
 
-                    var resname = tu.name;
-                    var restype = "string";
-                    if (tu.type && tu.type.startsWith("res:")) {
-                        restype = tu.type.substring(4);
-                    }
+                        var resname = xliffUnits[k].name;
+                        var restype = "string";
+                        if (xliffUnits[k].type && xliffUnits[k].type.startsWith("res:")) {
+                            restype = xliffUnits[k].type.substring(4);
+                        }
 
-                    if (tu.segment) {
-                        var segments = makeArray(tu.segment);
-                        for (var j = 0; j < segments.length; j++) {
-                            var segment = segments[j];
+                        if (xliffUnits[k].segment) {
+                            var segments = makeArray(xliffUnits[k].segment);
+                            for (var m = 0; m < segments.length; m++) {
+                                var segment = segments[m];
 
-                            if (segment.source["$t"]) {
-                                source += segment.source["$t"];
-                                if (segment.target) {
-                                    target += segment.target["$t"];
+                                if (segment.source["$t"]) {
+                                    source += segment.source["$t"];
+                                    if (segment.target) {
+                                        target += segment.target["$t"];
 
-                                    if (segment.target.state) {
-                                        state = segment.target.state;
+                                        if (segment.target.state) {
+                                            state = segment.target.state;
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    if (!resname) {
-                        resname = source;
-                    }
-
-                    if (source.trim()) {
-                        try {
-                            var unit = new TranslationUnit({
-                                file: fileSettings.pathName,
-                                sourceLocale: fileSettings.locale,
-                                project: fileSettings.project,
-                                id: tu.id,
-                                key: unescapeAttr(resname),
-                                source: source,
-                                context: tu["l:context"],
-                                comment: comment,
-                                targetLocale: targetLocale,
-                                target: target,
-                                resType: restype,
-                                state: state,
-                                datatype: datatype,
-                                flavor: fileSettings.flavor
-                            });
-                            switch (restype) {
-                            case "array":
-                                unit.ordinal = tu["l:index"] && Number(tu["l:index"]).valueOf();
-                                break;
-                            case "plural":
-                                unit.quantity = tu["l:category"];
-                                break;
-                            }
-                            this.tu.push(unit);
-                        } catch (e) {
-                            logger.warn("Skipping invalid translation unit found in xliff file.\n" + e);
+                        if (!resname) {
+                            resname = source;
                         }
-                    } else {
-                        logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu.resname);
+
+                        if (source.trim()) {
+                            try {
+                                var unit = new TranslationUnit({
+                                    file: fileSettings.pathName,
+                                    sourceLocale: fileSettings.locale,
+                                    project: fileSettings.project,
+                                    id: xliffUnits[k].id,
+                                    key: unescapeAttr(resname),
+                                    source: source,
+                                    context: xliffUnits[k]["l:context"],
+                                    comment: comment,
+                                    targetLocale: targetLocale,
+                                    target: target,
+                                    resType: restype,
+                                    state: state,
+                                    datatype: datatype,
+                                    flavor: fileSettings.flavor
+                                });
+                                switch (restype) {
+                                case "array":
+                                    unit.ordinal = xliffUnits[k]["l:index"] && Number(xliffUnits[k]["l:index"]).valueOf();
+                                    break;
+                                case "plural":
+                                    unit.quantity = xliffUnits[k]["l:category"];
+                                    break;
+                                }
+                                this.tu.push(unit);
+                            } catch (e) {
+                                logger.warn("Skipping invalid translation unit found in xliff file.\n" + e);
+                            }
+                        } else {
+                            logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + xliffUnits[k].resname);
+                        }
                     }
-                }.bind(this));
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -3228,7 +3228,7 @@ module.exports.xliff = {
     },
 
     testXliff20DeserializeRealLGFile: function(test) {
-        test.expect(36);
+        test.expect(37);
 
         var x = new Xliff();
         test.ok(x);
@@ -3240,9 +3240,7 @@ module.exports.xliff = {
         x.deserialize(str);
 
         var reslist = x.getResources();
-
         test.ok(reslist);
-
         test.equal(reslist.length, 7);
 
         test.equal(reslist[0].getSource(), "Closed Caption Settings");
@@ -3279,8 +3277,8 @@ module.exports.xliff = {
         test.equal(reslist[6].resType, "string");
         test.equal(reslist[6].datatype, "x-qml");
         test.ok(reslist[6].getComment());
+        test.equal(reslist[6].getComment(), "copy strings from voice app");
         test.equal(reslist[6].getId(), "settings_22");
-
 
         test.done();
     }

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -3228,7 +3228,7 @@ module.exports.xliff = {
     },
 
     testXliff20DeserializeRealLGFile: function(test) {
-        test.expect(25);
+        test.expect(36);
 
         var x = new Xliff();
         test.ok(x);
@@ -3243,7 +3243,7 @@ module.exports.xliff = {
 
         test.ok(reslist);
 
-        test.equal(reslist.length, 6);
+        test.equal(reslist.length, 7);
 
         test.equal(reslist[0].getSource(), "Closed Caption Settings");
         test.equal(reslist[0].getSourceLocale(), "en-KR");
@@ -3268,6 +3268,19 @@ module.exports.xliff = {
         test.equal(reslist[3].datatype, "javascript");
         test.ok(!reslist[3].getComment());
         test.equal(reslist[3].getId(), "settings_1524");
+
+        test.equal(reslist[6].getSource(), "SEARCH");
+        test.equal(reslist[6].getSourceLocale(), "en-KR");
+        test.equal(reslist[6].getTarget(), "검색");
+        test.equal(reslist[6].getTargetLocale(), "ko-KR");
+        test.equal(reslist[6].getKey(), "SEARCH");
+        test.equal(reslist[6].getPath(), "settings");
+        test.equal(reslist[6].getProject(), "settings");
+        test.equal(reslist[6].resType, "string");
+        test.equal(reslist[6].datatype, "x-qml");
+        test.ok(reslist[6].getComment());
+        test.equal(reslist[6].getId(), "settings_22");
+
 
         test.done();
     }

--- a/test/testfiles/test5.xliff
+++ b/test/testfiles/test5.xliff
@@ -42,5 +42,16 @@
     </segment>
    </unit>
  </group>
+ <group id="settings_g2" name="x-qml">
+    <unit id="settings_22">
+    <notes>
+     <note>copy strings from voiceagnet</note>
+    </notes>
+    <segment>
+     <source>SEARCH</source>
+     <target>검색</target>
+    </segment>
+   </unit>
+  </group>
  </file>
 </xliff>

--- a/test/testfiles/test5.xliff
+++ b/test/testfiles/test5.xliff
@@ -45,7 +45,7 @@
  <group id="settings_g2" name="x-qml">
     <unit id="settings_22">
     <notes>
-     <note>copy strings from voiceagnet</note>
+     <note>copy strings from voice app</note>
     </notes>
     <segment>
      <source>SEARCH</source>


### PR DESCRIPTION
The loctool need to support multiple groups in an xliff case.
Currently, loctool considers only one group tag in an xliff file. but we have a case to have two groups in xliff file. something like:
https://github.com/iLib-js/loctool/blob/xliffGroupArray/test/testfiles/test5.xliff
