### PR TITLE
Update to handle multiple pseudo locale list

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,10 @@ New Features:
 * Added the -s or --silent flag which never prints anything. Instead, it only sets the exit code.
   This is intended to be used in scripts where all the verbose output is not needed.
 * Added the --localizeOnly flag which Generate a localization resource only. Do not create any other files at all after running loctool.
+* Added support to handle multiple pseudo locales. If you want to use more than one pseudo locale, you have put list to an array. Example:
+  ```
+  pseudoLocale: ["zxx-XX", "zxx-Hans-XX", "zxx-Hebr-XX"]
+  ```
 
 Bug Fixes:
 * Fixed to include locale when creating cleanHashKey in ContextResourceString

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,7 +11,7 @@ New Features:
 * Added the -s or --silent flag which never prints anything. Instead, it only sets the exit code.
   This is intended to be used in scripts where all the verbose output is not needed.
 * Added the --localizeOnly flag which Generate a localization resource only. Do not create any other files at all after running loctool.
-* Added support to handle multiple pseudo locales. If you want to use more than one pseudo locale, you have put list to an array. Example:
+* Added support to handle multiple pseudo locales. If you want to use more than one pseudo locale, you have to put the locales in an array. Example:
   ```
   pseudoLocale: ["zxx-XX", "zxx-Hans-XX", "zxx-Hebr-XX"]
   ```

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -193,6 +193,17 @@ var PseudoFactory = function(options) {
 
     // regular pseudo-localization
     //var pseudoLocale = new Locale(options.project.pseudoLocale);
+    if ((targetLocale.getLanguage() !== "zxx") && !options.project.settings.nopseudo) {
+        logger.trace('Regular pseudo for locale ' + options.targetLocale);
+        return new RegularPseudo({
+            set: options.set,
+            type: options.type,
+            sourceLocale: sourceLocale.getSpec(),
+            targetLocale: options.targetLocale
+        });
+    }
+
+    // regular pseudo-localization for zxx-XX, zxx-Hans-XX, zxx-Hebr-XX, zxx-Cyrl-XX)
     if (targetLocale.getLanguage() === "zxx" && !options.project.settings.nopseudo) {
         logger.trace('Regular pseudo for locale ' + options.targetLocale);
         return new RegularPseudo({

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -192,19 +192,10 @@ var PseudoFactory = function(options) {
     }
 
     // regular pseudo-localization
-    //var pseudoLocale = new Locale(options.project.pseudoLocale);
-    if ((targetLocale.getLanguage() !== "zxx") && !options.project.settings.nopseudo) {
-        logger.trace('Regular pseudo for locale ' + options.targetLocale);
-        return new RegularPseudo({
-            set: options.set,
-            type: options.type,
-            sourceLocale: sourceLocale.getSpec(),
-            targetLocale: options.targetLocale
-        });
-    }
-
-    // regular pseudo-localization for zxx-XX, zxx-Hans-XX, zxx-Hebr-XX, zxx-Cyrl-XX)
-    if (targetLocale.getLanguage() === "zxx" && !options.project.settings.nopseudo) {
+    pseudoLocales = (typeof options.project.pseudoLocale === "string") ? [options.project.pseudoLocale] : options.project.pseudoLocale
+    if (targetLocale.getSpec() !== "" &&
+       (pseudoLocales.indexOf(targetLocale.getSpec()) !== -1 || options.targetLocale.indexOf(pseudoLocales[0]) !== -1)
+        && !options.project.settings.nopseudo) {
         logger.trace('Regular pseudo for locale ' + options.targetLocale);
         return new RegularPseudo({
             set: options.set,

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -192,8 +192,8 @@ var PseudoFactory = function(options) {
     }
 
     // regular pseudo-localization
-    var pseudoLocale = new Locale(options.project.pseudoLocale);
-    if (targetLocale.getLanguage() === pseudoLocale.getLanguage() &&  targetLocale.getRegion() === pseudoLocale.getRegion() && !options.project.settings.nopseudo) {
+    //var pseudoLocale = new Locale(options.project.pseudoLocale);
+    if (targetLocale.getLanguage() === "zxx" && !options.project.settings.nopseudo) {
         logger.trace('Regular pseudo for locale ' + options.targetLocale);
         return new RegularPseudo({
             set: options.set,

--- a/lib/RegularPseudo.js
+++ b/lib/RegularPseudo.js
@@ -42,8 +42,8 @@ var RegularPseudo = function(options) {
     // zxx is the language "unspecified" and XX is the region "unknown", which
     // ilib uses for pseudo localization
     this.pseudoBundle = new ResBundle({
-        type: options.type || "text",
-        locale: options.targetLocale || "zxx-XX",
+        type: (options && options.type) || "text",
+        locale: (options && options.targetLocale) || "zxx-XX",
         lengthen: true
     });
 };

--- a/lib/RegularPseudo.js
+++ b/lib/RegularPseudo.js
@@ -43,7 +43,7 @@ var RegularPseudo = function(options) {
     // ilib uses for pseudo localization
     this.pseudoBundle = new ResBundle({
         type: options.type || "text",
-        locale: "zxx-XX",
+        locale: options.targetLocale || "zxx-XX",
         lengthen: true
     });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
         {
             "name": "Edwin Hoogerbeets",
             "email": "edwin.hoogerbeets@healthtap.com"
+        },
+        {
+            "name": "Goun Lee",
+            "email": "goun.lee@lge.com"
         }
     ],
     "files": [

--- a/test/testPseudoFactory.js
+++ b/test/testPseudoFactory.js
@@ -35,6 +35,26 @@ var project = new WebProject({
     locales: ["en-GB", "en-NZ", "es-US"]
 });
 
+var project2 = new WebProject({
+    sourceLocale: "en-US",
+    pseudoLocale: "zxx-XX",
+    resourceDirs: {
+        "yml": "config/locales"
+    }
+}, "./testfiles", {
+    locales: ["en-GB", "en-NZ", "es-US"]
+});
+
+var project3 = new WebProject({
+    sourceLocale: "en-US",
+    pseudoLocale: ["zxx-XX", "zxx-Hans-XX"],
+    resourceDirs: {
+        "yml": "config/locales"
+    }
+}, "./testfiles", {
+    locales: ["en-GB", "en-NZ", "es-US"]
+});
+
 module.exports.pseudofactory = {
     testPseudoFactoryBritishEnglish: function(test) {
         test.expect(2);
@@ -286,6 +306,45 @@ module.exports.pseudofactory = {
         });
         test.ok(pseudo);
         test.equal(pseudo.getSourceLocale(), "en-US-ASDF");
+
+        test.done();
+    },
+    testPseudoFactoryNormalzxx: function(test) {
+        test.expect(2);
+
+        var pseudo = PseudoFactory({
+            project: project2,
+            targetLocale: "zxx-XX",
+            type: "text"
+        });
+        test.ok(pseudo);
+        test.ok(pseudo instanceof RegularPseudo);
+
+        test.done();
+    },
+    testPseudoFactoryNormalzxx2: function(test) {
+        test.expect(2);
+
+        var pseudo = PseudoFactory({
+            project: project3,
+            targetLocale: "zxx-Hans-XX",
+            type: "text"
+        });
+        test.ok(pseudo);
+        test.ok(pseudo instanceof RegularPseudo);
+
+        test.done();
+    },
+    testPseudoFactoryNormalzxx3: function(test) {
+        test.expect(2);
+
+        var pseudo = PseudoFactory({
+            project: project3,
+            targetLocale: "zxx-XX-ASDF",
+            type: "text"
+        });
+        test.ok(pseudo);
+        test.ok(pseudo instanceof RegularPseudo);
 
         test.done();
     },


### PR DESCRIPTION
Loctool could handle multiple pseudo locale list,
Currently, it handles one locale which is expected a string type.
```
/// project.json
pseudoLocale: "ps-DO"
```
I modified codes to support multiple pseudo locale lists while supporting the current operation too. 
It works fine from below form too.
```
/// project.json
pseudoLocale: ["zxx-XX", zxx-Hans-XX", "zxx-Cyrl-XX"]