### PR TITLE
Fix parsing and localization of markdown tables

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,10 @@ Published as version 2.7.2
 Bug Fixes:
 * Backtracked to opencc 1.0.6 because the current version (1.1.1) does
 not compile properly on ubuntu with node 12+
+* Fixed the parsing and localization of text in table cells
+* Fixed the parsing and localization of inline code that is the only part of a localizable
+segment. Inline code is only translatable when it is part of a larger localizable piece of
+text, not when it is by itself.
 
 Build 011
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -185,7 +185,7 @@ Bug Fixes:
 * Many file types were not producing any translated output for the generated pseudo locales.
   Now they do!
 * If you had loctool install in the global node modules, and your loctool plugin installed in your
-  project's node modules, it was not finding and loading that plugin. Now loctool will check the 
+  project's node modules, it was not finding and loading that plugin. Now loctool will check the
   loctool directory, the current project, and the ../plugins directory for plugins.
 
 Build 003

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -22,14 +22,11 @@ var path = require("path");
 var log4js = require("log4js");
 var MessageAccumulator = require("message-accumulator").default;
 var Node = require("ilib-tree-node").default;
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var isAlnum = require("ilib/lib/isAlnum.js");
 var isIdeo = require("ilib/lib/isIdeo.js");
-var IString = require("ilib/lib/IString.js");
 var unified = require("unified");
 var markdown = require("remark-parse");
-var html = require("remark-html");
 var remark2rehype = require('remark-rehype');
 var highlight = require('remark-highlight.js');
 var raw = require('rehype-raw');
@@ -37,8 +34,6 @@ var stringify = require('remark-stringify');
 var frontmatter = require('remark-frontmatter');
 var he = require("he");
 var unistFilter = require('unist-util-filter');
-var unistMap = require('unist-util-map');
-var unistVisit = require('unist-util-visit');
 var u = require('unist-builder');
 
 var utils = require("./utils.js");
@@ -285,7 +280,10 @@ MarkdownFile.prototype.isTranslatable = function(str) {
  * @private
  */
 MarkdownFile.prototype._emitText = function(escape) {
-    if (!this.message.getTextLength()) return;
+    if (!this.message.getTextLength()) {
+        this.message = new MessageAccumulator();
+        return;
+    }
 
     var text = this.message.getMinimalString();
 

--- a/loctool.js
+++ b/loctool.js
@@ -22,13 +22,11 @@
  */
 var fs = require('fs');
 var path = require('path');
-var util = require('util');
 var log4js = require("log4js");
 var Queue = require("js-stl").Queue;
 var mm = require("micromatch");
 
 var ProjectFactory = require("./lib/ProjectFactory.js");
-var TranslationSet = require("./lib/TranslationSet.js");
 var Xliff = require("./lib/Xliff.js");
 
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -913,6 +913,38 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseInlineCodeByItself: function(test) {
+        test.expect(9);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'This is a test of the inline code system.\n' +
+            '\n' +
+            '`inline code`\n' +
+            '\n' +
+            'Sentence after.');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        // should not extract the inline code by itself
+        var r = set.getBySource("This is a test of the inline code system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the inline code system.");
+        test.equal(r.getKey(), "r41637229");
+
+        r = set.getBySource("Sentence after.");
+        test.ok(r);
+        test.equal(r.getSource(), "Sentence after.");
+        test.equal(r.getKey(), "r16227039");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingHTMLTags: function(test) {
         test.expect(5);
 
@@ -1486,6 +1518,142 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseTable: function(test) {
+        test.expect(21);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| asdf              | fdsa            |\n" +
+            "| foo               | bar             |\n");
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 6);
+
+        r = set.getBySource("Query description");
+        test.ok(r);
+        test.equal(r.getSource(), "Query description");
+        test.equal(r.getKey(), "r744039504");
+
+        r = set.getBySource("Returns column");
+        test.ok(r);
+        test.equal(r.getSource(), "Returns column");
+        test.equal(r.getKey(), "r595024848");
+
+        var r = set.getBySource("asdf");
+        test.ok(r);
+        test.equal(r.getSource(), "asdf");
+        test.equal(r.getKey(), "r976104267");
+
+        r = set.getBySource("fdsa");
+        test.ok(r);
+        test.equal(r.getSource(), "fdsa");
+        test.equal(r.getKey(), "r486555110");
+
+        var r = set.getBySource("foo");
+        test.ok(r);
+        test.equal(r.getSource(), "foo");
+        test.equal(r.getKey(), "r941132140");
+
+        r = set.getBySource("bar");
+        test.ok(r);
+        test.equal(r.getSource(), "bar");
+        test.equal(r.getKey(), "r755240053");
+
+        test.done();
+    },
+
+    testMarkdownFileParseTableWithInlineCode: function(test) {
+        test.expect(15);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| `asdf`            | `fdsa`          |\n" +
+            "| foo               | bar             |\n");
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+
+        r = set.getBySource("Query description");
+        test.ok(r);
+        test.equal(r.getSource(), "Query description");
+        test.equal(r.getKey(), "r744039504");
+
+        r = set.getBySource("Returns column");
+        test.ok(r);
+        test.equal(r.getSource(), "Returns column");
+        test.equal(r.getKey(), "r595024848");
+
+        var r = set.getBySource("foo");
+        test.ok(r);
+        test.equal(r.getSource(), "foo");
+        test.equal(r.getKey(), "r941132140");
+
+        r = set.getBySource("bar");
+        test.ok(r);
+        test.equal(r.getSource(), "bar");
+        test.equal(r.getKey(), "r755240053");
+
+        test.done();
+    },
+
+    testMarkdownFileParseTableWithInlineCodeAndTextAfterwards: function(test) {
+        test.expect(14);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| `order_by`        | `field_key`     |\n" +
+            "\n" +
+            "## Heading Title\n" +
+            "\n" +
+            "Text body.\n");
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+
+        r = set.getBySource("Query description");
+        test.ok(r);
+        test.equal(r.getSource(), "Query description");
+        test.equal(r.getKey(), "r744039504");
+
+        r = set.getBySource("Returns column");
+        test.ok(r);
+        test.equal(r.getSource(), "Returns column");
+        test.equal(r.getKey(), "r595024848");
+
+        var r = set.getBySource("Heading Title");
+        test.ok(r);
+        test.equal(r.getSource(), "Heading Title");
+        test.equal(r.getKey(), "r931719890");
+
+        r = set.getBySource("Text body.");
+        test.ok(r);
+        test.equal(r.getSource(), "Text body.");
+        test.equal(r.getKey(), "r443039973");
+
+        test.done();
+    },
+
     testMarkdownFileExtractFile: function(test) {
         test.expect(14);
 
@@ -1831,6 +1999,70 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
             'Avec cette commande `git rm filename`, vous pouvez supprimer le fichier.\n');
