### PR TITLE
Fix handling of self-closed HTML tags in Markdown

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,9 @@ Published as version 2.7.1
 Bug Fixes:
 * Fixed a bug where xliff files are trying to be created when there was no extracted string.
 
+* Fixed a bug where self-closed tags like <br/> in markdown files were not handled properly,
+causing exceptions that complained about syntax errors
+
 Build 010
 -------
 

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -387,6 +387,7 @@ MarkdownFile.prototype._localizeAttributes = function(tagName, tag, locale, tran
 }
 
 var reTagName = /<(\/?)\s*(\w+)(\s|>)/;
+var reSelfClosingTag = /<\s*(\w+)\/>/;
 var reL10NComment = /<!--\s*[iI]18[Nn]\s*(.*)\s*-->/;
 
 var reDirectiveComment = /<!--\s*i18n-(en|dis)able\s+(\S*)\s*-->/;
@@ -398,7 +399,7 @@ var reDirectiveComment = /<!--\s*i18n-(en|dis)able\s+(\S*)\s*-->/;
  * walk.
  */
 MarkdownFile.prototype._walk = function(node) {
-    var match, valid;
+    var match, valid, tagName;
 
     switch (node.type) {
         case 'text':
@@ -515,7 +516,8 @@ MarkdownFile.prototype._walk = function(node) {
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.trim().substring(0, 4) === '<!--') {
+            var trimmed = node.value.trim();
+            if (trimmed.substring(0, 4) === '<!--') {
                 reDirectiveComment.lastIndex = 0;
                 match = reDirectiveComment.exec(node.value);
                 if (match) {
@@ -532,47 +534,68 @@ MarkdownFile.prototype._walk = function(node) {
                 // ignore HTML comments
                 break;
             }
-            match = reTagName.exec(node.value);
-
+            reSelfClosingTag.lastIndex = 0;
+            match = reSelfClosingTag.exec(trimmed);
             if (match) {
-                var tagName = match[2];
-                if (match[1] !== '/') {
-                    // opening tag
-                    if (this.message.getTextLength()) {
-                        if (utils.nonBreakingTags[tagName]) {
-                            this.message.push({
-                                name: tagName,
-                                node: node
-                            });
-                            node.localizable = true;
-                        } else {
-                            // it's a breaking tag, so emit any text
-                            // we have accumulated so far
-                            this._emitText();
-                        }
-                    }
-                    this._findAttributes(tagName, node.value);
+                tagName = match[1];
+                if (utils.nonBreakingTags[tagName]) {
+                    this.message.push({
+                        name: tagName,
+                        node: node
+                    });
+                    node.localizable = true;
+                    this.message.pop();
                 } else {
-                    // closing tag
-                    if (this.message.getTextLength()) {
-                        if (utils.nonBreakingTags[tagName] && this.message.getCurrentLevel() > 0) {
-                            var tag = this.message.pop();
-                            while (tag.name !== tagName && this.message.getCurrentLevel() > 0) {
-                                tag = this.message.pop();
-                            }
-                            if (tag.name !== tagName) {
-                                throw new Error("Syntax error in markdown file " + this.pathName + " line " +
-                                    node.position.start.line + " column " + node.position.start.column + ". Unbalanced HTML tags.");
-                            }
-                            node.localizable = true;
-                        } else {
-                            this._emitText();
-                        }
-                    }
+                    // it's a breaking tag, so emit any text
+                    // we have accumulated so far
+                    this._emitText();
                 }
             } else {
-                throw new Error("Syntax error in markdown file " + this.pathName + " line " +
-                    node.position.start.line + " column " + node.position.start.column + ". Bad HTML tag.");
+                match = reTagName.exec(node.value);
+
+                if (match) {
+                    tagName = match[2];
+                    if (match[1] !== '/') {
+                        // opening tag
+                        if (this.message.getTextLength()) {
+                            if (utils.nonBreakingTags[tagName]) {
+                                this.message.push({
+                                    name: tagName,
+                                    node: node
+                                });
+                                node.localizable = true;
+                                if (utils.selfClosingTags[tagName]) {
+                                    this.message.pop();
+                                }
+                            } else {
+                                // it's a breaking tag, so emit any text
+                                // we have accumulated so far
+                                this._emitText();
+                            }
+                        }
+                        this._findAttributes(tagName, node.value);
+                    } else {
+                        // closing tag
+                        if (this.message.getTextLength()) {
+                            if (utils.nonBreakingTags[tagName] && this.message.getCurrentLevel() > 0) {
+                                var tag = this.message.pop();
+                                while (tag.name !== tagName && this.message.getCurrentLevel() > 0) {
+                                    tag = this.message.pop();
+                                }
+                                if (tag.name !== tagName) {
+                                    throw new Error("Syntax error in markdown file " + this.pathName + " line " +
+                                        node.position.start.line + " column " + node.position.start.column + ". Unbalanced HTML tags.");
+                                }
+                                node.localizable = true;
+                            } else {
+                                this._emitText();
+                            }
+                        }
+                    }
+                } else {
+                    throw new Error("Syntax error in markdown file " + this.pathName + " line " +
+                        node.position.start.line + " column " + node.position.start.column + ". Bad HTML tag.");
+                }
             }
             break;
 
@@ -762,7 +785,7 @@ MarkdownFile.prototype._addComment = function(comment) {
  * @private
  */
 MarkdownFile.prototype._localizeNode = function(node, message, locale, translations) {
-    var match, valid, translation;
+    var match, translation, trimmed;
 
     switch (node.type) {
         case 'text':
@@ -855,7 +878,8 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.trim().substring(0, 4) === '<!--') {
+            trimmed = node.value.trim();
+            if (trimmed.substring(0, 4) === '<!--') {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {
@@ -864,33 +888,46 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 // ignore HTML comments
                 break;
             }
-            match = reTagName.exec(node.value);
-
+            reSelfClosingTag.lastIndex = 0;
+            match = reSelfClosingTag.exec(trimmed);
             if (match) {
-                var tagName = match[2];
-                if (match[1] !== '/') {
-                    // opening tag
-                    node.value = this._localizeAttributes(tagName, node.value, locale, translations);
-                    if (node.localizable && utils.nonBreakingTags[tagName]) {
-                        node.name = tagName;
-                        message.push(node);
-                    }
-                } else {
-                    // closing tag
-                    if (node.localizable && utils.nonBreakingTags[tagName] && message.getCurrentLevel() > 0) {
-                        var tag = message.pop();
-                        while (tag.name !== tagName && message.getCurrentLevel() > 0) {
-                            tag = message.pop();
-                        }
-                        if (tag.name !== tagName) {
-                            throw new Error("Syntax error in markdown file " + this.pathName + " line " +
-                                node.position.start.line + " column " + node.position.start.column + ". Unbalanced HTML tags.");
-                        }
-                    }
+                tagName = match[1];
+                if (node.localizable) {
+                    message.push(node);
+                    message.pop();
                 }
             } else {
-                throw new Error("Syntax error in markdown file " + this.pathName + " line " +
-                    node.position.start.line + " column " + node.position.start.column + ". Bad HTML tag.");
+                match = reTagName.exec(node.value);
+
+                if (match) {
+                    var tagName = match[2];
+                    if (match[1] !== '/') {
+                        // opening tag
+                        node.value = this._localizeAttributes(tagName, node.value, locale, translations);
+                        if (node.localizable && utils.nonBreakingTags[tagName]) {
+                            node.name = tagName;
+                            message.push(node);
+                            if (node.selfclosing || utils.selfClosingTags[tagName]) {
+                                message.pop();
+                            }
+                        }
+                    } else {
+                        // closing tag
+                        if (node.localizable && utils.nonBreakingTags[tagName] && message.getCurrentLevel() > 0) {
+                            var tag = message.pop();
+                            while (tag.name !== tagName && message.getCurrentLevel() > 0) {
+                                tag = message.pop();
+                            }
+                            if (tag.name !== tagName) {
+                                throw new Error("Syntax error in markdown file " + this.pathName + " line " +
+                                    node.position.start.line + " column " + node.position.start.column + ". Unbalanced HTML tags.");
+                            }
+                        }
+                    }
+                } else {
+                    throw new Error("Syntax error in markdown file " + this.pathName + " line " +
+                        node.position.start.line + " column " + node.position.start.column + ". Bad HTML tag.");
+                }
             }
             break;
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -953,6 +953,90 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseNonBreakingSelfClosingHTMLTags: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('<em>This is a test of the <br> emergency parsing system.</em>\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        // should not pick up the emphasis marker because there is no localizable text
+        // before it or after it
+        var r = set.getBySource("This is a test of the <c0/> emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0/> emergency parsing system.");
+        test.equal(r.getKey(), "r1070934855");
+
+        test.done();
+    },
+
+    testMarkdownFileParseBreakingSelfClosedHTMLTags: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('<em>This is a test of the <p/> emergency parsing system.</em>\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        // should not pick up the emphasis marker because there is no localizable text
+        // before it or after it
+        var r = set.getBySource("This is a test of the");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the");
+        test.equal(r.getKey(), "r593084440");
+
+        test.done();
+    },
+
+    testMarkdownFileParseBreakingNotClosedHTMLTags: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('<em>This is a test of the <p> emergency parsing system.</em>\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        // should not pick up the emphasis marker because there is no localizable text
+        // before it or after it
+        var r = set.getBySource("This is a test of the");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the");
+        test.equal(r.getKey(), "r593084440");
+
+        test.done();
+    },
+
+    testMarkdownFileParseNonBreakingSelfClosedHTMLTags: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('<em>This is a test of the <br/> emergency parsing system.</em>\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        // should not pick up the emphasis marker because there is no localizable text
+        // before it or after it
+        var r = set.getBySource("This is a test of the <c0/> emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0/> emergency parsing system.");
+        test.equal(r.getKey(), "r1070934855");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingIgnoreComplexIrrelevant: function(test) {
         test.expect(5);
 
@@ -1997,6 +2081,124 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
                 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence.</em></span>\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextBreakingTags: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <p>test of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r21364457",
+            source: "This is a",
+            sourceLocale: "en-US",
+            target: "Ceci est un",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r787549036",
+            source: "test of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "essai du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <p>essai du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextSelfClosedBreakingTags: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <p/>test of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r21364457",
+            source: "This is a",
+            sourceLocale: "en-US",
+            target: "Ceci est un",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r787549036",
+            source: "test of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "essai du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <p/>essai du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextSelfClosingNonBreakingTags: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <br>test of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r292870472",
+            source: "This is a <c0/>test of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0/>essai du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <br>essai du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextSelfClosedNonBreakingTags: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse('This is a <br/>test of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r292870472",
+            source: "This is a <c0/>test of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0/>essai du système d'analyse syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <br/>essai du système d\'analyse syntaxique de l\'urgence.\n');
 
         test.done();
     },


### PR DESCRIPTION
This is one problem in the loctool's markdown handling causing some of the strings in the Box developer documentation not to be extracted properly. (There are others as well, but I'll put them in separate PRs for separate fixes.)

In this case, self-closed tags like &lt;br/> or &lt;p/> cause the loctool to report syntax errors in the markdown, which is not correct.