### PR TITLE
Add support for localizing links and link references.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,56 @@
 Release Notes for Version 2
 ============================
 
+Build 009
+-------
+
+Published as version 2.6.0
+
+New Features:
+* Added support for localizing links and link references in github-flavored markdown files
+
+By default, URLs are not localizable, as the majority are the same
+in all languages. Sometimes, however you want to be able to give a
+different URL for each locale. With this new features, you can turn
+on link localization.
+
+To localize a link in the text, put a localize-links directive around
+it, which is an lint-style HTML comment. Example:
+
+```markdown
+There are
+<!-- i18n-enable localize-links -->
+[fifty](http://www.example.com/)
+<!-- i18n-disable localize-links -->
+of them for sale.
+```
+
+The text "fifty" is localized along with the rest of the sentence in the
+string:
+
+```
+There are <c0>fifty</c0> of them for sale.
+```
+
+Note the c0 tags denote where the link goes. The directives, being HTML
+comments, are not included in the string to translate.
+
+The URL itself appears as a separate string to translate.
+
+Localizing a link reference is very similar. Surround the reference
+definition with a localize-links directive:
+
+```markdown
+There are [fifty][url] of them for sale.
+
+<!-- i18n-enable localize-links -->
+[url]: http://www.example.com/ "link title"
+<!-- i18n-disable localize-links -->
+```
+
+The link title for link reference definitions is included as a separate string
+to translate.
+
 Build 008
 -------
 

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -467,8 +467,7 @@ MarkdownFile.prototype._walk = function(node) {
                 // only localizable if there already is some localizable text
                 // or if this text contains anything that is not whitespace
                 if (parts.text) {
-                    this.message.addText(value);
-                    this.message.isTranslatable = this.localizeLinks;
+                    this._addTransUnit(node.url);
                     node.localizable = true;
                 }
                 node.title && this._addTransUnit(node.title);

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -133,7 +133,7 @@ var MarkdownFile = function(project, pathName, type) {
     this.pathName = pathName;
     this.type = type;
     this.set = new TranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
-
+    this.localizeLinks = false;
     // this.componentIndex = 0;
 };
 
@@ -221,6 +221,11 @@ MarkdownFile.prototype._addTransUnit = function(text, comment) {
  */
 function trim(text) {
     var i, pre = "", post = "", ret = {};
+    if (!text) {
+        return {
+            pre: ""
+        };
+    }
 
     for (i = 0; i < text.length && utils.isWhite(text.charAt(i)); i++);
 
@@ -262,12 +267,14 @@ var reUrl = /^(https?|github|ftps?|mailto|file|data|irc):\/\/[\S]+$/;
  * @returns {boolean} true if the given string contains translatable text,
  * and false otherwise.
  */
-function isTranslatable(str) {
+MarkdownFile.prototype.isTranslatable = function(str) {
     if (!str || !str.length || !str.trim().length) return false;
 
-    reUrl.startIndex = 0;
-    var match = reUrl.exec(str);
-    if (match && match.length) return false;
+    if (!this.localizeLinks) {
+        reUrl.startIndex = 0;
+        var match = reUrl.exec(str);
+        if (match && match.length) return false;
+    }
 
     return utils.containsActualText(str);
 }
@@ -284,7 +291,7 @@ MarkdownFile.prototype._emitText = function(escape) {
 
     logger.trace('text using message accumulator is: ' + text);
 
-    if (isTranslatable(text)) {
+    if (this.message.isTranslatable || this.isTranslatable(text)) {
         this._addTransUnit(text, this.comment);
         var prefixes = this.message.getPrefix();
         var suffixes = this.message.getSuffix();
@@ -382,6 +389,8 @@ MarkdownFile.prototype._localizeAttributes = function(tagName, tag, locale, tran
 var reTagName = /<(\/?)\s*(\w+)(\s|>)/;
 var reL10NComment = /<!--\s*[iI]18[Nn]\s*(.*)\s*-->/;
 
+var reDirectiveComment = /<!--\s*i18n-(en|dis)able\s+(\S*)\s*-->/;
+
 /**
  * @private
  * Walk the tree looking for localizable text.
@@ -398,6 +407,7 @@ MarkdownFile.prototype._walk = function(node) {
             // or if this text contains anything that is not whitespace
             if (this.message.getTextLength() > 0 || parts.text) {
                 this.message.addText(node.value);
+                this.message.isTranslatable = this.localizeLinks;
                 node.localizable = true;
             }
             break;
@@ -451,6 +461,18 @@ MarkdownFile.prototype._walk = function(node) {
         case 'definition':
             // definitions are breaking nodes
             this._emitText();
+            if (node.url && this.localizeLinks) {
+                var value = node.url;
+                var parts = trim(value);
+                // only localizable if there already is some localizable text
+                // or if this text contains anything that is not whitespace
+                if (parts.text) {
+                    this.message.addText(value);
+                    this.message.isTranslatable = this.localizeLinks;
+                    node.localizable = true;
+                }
+                node.title && this._addTransUnit(node.title);
+            }
             break;
 
         case 'footnoteDefinition':
@@ -495,10 +517,18 @@ MarkdownFile.prototype._walk = function(node) {
         case 'html':
             reTagName.lastIndex = 0;
             if (node.value.trim().substring(0, 4) === '<!--') {
-                reL10NComment.lastIndex = 0;
-                match = reL10NComment.exec(node.value);
+                reDirectiveComment.lastIndex = 0;
+                match = reDirectiveComment.exec(node.value);
                 if (match) {
-                    this._addComment(match[1].trim());
+                    if (match[2] === "localize-links") {
+                        this.localizeLinks = (match[1] === "en");
+                    }
+                } else {
+                    reL10NComment.lastIndex = 0;
+                    match = reL10NComment.exec(node.value);
+                    if (match) {
+                        this._addComment(match[1].trim());
+                    }
                 }
                 // ignore HTML comments
                 break;
@@ -804,6 +834,13 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 } else {
                     message.pop();
                 }
+
+                if (node.url) {
+                    node.url = this._localizeString(node.url, locale, translations);
+                }
+                if (node.title) {
+                    node.title = this._localizeString(node.title, locale, translations);
+                }
             }
             break;
 
@@ -1023,7 +1060,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
             }
             end = i;
         } else if (start > -1) {
-            if (isTranslatable(ma.getMinimalString())) {
+            if (this.isTranslatable(ma.getMinimalString())) {
                 var nodes = this._getTranslationNodes(locale, translations, ma);
                 if (nodes) {
                     // replace the source nodes with the translation nodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3053,8 +3053,8 @@ module.exports.markdown = {
         test.equal(resources.length, 3);
 
         test.equal(resources[0].getSource(), "Regular service will be <c0>available</c0>.");
-        test.equal(resources[1].getSource(), "link title");
-        test.equal(resources[2].getSource(), "http://a.com/");
+        test.equal(resources[1].getSource(), "http://a.com/");
+        test.equal(resources[2].getSource(), "link title");
 
         test.done();
     },

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -798,6 +798,42 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseTurnOnURLOnlyLinks: function(test) {
+        test.expect(12);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'Here are some links:\n\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '* [http://www.box.com/foobar](http://www.box.com/foobar)\n' +
+            '* [http://www.box.com/asdf](http://www.box.com/asdf)\n' +
+            '<!-- i18n-disable localize-links -->\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 3);
+
+        var r = set.getBySource("Here are some links:");
+        test.ok(r);
+        test.equal(r.getSource(), "Here are some links:");
+        test.equal(r.getKey(), "r539503678");
+
+        // the URLs should be extracted because we turned on link localization
+        r = set.getBySource("http://www.box.com/foobar");
+        test.ok(r);
+        test.equal(r.getSource(), "http://www.box.com/foobar");
+        test.equal(r.getKey(), "r803907207");
+
+        r = set.getBySource("http://www.box.com/asdf");
+        test.ok(r);
+        test.equal(r.getSource(), "http://www.box.com/asdf");
+        test.equal(r.getKey(), "r247450278");
+
+        test.done();
+    },
+
     testMarkdownFileParseDoExtractURLLinksMidString: function(test) {
         test.expect(5);
 
@@ -1206,7 +1242,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileParseLocalizableTitleSingleQuotes: function(test) {
+    testMarkdownFileParseLocalizableTitleWithSingleQuotes: function(test) {
         test.expect(8);
 
         var mf = new MarkdownFile(p);
@@ -1761,6 +1797,59 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
             'Ceci est un test du système d\'analyse syntaxique [Reponse1][R1] de l\'urgence [teste][C1].\n\n[C1]: https://www.box.com/test1\n\n[R1]: http://www.box.com/about.html\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithMultipleLocalizableLinkReferences: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency [C1] parsing system [R1].\n\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[C1]: https://www.box.com/test1\n' +
+            '[R1]: http://www.box.com/about.html\n' +
+            '<!-- i18n-disable localize-links -->\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r817759238",
+            source: "This is a test of the emergency <c0>C1</c0> parsing system <c1>R1</c1>.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique <c1>Reponse1</c1> de l'urgence <c0>teste</c0>.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r647537837",
+            source: "https://www.box.com/test1",
+            sourceLocale: "en-US",
+            target: "https://www.box.com/fr/test1",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r448858983",
+            source: "http://www.box.com/about.html",
+            sourceLocale: "en-US",
+            target: "http://www.box.com/fr/about.html",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique [Reponse1][R1] de l\'urgence [teste][C1].\n\n' +
+            '<!-- i18n-enable localize-links -->\n\n' +
+            '[C1]: https://www.box.com/fr/test1\n\n' +
+            '[R1]: http://www.box.com/fr/about.html\n\n' +
+            '<!-- i18n-disable localize-links -->\n');
 
         test.done();
     },
@@ -2907,6 +2996,101 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseWithLinkReferenceToExtractedURL: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '- [Ask on Facebook][facebook]: For general questions and support.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n' +
+            '[facebook]: http://www.facebook.com/OurPlatform\n' +
+            '<!-- i18n-disable localize-links -->'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 4);
+
+        test.equal(resources[0].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
+        test.equal(resources[1].getSource(), "<c0>Ask on Facebook</c0>: For general questions and support.");
+        test.equal(resources[2].getSource(), "https://twitter.com/OurPlatform");
+        test.equal(resources[3].getSource(), "http://www.facebook.com/OurPlatform");
+
+        test.done();
+    },
+
+    testMarkdownFileParseWithLinkReferenceWithLinkTitle: function(test) {
+        test.expect(7);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'Regular service will be [available][exception].\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[exception]: http://a.com/ "link title"\n' +
+            '<!-- i18n-disable localize-links -->'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 3);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 3);
+
+        test.equal(resources[0].getSource(), "Regular service will be <c0>available</c0>.");
+        test.equal(resources[1].getSource(), "link title");
+        test.equal(resources[2].getSource(), "http://a.com/");
+
+        test.done();
+    },
+
+    testMarkdownFileParseWithLinkReferenceToExtractedURLNotAfterTurnedOff: function(test) {
+        test.expect(7);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '- [Ask on Facebook][facebook]: For general questions and support.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n' +
+            '<!-- i18n-disable localize-links -->' +
+            '[facebook]: http://www.facebook.com/OurPlatform\n'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 3);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 3);
+
+        test.equal(resources[0].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
+        test.equal(resources[1].getSource(), "<c0>Ask on Facebook</c0>: For general questions and support.");
+        test.equal(resources[2].getSource(), "https://twitter.com/OurPlatform");
+
+        test.done();
+    },
+
     testMarkdownFileParseWithMultipleLinkReferenceWithText: function(test) {
         test.expect(8);
 
@@ -2942,7 +3126,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileLocalizeReferenceLinksWithTitle: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithLinkId: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile(p);
@@ -2991,7 +3175,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileLocalizeReferenceLinksWithoutTitle: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithoutLinkId: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile(p);
@@ -3034,6 +3218,75 @@ module.exports.markdown = {
             '* [Auf Twitter stellen][Ask on Twitter] für allgemeine Fragen und Unterstützung.\n' +
             '\n' +
             '[Ask on Twitter]: https://twitter.com/OurPlatform\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeReferenceLinksWithLinkTitle: function(test) {
+        test.expect(3);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter][twitter] For general questions and support.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[twitter]: https://twitter.com/OurPlatform "Our Platform"\n' +
+            '<!-- i18n-disable localize-links -->\n'
+        );
+        test.ok(mf);
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r816306377',
+            source: 'For developer support, please reach out to us via one of our channels:',
+            target: 'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r1030328207',
+            source: '<c0>Ask on Twitter</c0> For general questions and support.',
+            target: '<c0>Auf Twitter stellen</c0> für allgemeine Fragen und Unterstützung.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r85880207',
+            source: 'https://twitter.com/OurPlatform',
+            target: 'https://de.twitter.com/OurPlatform',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r504251007',
+            source: 'Our Platform',
+            target: 'Unsere Platformen',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
+            '\n' +
+            '* [Auf Twitter stellen][twitter] für allgemeine Fragen und Unterstützung.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n\n' +
+            '[twitter]: https://de.twitter.com/OurPlatform "Unsere Platformen"\n\n' +
+            '<!-- i18n-disable localize-links -->\n';
 
         diff(actual, expected);
         test.equal(actual, expected);


### PR DESCRIPTION
By default, URLs are not localizable, as the majority are the same
in all languages. Sometimes, however you want to be able to give a
different URL for each locale. With this new features, you can turn
on link localization.

To localize a link in the text, put a localize-links directive around
it, which is an lint-style HTML comment. Example:

```markdown
There are
<!-- i18n-enable localize-links -->
[fifty](http://www.example.com/)
<!-- i18n-disable localize-links -->
of them for sale.
```

The text "fifty" is localized along with the rest of the sentence in the
string:

```
There are <c0>fifty</c0> of them for sale.
```

Note the c0 tags denote where the link goes. The directives, being HTML
comments, are not included in the string to translate.

The URL itself appears as a separate string to translate.

Localizing a link reference is very similar. Surround the reference
definition with a localize-links directive:

```markdown
There are [fifty][url] of them for sale.

<!-- i18n-enable localize-links -->
[url]: http://www.example.com/ "link title"
<!-- i18n-disable localize-links -->
```

The link title for link reference definitions is included as a separate string
to translate.