### PR TITLE
Added a new SourceContextResourceString for qml strings

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,6 +15,7 @@ New Features:
   ```
   pseudoLocale: ["zxx-XX", "zxx-Hans-XX", "zxx-Hebr-XX"]
   ```
+* Added `SourceContextResourceString` that is for strings in qml files. The hash key made with this,  that it includes additionally the hash value of the source. That is a difference from ContextResourceString.
 
 Bug Fixes:
 * Fixed to include locale when creating cleanHashKey in ContextResourceString

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ New Features:
   ```
   pseudoLocale: ["zxx-XX", "zxx-Hans-XX", "zxx-Hebr-XX"]
   ```
-* Added `SourceContextResourceString` that is for strings in qml files. The hash key made with this,  that it includes additionally the hash value of the source. That is a difference from ContextResourceString.
+* Added `SourceContextResourceString` that is for strings in qml files. The hash key made with this, that it includes additionally the hash value of the source. That is a difference from ContextResourceString.
 
 Bug Fixes:
 * Fixed to include locale when creating cleanHashKey in ContextResourceString

--- a/lib/ResourceFactory.js
+++ b/lib/ResourceFactory.js
@@ -25,6 +25,7 @@ var ResourceArray = require("./ResourceArray.js");
 var ResourcePlural = require("./ResourcePlural.js");
 var ResourceString = require("./ResourceString.js");
 var ContextResourceString = require("./ContextResourceString.js");
+var SourceContextResourceString = require("./SourceContextResourceString.js");
 var IosLayoutResourceString = require("./IosLayoutResourceString.js");
 
 var logger = log4js.getLogger("loctool.lib.ResourceFactory");
@@ -42,6 +43,7 @@ var knownResourceClasses = {
     "ResourceArray": ResourceArray,
     "ResourcePlural": ResourcePlural,
     "ContextResourceString": ContextResourceString,
+    "SourceContextResourceString": SourceContextResourceString,
     "IosLayoutResourceString": IosLayoutResourceString,
 };
 

