### PR TITLE
Fix the localizeOnly flag to do the right thing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -495,6 +495,14 @@ limitations under the License.
 		<debug script="${build.test}/testPseudoCanadian.js" dir="${build.test}"/>
 	</target>
 
+    <target name="test.project" description="Run only the tests for the project object">
+        <run script="${build.test}/testProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.project" description="Debug only the tests for the project object">
+        <debug script="${build.test}/testProject.js" dir="${build.test}"/>
+    </target>
+
 	<target name="test.projectfactory" description="Run only the tests for the project factory object">
 		<run script="${build.test}/testProjectFactory.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
 	</target>
@@ -591,7 +599,7 @@ limitations under the License.
         <debug script="${build.test}/testResourceFactory.js" dir="${build.test}"/>
     </target>
 
-	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject">
+	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject,test.project">
 	</target>
 
 	<macrodef name="runsql">

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,8 +8,8 @@ Published as version 2.7.1
 
 Bug Fixes:
 * Fixed a bug where xliff files are trying to be created when there was no extracted string.
-* Fixed a bug where self-closed tags like <br/> in markdown files were not handled properly,
-causing exceptions that complained about syntax errors
+* Fixed a bug where the xliff files (extracted + new files) were never generated, even when
+localizeOnly is turned off
 
 Build 010
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,8 @@ Published as version 2.7.1
 
 Bug Fixes:
 * Fixed a bug where xliff files are trying to be created when there was no extracted string.