+
+        test.done();
+    },
+
+    
+    testMarkdownFileParseInlineCodeByItself: function(test) {
+        test.expect(9);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            'This is a test of the inline code system.\n' +
+            '\n' +
+            '`inline code`\n' +
+            '\n' +
+            'Sentence after.\n');
+
+        // should not optimize out inline code at the end of strings so that it can be
+        // part of the text that is translated
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r41637229",
+            source: "This is a test of the inline code system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un teste de la systeme 'inline code'.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r16227039",
+            source: "Sentence after.",
+            sourceLocale: "en-US",
+            target: "La phrase denier.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            "Ceci est un teste de la systeme 'inline code'.\n" +
+            '\n' +
+            '`inline code`\n' +
+            '\n' +
+            'La phrase denier.\n');
+
+        test.done();
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        // should not extract the inline code by itself
+        var r = set.getBySource("This is a test of the inline code system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the inline code system.");
+        test.equal(r.getKey(), "r41637229");
+
+        r = set.getBySource("Sentence after.");
+        test.ok(r);
+        test.equal(r.getSource(), "Sentence after.");
+        test.equal(r.getKey(), "r16227039");
 
         test.done();
     },
@@ -3575,5 +3807,200 @@ module.exports.markdown = {
         test.equal(actual, expected);
 
         test.done();
+    },
+
+    testMarkdownFileLocalizeTable: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| foo               | bar             |\n");
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r744039504',
+            source: 'Query description',
+            target: 'Query description... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r595024848',
+            source: 'Returns column',
+            target: 'Returns column... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r941132140',
+            source: 'foo',
+            target: 'foo... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r755240053',
+            source: 'bar',
+            target: 'bar... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            "|                                 |                              |\n" +
+            "| ------------------------------- | ---------------------------- |\n" +
+            "| Query description... in GERMAN! | Returns column... in GERMAN! |\n" +
+            "| foo... in GERMAN!               | bar... in GERMAN!            |\n";
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+    
+    testMarkdownFileLocalizeTableWithInlineCode: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| `code`            | `more code`     |\n" +
+            "| foo               | bar             |\n");
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r744039504',
+            source: 'Query description',
+            target: 'Query description... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r595024848',
+            source: 'Returns column',
+            target: 'Returns column... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r941132140',
+            source: 'foo',
+            target: 'foo... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r755240053',
+            source: 'bar',
+            target: 'bar... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            "|                                 |                              |\n" +
+            "| ------------------------------- | ---------------------------- |\n" +
+            "| Query description... in GERMAN! | Returns column... in GERMAN! |\n" +
+            "| `code`                          | `more code`                  |\n" +
+            "| foo... in GERMAN!               | bar... in GERMAN!            |\n";
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTableWithInlineCodeAndTextAfter: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile(p);
+        test.ok(mf);
+
+        mf.parse(
+            "|                   |                 |\n" +
+            "|-------------------|-----------------|\n" +
+            "| Query description | Returns column  |\n" +
+            "| `code`            | `more code`     |\n" +
+            "\n" +
+            "## Header Title\n" +
+            "\n" +
+            "Body text.\n");
+
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r744039504',
+            source: 'Query description',
+            target: 'Query description... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r595024848',
+            source: 'Returns column',
+            target: 'Returns column... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r941132140',
+            source: 'Header Title',
+            target: 'Header Title... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r755240053',
+            source: 'Body text.',
+            target: 'Body text... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            "|                                 |                              |\n" +
+            "| ------------------------------- | ---------------------------- |\n" +
+            "| Query description... in GERMAN! | Returns column... in GERMAN! |\n" +
+            "| `code`                          | `more code`                  |\n" +
+            "\n" +
+            "## Header Title... in GERMAN!\n" +
+            "\n" +
+            "Body text... in GERMAN!\n";
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
     }
