### PR TITLE
Add --localizeOnly flag which generate a localization resource only

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,7 +10,7 @@ New Features:
 * Added the -q or --quiet flag which only prints out banners, errors, and warnings
 * Added the -s or --silent flag which never prints anything. Instead, it only sets the exit code.
   This is intended to be used in scripts where all the verbose output is not needed.
-* Added the --no-xliffsOut flag which not to generate xliff files for extracted strings from files.
+* Added the --localizeOnly flag which Generate a localization resource only. Do not create any other files at all after running loctool.
 
 Bug Fixes:
 * Fixed to include locale when creating cleanHashKey in ContextResourceString

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ New Features:
 * Added the -q or --quiet flag which only prints out banners, errors, and warnings
 * Added the -s or --silent flag which never prints anything. Instead, it only sets the exit code.
   This is intended to be used in scripts where all the verbose output is not needed.
+* Added the --no-xliffsOut flag which not to generate xliff files for extracted strings from files.
 
 Bug Fixes:
 * Fixed to include locale when creating cleanHashKey in ContextResourceString

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -89,8 +89,8 @@ var Project = function(options, root, settings) {
     // where the xliff files are written to
     this.xliffsOut = (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || this.root;
 
-    // Do not generate xliff files for extracted strings
-    this.noxliffsOut = (options.settings && options.settings.noxliffsOut) || this.settings.noxliffsOut;
+    // generate a localization resource only. not create any other files after running loctool
+    this.localizeOnly = (options.settings && options.settings.localizeOnly) || this.settings.localizeOnly;
 
     // all translations in the db
     this.translations = new TranslationSet(this.sourceLocale);
@@ -459,7 +459,7 @@ Project.prototype.close = function(cb) {
     // before we recurse and allocate a lot more memory.
     this.files = undefined;
 
-    if(!this.noxliffsOut) {
+    if(!this.localizeOnly) {
         var dir = this.xliffsOut;
         var base = this.options.id;
         var extractedPath = path.join(dir, base + "-extracted.xliff");

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -89,6 +89,9 @@ var Project = function(options, root, settings) {
     // where the xliff files are written to
     this.xliffsOut = (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || this.root;
 
+    // Do not generate xliff files for extracted strings
+    this.noXliffsOut = (options.settings && options.settings.noXliffsOut) || this.settings.noXliffsOut;
+
     // all translations in the db
     this.translations = new TranslationSet(this.sourceLocale);
 
@@ -456,88 +459,89 @@ Project.prototype.close = function(cb) {
     // before we recurse and allocate a lot more memory.
     this.files = undefined;
 
-    var dir = this.xliffsOut;
-    var base = this.options.id;
-    var extractedPath = path.join(dir, base + "-extracted.xliff");
-    var extracted = new TranslationSet(this.sourceLocale);
+    if(!this.noXliffsOut) {
+        var dir = this.xliffsOut;
+        var base = this.options.id;
+        var extractedPath = path.join(dir, base + "-extracted.xliff");
+        var extracted = new TranslationSet(this.sourceLocale);
 
-    for (var i = 0; i < this.fileTypes.length; i++) {
-        logger.trace("Collecting extracted strings from " + this.fileTypes[i].name());
-        extracted.addAll(this.fileTypes[i].getExtracted().getBy({
-            sourceLocale: this.sourceLocale
-        }));
+        for (var i = 0; i < this.fileTypes.length; i++) {
+            logger.trace("Collecting extracted strings from " + this.fileTypes[i].name());
+            extracted.addAll(this.fileTypes[i].getExtracted().getBy({
+                sourceLocale: this.sourceLocale
+            }));
 
-        if (this.fileTypes[i].modern && this.fileTypes[i].modern.size() > 0) {
-            var modernPath = path.join(dir, base + "-modern.xliff");
-            logger.info("Writing out the modern translation strings to " + modernPath);
-            var modernXliff = new Xliff({
-                pathName: modernPath,
-                version: this.settings.xliffVersion
-            });
-            modernXliff.addSet(this.fileTypes[i].modern);
-            fs.writeFileSync(modernPath, modernXliff.serialize(true), "utf-8");
-        }
-    }
-
-    // calculate only the new strings and save them to the db
-    var newres = this.newres;
-
-    logger.trace("translations is size " + this.translations.size());
-    logger.trace("extracted is size " + extracted.size());
-    logger.trace("newres is size " + newres.size());
-    /*
-    this.db.addAll(newres, function() {
-        this.db.close(function() {
-            cb();
-        });
-    }.bind(this));
-    */
-
-    logger.info("Writing out the extracted strings to " + extractedPath);
-    var extractedXliff = new Xliff({
-        pathName: extractedPath,
-        allowDups: true,
-        version: this.settings.xliffVersion
-    });
-    extractedXliff.addSet(extracted);
-    fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");
-
-    var newLocales = newres.getLocales();
-
-    if (newLocales && newLocales.length) {
-        for (var i = 0; i < newLocales.length; i++) {
-            var locale = newLocales[i];
-            if (!this.isSourceLocale(locale) && !PseudoFactory.isPseudoLocale(locale)) {
-                var newPath = path.join(dir, base + "-new-" + locale + ".xliff");
-                var resources = newres.getAll().filter(function(res) {
-                    return res.getTargetLocale() === locale && !res.dnt;
+            if (this.fileTypes[i].modern && this.fileTypes[i].modern.size() > 0) {
+                var modernPath = path.join(dir, base + "-modern.xliff");
+                logger.info("Writing out the modern translation strings to " + modernPath);
+                var modernXliff = new Xliff({
+                    pathName: modernPath,
+                    version: this.settings.xliffVersion
                 });
+                modernXliff.addSet(this.fileTypes[i].modern);
+                fs.writeFileSync(modernPath, modernXliff.serialize(true), "utf-8");
+            }
+        }
 
-                if (resources && resources.length) {
-                    logger.info("Writing out the new strings to " + newPath);
-                    var newXliff = new Xliff({
-                        project: this.name,
-                        pathName: newPath,
-                        sourceLocale: this.sourceLocale,
-                        version: this.settings.xliffVersion
+        // calculate only the new strings and save them to the db
+        var newres = this.newres;
+
+        logger.trace("translations is size " + this.translations.size());
+        logger.trace("extracted is size " + extracted.size());
+        logger.trace("newres is size " + newres.size());
+        /*
+        this.db.addAll(newres, function() {
+            this.db.close(function() {
+                cb();
+            });
+        }.bind(this));
+        */
+
+        logger.info("Writing out the extracted strings to " + extractedPath);
+        var extractedXliff = new Xliff({
+            pathName: extractedPath,
+            allowDups: true,
+            version: this.settings.xliffVersion
+        });
+        extractedXliff.addSet(extracted);
+        fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");
+
+        var newLocales = newres.getLocales();
+
+        if (newLocales && newLocales.length) {
+            for (var i = 0; i < newLocales.length; i++) {
+                var locale = newLocales[i];
+                if (!this.isSourceLocale(locale) && !PseudoFactory.isPseudoLocale(locale)) {
+                    var newPath = path.join(dir, base + "-new-" + locale + ".xliff");
+                    var resources = newres.getAll().filter(function(res) {
+                        return res.getTargetLocale() === locale && !res.dnt;
                     });
 
-                    resources.forEach(function(res) {
-                        newXliff.addResource(res);
-                    });
+                    if (resources && resources.length) {
+                        logger.info("Writing out the new strings to " + newPath);
+                        var newXliff = new Xliff({
+                            project: this.name,
+                            pathName: newPath,
+                            sourceLocale: this.sourceLocale,
+                            version: this.settings.xliffVersion
+                        });
 
-                    fs.writeFileSync(newPath, newXliff.serialize(true), "utf-8");
-                } else {
-                    if (fs.existsSync(newPath)) {
-                        fs.unlinkSync(newPath);
+                        resources.forEach(function(res) {
+                            newXliff.addResource(res);
+                        });
+
+                        fs.writeFileSync(newPath, newXliff.serialize(true), "utf-8");
+                    } else {
+                        if (fs.existsSync(newPath)) {
+                            fs.unlinkSync(newPath);
+                        }
                     }
                 }
             }
+        } else {
+            logger.info("No new strings in this run.");
         }
-    } else {
-        logger.info("No new strings in this run.");
     }
-
     // now call the plugins in case they need to do anything else
     for (var i = 0; i < this.fileTypes.length; i++) {
         if (typeof(this.fileTypes[i].projectClose) === "function") {

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -90,7 +90,7 @@ var Project = function(options, root, settings) {
     this.xliffsOut = (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || this.root;
 
     // Do not generate xliff files for extracted strings
-    this.noXliffsOut = (options.settings && options.settings.noXliffsOut) || this.settings.noXliffsOut;
+    this.noxliffsOut = (options.settings && options.settings.noxliffsOut) || this.settings.noxliffsOut;
 
     // all translations in the db
     this.translations = new TranslationSet(this.sourceLocale);
@@ -459,7 +459,7 @@ Project.prototype.close = function(cb) {
     // before we recurse and allocate a lot more memory.
     this.files = undefined;
 
-    if(!this.noXliffsOut) {
+    if(!this.noxliffsOut) {
         var dir = this.xliffsOut;
         var base = this.options.id;
         var extractedPath = path.join(dir, base + "-extracted.xliff");

--- a/loctool.js
+++ b/loctool.js
@@ -83,8 +83,8 @@ function usage() {
         "  Print the current loctool version and exit\n" +
         "-x or --xliffs\n" +
         "  Specify the dir where the xliffs files live. Default: \".\"\n" +
-        "--no-xliffsOut\n" +
-        "  Do not generate xliff files for extracted strings from files. (Default is generate xliff files) \n" +
+        "--localizeOnly\n" +
+        "  Generate a localization resource only. Do not create any other files at all after running loctool. \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    localize [root-dir-name] - extract strings and generate localized resource\n" +
@@ -120,7 +120,7 @@ var settings = {
     targetDir: ".",            // target directory for all output files
     xliffsDir: ".",
     xliffVersion: 1.2,
-    noxliffsOut: false
+    localizeOnly: false
 };
 
 var options = [];
@@ -178,8 +178,8 @@ for (var i = 0; i < argv.length; i++) {
             console.error("Error: -z (--xliffsOut) option requires a directory name argument to follow it.");
             usage();
         }
-    } else if (val === "--no-xliffsOut") {
-        settings.noxliffsOut = true;
+    } else if (val === "--localizeOnly") {
+        settings.localizeOnly = true;
     }
     else {
         options.push(val);

--- a/loctool.js
+++ b/loctool.js
@@ -120,7 +120,7 @@ var settings = {
     targetDir: ".",            // target directory for all output files
     xliffsDir: ".",
     xliffVersion: 1.2,
-    noXliffsOut: false
+    noxliffsOut: false
 };
 
 var options = [];
@@ -179,7 +179,7 @@ for (var i = 0; i < argv.length; i++) {
             usage();
         }
     } else if (val === "--no-xliffsOut") {
-        settings.noXliffsOut = true;
+        settings.noxliffsOut = true;
     }
     else {
         options.push(val);

--- a/loctool.js
+++ b/loctool.js
@@ -83,6 +83,8 @@ function usage() {
         "  Print the current loctool version and exit\n" +
         "-x or --xliffs\n" +
         "  Specify the dir where the xliffs files live. Default: \".\"\n" +
+        "--no-xliffsOut\n" +
+        "  Do not generate xliff files for extracted strings from files. (Default is generate xliff files) \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    localize [root-dir-name] - extract strings and generate localized resource\n" +
@@ -117,7 +119,8 @@ var settings = {
     nopseudo: true,
     targetDir: ".",            // target directory for all output files
     xliffsDir: ".",
-    xliffVersion: 1.2
+    xliffVersion: 1.2,
+    noXliffsOut: false
 };
 
 var options = [];
@@ -175,7 +178,10 @@ for (var i = 0; i < argv.length; i++) {
             console.error("Error: -z (--xliffsOut) option requires a directory name argument to follow it.");
             usage();
         }
-    } else {
+    } else if (val === "--no-xliffsOut") {
+        settings.noXliffsOut = true;
+    }
+    else {
         options.push(val);
     }
 }


### PR DESCRIPTION
I've added the `--no-xliffsOut` flag which not to generate xliff files for extracted strings from files.
(not sure if it's appropriate to name. If you have another name suggestion, please let me know)
I think it's ok to provide an option. as a product perspective, Getting a resource is enough. It'  would be useful for the localization manager.
