### PR TITLE
Fixed to include locale when creating cleanHashKey in ContextResourceString

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,9 @@ New Features:
 * Added the -s or --silent flag which never prints anything. Instead, it only sets the exit code.
   This is intended to be used in scripts where all the verbose output is not needed.
 
+Bug Fixes:
+* Fixed to include locale when creating cleanHashKey in ContextResourceString
+
 Build 009
 -------
 

--- a/lib/ContextResourceString.js
+++ b/lib/ContextResourceString.js
@@ -116,7 +116,8 @@ ContextResourceString.cleanHashKey = function(project, context, locale, reskey, 
  *  @return {String} a unique hash key for this resource, but cleaned
  */
 ContextResourceString.prototype.cleanHashKey = function() {
-    return ContextResourceString.cleanHashKey(this.project, this.context, this.locale, this.reskey, this.datatype, this.flavor);
+    var locale = this.targetLocale || this.sourceLocale;
+    return ContextResourceString.cleanHashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor);
 };
 
 /**

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1035,7 +1035,7 @@ module.exports.resourcestring = {
         test.done();
     },
 
-    testContextResourceStringCkeanHashKey: function(test) {
+    testContextResourceStringCleanHashKey: function(test) {
         test.expect(2);
 
         var rs = new ContextResourceString({

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1035,6 +1035,25 @@ module.exports.resourcestring = {
         test.done();
     },
 
+    testContextResourceStringCkeanHashKey: function(test) {
+        test.expect(2);
+
+        var rs = new ContextResourceString({
+            project: "custom-app",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            locale: "de-DE",
+            pathName: "a/b/c.js",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+
+        test.equal(rs.cleanHashKey(), "crs_custom-app_foobar_de-DE_This is a test_x-qml_");
+
+        test.done();
+    },
+
     testContextResourceStringSourceOnlyHashKey: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
Fixed to include locale when creating `cleanHashKey` in ContextResourceString. Without this, Loctool can't find the translation correctly. 