+
 };

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2003,7 +2003,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    
+
     testMarkdownFileLocalizeInlineCodeByItself: function(test) {
         test.expect(2);
 
@@ -3851,7 +3851,7 @@ module.exports.markdown = {
 
         test.done();
     },
-    
+
     testMarkdownFileLocalizeTableWithInlineCode: function(test) {
         test.expect(2);
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1611,7 +1611,7 @@ module.exports.markdown = {
     },
 
     testMarkdownFileParseTableWithInlineCodeAndTextAfterwards: function(test) {
-        test.expect(14);
+        test.expect(15);
 
         var mf = new MarkdownFile(p);
         test.ok(mf);
@@ -2004,8 +2004,8 @@ module.exports.markdown = {
     },
 
     
-    testMarkdownFileParseInlineCodeByItself: function(test) {
-        test.expect(9);
+    testMarkdownFileLocalizeInlineCodeByItself: function(test) {
+        test.expect(2);
 
         var mf = new MarkdownFile(p);
         test.ok(mf);
@@ -2045,24 +2045,6 @@ module.exports.markdown = {
             '`inline code`\n' +
             '\n' +
             'La phrase denier.\n');
-
-        test.done();
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-
-        test.equal(set.size(), 2);
-
-        // should not extract the inline code by itself
-        var r = set.getBySource("This is a test of the inline code system.");
-        test.ok(r);
-        test.equal(r.getSource(), "This is a test of the inline code system.");
-        test.equal(r.getKey(), "r41637229");
-
-        r = set.getBySource("Sentence after.");
-        test.ok(r);
-        test.equal(r.getSource(), "Sentence after.");
-        test.equal(r.getKey(), "r16227039");
 
         test.done();
     },
@@ -3970,7 +3952,7 @@ module.exports.markdown = {
         }));
         translations.add(new ResourceString({
             project: "foo",
-            key: 'r941132140',
+            key: 'r1037333769',
             source: 'Header Title',
             target: 'Header Title... in GERMAN!',
             targetLocale: "de-DE",
@@ -3978,7 +3960,7 @@ module.exports.markdown = {
         }));
         translations.add(new ResourceString({
             project: "foo",
-            key: 'r755240053',
+            key: 'r521829558',
             source: 'Body text.',
             target: 'Body text... in GERMAN!',
             targetLocale: "de-DE",


### PR DESCRIPTION
* fixed parsing and localization of text in markdown table cells
* fixed parsing and localization of inline code when the only thing in a localizable segment is that inline code.
    * Inline code is only translatable when it is part of a larger localizable piece of text, not when it is by itself.