--- a/lib/SourceContextResourceString.js
+++ b/lib/SourceContextResourceString.js
@@ -1,5 +1,5 @@
 /*
- * SourceSourceContextResourceString.js - represents an string in a qml file
+ * SourceContextResourceString.js - represents an string in a qml file
  *
  * Copyright © 2020, JEDLSoft
  *

--- a/lib/SourceContextResourceString.js
+++ b/lib/SourceContextResourceString.js
@@ -1,0 +1,153 @@
+/*
+ * SourceSourceContextResourceString.js - represents an string in a qml file
+ *
+ * Copyright © 2020, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var log4js = require("log4js");
+
+var ResourceString = require("./ResourceString.js");
+var utils = require("./utils.js");
+var logger = log4js.getLogger("loctool.lib.SourceSourceContextResourceString");
+
+/**
+ * @class Represents a string resource extracted from an Android resource
+ * or layout file. The props may contain any
+ * of properties from the Resource constructor and additionally,
+ * these properties:
+ *
+ * <ul>
+ * <li>source {String} - the source string associated with this key
+ * </ul>
+ *
+ * @constructor
+ * @extends ResourceString
+ * @param {Object} props properties of the string, as defined above
+ */
+var SourceContextResourceString = function(props) {
+    ResourceString.prototype.constructor.call(this, props);
+};
+
+SourceContextResourceString.prototype = new ResourceString();
+SourceContextResourceString.prototype.parent = ResourceString;
+SourceContextResourceString.prototype.constructor = ResourceString;
+
+/**
+ * The class of this kind of string resource.
+ *
+ * @static
+ * @const
+ */
+SourceContextResourceString.resClass = "string";
+
+/**
+ * Calculate a resource key string for this class of resource given the
+ * parameters.
+ *
+ * @param {String} project the project of the string
+ * @param {String} context the context of the string
+ * @param {String} locale the locale of the string
+ * @param {String} reskey the key of the string
+ * @param {String} datatype the datatype of the string
+ * @param {String} flavor the flavor of the app that contains this string
+ * @param {String} sourcehash the hash value of the source string
+ * @static
+ * @return {String} a hash key
+ */
+SourceContextResourceString.hashKey = function(project, context, locale, reskey, datatype, flavor, sourcehash) {
+    var key = ["scrs", project, context, locale, reskey, datatype, flavor, sourcehash].join("_");
+    logger.trace("Hashkey is " + key);
+    return key;
+};
+
+/**
+ * Return the a hash key that uniquely identifies this resource.
+ *
+ *  @return {String} a unique hash key for this resource
+ */
+SourceContextResourceString.prototype.hashKey = function() {
+    var locale = this.targetLocale || this.sourceLocale;
+    this.sourcehash = utils.hashKey(this.source);
+    return SourceContextResourceString.hashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor, this.sourcehash);
+};
+
+/**
+ * Return the a hash key that uniquely identifies the translation of
+ * this resource to the given locale.
+ *
+ * @param {String} locale a locale spec of the desired translation
+ * @return {String} a unique hash key for this resource
+ */
+SourceContextResourceString.prototype.hashKeyForTranslation = function(locale) {
+    return SourceContextResourceString.hashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor, this.sourcehash);
+};
+
+/**
+ * Calculate a resource key string for this class of resource given the
+ * parameters.
+ *
+ * @param {String} project the project of the string
+ * @param {String} locale the locale of the string
+ * @param {String} reskey the key of the string
+ * @param {String} datatype the datatype of the string
+ * @static
+ * @return {String} a hash key
+ */
+SourceContextResourceString.cleanHashKey = function(project, context, locale, reskey, datatype, flavor, sourcehash) {
+    // reskey does not need cleaning for context strings
+    return SourceContextResourceString.hashKey(project, context, locale, reskey, datatype, flavor, sourcehash);
+};
+
+/**
+ * Return the a hash key that uniquely identifies this resource, but cleaned
+ *
+ *  @return {String} a unique hash key for this resource, but cleaned
+ */
+SourceContextResourceString.prototype.cleanHashKey = function() {
+    var locale = this.targetLocale || this.sourceLocale;
+    this.sourcehash = utils.hashKey(this.source);
+    return SourceContextResourceString.cleanHashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor, this.sourcehash);
+};
+
+/**
+ * Return the a hash key that uniquely identifies the translation of
+ * this resource to the given locale, but cleaned
+ *
+ * @param {String} locale a locale spec of the desired translation
+ * @return {String} a unique hash key for this resource's string
+ */
+SourceContextResourceString.prototype.cleanHashKeyForTranslation = function(locale) {
+    return SourceContextResourceString.cleanHashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor, this.sourcehash);
+};
+
+/**
+ * Clone this resource and override the properties with the given ones.
+ *
+ * @params {Object|undefined} overrides optional properties to override in
+ * the cloned object
+ * @returns {SourceContextResourceString} a clone of this resource
+ */
+SourceContextResourceString.prototype.clone = function(overrides) {
+    var r = new SourceContextResourceString(this);
+    if (overrides) {
+        for (var p in overrides) {
+            r[p] = overrides[p];
+        }
+    }
+    return r;
+};
+
+module.exports = SourceContextResourceString;

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1329,7 +1329,7 @@ module.exports.resourcestring = {
             key: "This is a test",
             source: "This is a test",
             locale: "de-DE",
-            pathName: "a/b/c.js",
+            pathName: "a.qml",
             datatype: "x-qml"
         });
         test.ok(rs);

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1247,7 +1247,7 @@ module.exports.resourcestring = {
     testSourceContextResourceStringStaticHashKey: function(test) {
         test.expect(1);
 
-        test.equal(SourceContextResourceString.hashKey("qmlapp", "foobar", "de-DE", "This is a test", "x-qml", "flavor"), "scrs_qmlapp_foobar_de-DE_This is a test_x-qml_flavor_");
+        test.equal(SourceContextResourceString.hashKey("qmlapp", "foobar", "de-DE", "This is a test", "x-qml", "flavor", "r12345678"), "scrs_qmlapp_foobar_de-DE_This is a test_x-qml_flavor_r12345678");
 
         test.done();
     },

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -20,6 +20,7 @@
 if (!ResourceString) {
     var ResourceString = require("../lib/ResourceString.js");
     var ContextResourceString = require("../lib/ContextResourceString.js");
+    var SourceContextResourceString = require("../lib/SourceContextResourceString.js");
     var IosLayoutResourceString = require("../lib/IosLayoutResourceString.js");
     var RegularPseudo = require("../lib/RegularPseudo.js");
     var PseudoFactory = require("../lib/PseudoFactory.js");
@@ -1240,6 +1241,119 @@ module.exports.resourcestring = {
         test.ok(dup);
 
         test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
+    testSourceContextResourceStringStaticHashKey: function(test) {
+        test.expect(1);
+
+        test.equal(SourceContextResourceString.hashKey("qmlapp", "foobar", "de-DE", "This is a test", "x-qml", "flavor"), "scrs_qmlapp_foobar_de-DE_This is a test_x-qml_flavor_");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringStaticHashKeyMissingParts: function(test) {
+        test.expect(1);
+
+        test.equal(SourceContextResourceString.hashKey(undefined, undefined, "de-DE", undefined, undefined, undefined, undefined), "scrs___de-DE____");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringHashKey: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Dies ist einen Test.",
+            targetLocale: "de-DE",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+
+        test.equal(rs.hashKey(), "scrs_qmlqpp_foobar_de-DE_This is a test_x-qml__r654479252");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringGetFlavor: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            locale: "de-DE",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml",
+            flavor: "a"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getFlavor(), "a");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringHashKeyWithFlavor: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            locale: "de-DE",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+
+        test.equal(rs.hashKey(), "scrs_qmlqpp_foobar_de-DE_This is a test_x-qml__r654479252");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringCleanHashKey: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "custom-app",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            locale: "de-DE",
+            pathName: "a/b/c.js",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+
+        test.equal(rs.cleanHashKey(), "scrs_custom-app_foobar_de-DE_This is a test_x-qml__r654479252");
+
+        test.done();
+    },
+
+    testSourceContextResourceStringSourceOnlyHashKey: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+
+        test.equal(rs.hashKey(), "scrs_qmlqpp_foobar_en-US_This is a test_x-qml__r654479252");
 
         test.done();
     },


### PR DESCRIPTION
Added a new Resource class `SourceContextResourceString` for strings in qml files. The hash key made with this, that it includes additionally the hash value of the source. That is a difference from ContextResourceString.

In qml files, The second parameter of qsTr is optional. https://doc.qt.io/qt-5/qml-qtqml-qt.html#qsTr-method). and loctool treated as alike key which it expected unique. not duplicated. But the second one of qsTr doesn't need to be unique. In order to meet the following example cases, I've defined a new resource class `SourceContextResourceString.`
```
qsTr("Maximum", "energy")
qsTr("Mimum", "energy")
```