+* Fixed a bug where self-closed tags like <br/> in markdown files were not handled properly,
+causing exceptions that complained about syntax errors
 
 Build 010
 -------

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -458,12 +458,12 @@ Project.prototype.close = function(cb) {
     // signal to the GC that we don't need these any more
     // before we recurse and allocate a lot more memory.
     this.files = undefined;
-    var extracted = new TranslationSet(this.sourceLocale);
 
-    if(!this.localizeOnly && extracted.size()) {
+    if(!this.localizeOnly) {
         var dir = this.xliffsOut;
         var base = this.options.id;
         var extractedPath = path.join(dir, base + "-extracted.xliff");
+        var extracted = new TranslationSet(this.sourceLocale);
 
         for (var i = 0; i < this.fileTypes.length; i++) {
             logger.trace("Collecting extracted strings from " + this.fileTypes[i].name());
@@ -497,14 +497,18 @@ Project.prototype.close = function(cb) {
         }.bind(this));
         */
 
-        logger.info("Writing out the extracted strings to " + extractedPath);
-        var extractedXliff = new Xliff({
-            pathName: extractedPath,
-            allowDups: true,
-            version: this.settings.xliffVersion
-        });
-        extractedXliff.addSet(extracted);
-        fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");
+        if (extracted.size()) {
+            logger.info("Writing out the extracted strings to " + extractedPath);
+            var extractedXliff = new Xliff({
+                pathName: extractedPath,
+                allowDups: true,
+                version: this.settings.xliffVersion
+            });
+            extractedXliff.addSet(extracted);
+            fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");
+        } else {
+            logger.info("No strings extracted from this run.");
+        }
 
         var newLocales = newres.getLocales();
 

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -1,0 +1,127 @@
+/*
+ * testProject.js - test Project class
+ *
+ * Copyright © 2020, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs');
+
+if (!Project) {
+    var ProjectFactory = require("../lib/ProjectFactory.js");
+    var Project = require("../lib/Project.js");
+}
+
+function rmrf(path) {
+    if (fs.existsSync(path)) {
+        fs.unlinkSync(path);
+    }
+}
+
+module.exports.project = {
+    testProjectCreationAllEmpty: function(test){
+        test.expect(1);
+        var project = ProjectFactory('', {});
+        test.equals(project, undefined);
+        test.done();
+    },
+
+    testProjectGeneratesExtractedXliff: function(test){
+        test.expect(2);
+        // set up first
+        rmrf("./testfiles/loctest-extracted.xliff");
+
+        test.ok(!fs.existsSync("./testfiles/loctest-extracted.xliff"));
+
+        var project = ProjectFactory('./testfiles', {'locales': ['ja-JP']});
+        project.addPath("md/test1.md");
+        project.init(function() {
+            project.extract(function() {
+                project.generatePseudo();
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            test.ok(fs.existsSync("./testfiles/loctest-extracted.xliff"));
+                        });
+                    });
+                });
+            });
+        });
+        test.done();
+    },
+    
+    testProjectGeneratesNewStringsXliffs: function(test){
+        test.expect(6);
+        // set up first
+        rmrf("./testfiles/loctest-new-es-US.xliff");
+        rmrf("./testfiles/loctest-new-ja-JP.xliff");
+        rmrf("./testfiles/loctest-new-zh-Hans-CN.xliff");
+
+        test.ok(!fs.existsSync("./testfiles/loctest-new-es-US.xliff"));
+        test.ok(!fs.existsSync("./testfiles/loctest-new-ja-JP.xliff"));
+        test.ok(!fs.existsSync("./testfiles/loctest-new-zh-Hans-CN.xliff"));
+
+        var project = ProjectFactory('./testfiles', {'locales': ['ja-JP']});
+        project.addPath("md/test1.md");
+        project.init(function() {
+            project.extract(function() {
+                project.generatePseudo();
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            test.ok(fs.existsSync("./testfiles/loctest-new-es-US.xliff"));
+                            test.ok(fs.existsSync("./testfiles/loctest-new-ja-JP.xliff"));
+                            test.ok(fs.existsSync("./testfiles/loctest-new-zh-Hans-CN.xliff"));
+                        });
+                    });
+                });
+            });
+        });
+        test.done();
+    },
+
+    testProjectLocalizeOnlyGeneratesNoXliffs: function(test){
+        test.expect(8);
+        // set up first
+        rmrf("./testfiles/loctest-extracted.xliff");
+        rmrf("./testfiles/loctest-new-es-US.xliff");
+        rmrf("./testfiles/loctest-new-ja-JP.xliff");
+        rmrf("./testfiles/loctest-new-zh-Hans-CN.xliff");
+
+        test.ok(!fs.existsSync("./testfiles/loctest-extracted.xliff"));
+        test.ok(!fs.existsSync("./testfiles/loctest-new-es-US.xliff"));
+        test.ok(!fs.existsSync("./testfiles/loctest-new-ja-JP.xliff"));
+        test.ok(!fs.existsSync("./testfiles/loctest-new-zh-Hans-CN.xliff"));
+
+        var project = ProjectFactory('./testfiles', {'localizeOnly': true, 'locales': ['ja-JP']});
+        project.addPath("md/test1.md");
+        project.init(function() {
+            project.extract(function() {
+                project.generatePseudo();
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            test.ok(!fs.existsSync("./testfiles/loctest-extracted.xliff"));
+                            test.ok(!fs.existsSync("./testfiles/loctest-new-es-US.xliff"));
+                            test.ok(!fs.existsSync("./testfiles/loctest-new-ja-JP.xliff"));
+                            test.ok(!fs.existsSync("./testfiles/loctest-new-zh-Hans-CN.xliff"));
+                        });
+                    });
+                });
+            });
+        });
+        test.done();
+    }
+};

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -51,6 +51,7 @@ module.exports.files = [
     "testObjectiveCFile.js",
     "testObjectiveCFileType.js",
     "testOldHamlFileType.js",
+    "testProject.js",
     "testProjectFactory.js",
     "testPseudoBritish.js",
     "testPseudoCanadian.js",

--- a/test/testfiles/project.json
+++ b/test/testfiles/project.json
@@ -1,6 +1,6 @@
 {
-    "name": "HT Test",
-    "id": "ht-test",
+    "name": "Loctool Test",
+    "id": "loctest",
     "projectType": "web",
     "pseudoLocale": "de-DE",
     "resourceDirs": {
@@ -9,7 +9,6 @@
     },
     "schema": "./appinfo.schema.json",
     "excludes": [
-        ".*"
     ],
     "includes": [
         "config/notifications.yml"


### PR DESCRIPTION
As it was coded, the localizeOnly flag does not write out the xliffs when it is turned on. It also does not write out the xliffs when it is turned off. In fact, it never writes out the xliffs. The reason was that the translation set was tested to see if it had any contents before the strings were added to it. It needed to be tested afterwards, right before we write out the xliff file.