### PR TITLE
Backtrack to opencc 1.0.6

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 012
+-------
+
+Published as version 2.7.2
+
+Bug Fixes:
+* Backtracked to opencc 1.0.6 because the current version (1.1.1) does
+not compile properly on ubuntu with node 12+
+
 Build 011
 -------
 
@@ -10,7 +19,6 @@ Bug Fixes:
 * Fixed a bug where xliff files are trying to be created when there was no extracted string.
 * Fixed a bug where the xliff files (extracted + new files) were never generated, even when
 localizeOnly is turned off
-
 * Fixed a bug where self-closed tags like <br/> in markdown files were not handled properly,
 causing exceptions that complained about syntax errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.7.1",
+    "version": "2.7.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "micromatch": "^3.1.0",
         "mysql2": "^1.7.0",
         "node-expat": "^2.3.18",
-        "opencc": "^1.0.6",
+        "opencc": "1.0.6",
         "pretty-data": ">=0.40.0",
         "rehype-raw": "^4.0.2",
         "remark-frontmatter": "^1.3.3",


### PR DESCRIPTION
Latest is opencc 1.1.1 but it does not compile on ubuntu properly
so we cannot use it.