### PR TITLE
Add the ability to only localize a markdown file if it is fully translated

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,18 @@
 Release Notes for Version 2
 ============================
 
+Build 013
+-------
+
+Published as version 2.8.0
+
+New Features:
+- added a "fullyTranslated" setting for the markdown code. This makes sure that if a
+  file does not have all of its translations, then that file is produced in the source
+  language.
+    - Also produces a file in the project root called `translation-status.json`
+      that details which files were fully translated and which were not
+
 Build 012
 -------
 

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -130,6 +130,10 @@ var MarkdownFile = function(project, pathName, type) {
     this.set = new TranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
     this.localizeLinks = false;
     // this.componentIndex = 0;
+    // if this is set, only produce fully translated markdown files. Otherwise if they
+    // are not fully translated, just output the original source text.
+    this.fullyTranslated = project.settings.markdown && project.settings.markdown.fullyTranslated;
+    this.translationStatus = {};
 };
 
 /**
@@ -754,6 +758,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
                 datatype: "markdown",
                 index: this.resourceIndex++
             }));
+            this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
 
             translation = source;
 
@@ -763,6 +768,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
         }
     } else {
         translation = source;
+        this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
     }
 
     return translation;
@@ -783,7 +789,7 @@ MarkdownFile.prototype._addComment = function(comment) {
  * @private
  */
 MarkdownFile.prototype._localizeNode = function(node, message, locale, translations) {
-    var match, translation, trimmed;
+    var match, trimmed;
 
     switch (node.type) {
         case 'text':
@@ -1061,7 +1067,6 @@ function mapToNodes(astNode) {
  * @returns {String} the localized text of this file
  */
 MarkdownFile.prototype.localizeText = function(translations, locale) {
-    var output = "";
     this.resourceIndex = 0;
 
     logger.debug("Localizing strings for locale " + locale);
@@ -1076,6 +1081,8 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     var nodeArray = mapToNodes(ast).toArray();
 
     var valid = true, start = -1, end, ma = new MessageAccumulator();
+    
+    this.translationStatus[locale] = true;
 
     for (var i = 0; i < nodeArray.length; i++) {
         if (nodeArray[i].type === 'linkReference') {
@@ -1126,7 +1133,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     // convert to a tree again
     ast = mapToAst(Node.fromArray(nodeArray));
 
-    var str = mdstringify.stringify(ast);
+    var str = mdstringify.stringify((!this.fullyTranslated || this.translationStatus[locale]) ? ast : this.ast);
 
     // make sure the thematic breaks don't have blank lines after them and they
     // don't erroneously escape the backslash chars

--- a/lib/MarkdownFile.js
+++ b/lib/MarkdownFile.js
@@ -132,7 +132,7 @@ var MarkdownFile = function(project, pathName, type) {
     // this.componentIndex = 0;
     // if this is set, only produce fully translated markdown files. Otherwise if they
     // are not fully translated, just output the original source text.
-    this.fullyTranslated = project.settings.markdown && project.settings.markdown.fullyTranslated;
+    this.fullyTranslated = project && project.settings && project.settings.markdown && project.settings.markdown.fullyTranslated;
     this.translationStatus = {};
 };
 
@@ -857,6 +857,9 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             if (node.localizable) {
                 if (node.use === "start") {
                     message.push(node);
+                } else if (node.use === "startend") {
+                    message.push(node, true);
+                    message.pop();
                 } else {
                     message.pop();
                 }
@@ -1081,7 +1084,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     var nodeArray = mapToNodes(ast).toArray();
 
     var valid = true, start = -1, end, ma = new MessageAccumulator();
-    
+
     this.translationStatus[locale] = true;
 
     for (var i = 0; i < nodeArray.length; i++) {
@@ -1153,18 +1156,28 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
  * @param {Array.<String>} locales array of locales to translate to
  */
 MarkdownFile.prototype.localize = function(translations, locales) {
+    var pathName;
     for (var i = 0; i < locales.length; i++) {
         if (!this.project.isSourceLocale(locales[i])) {
             // skip variants for now until we can handle them properly
             var l = new Locale(locales[i]);
+            pathName = "";
             if (!l.getVariant()) {
-                var pathName = this.getLocalizedPath(locales[i]);
+                pathName = this.getLocalizedPath(locales[i]);
                 logger.debug("Writing file " + pathName);
                 var p = path.join(this.project.target, pathName);
                 var d = path.dirname(p);
                 utils.makeDirs(d);
 
                 fs.writeFileSync(p, this.localizeText(translations, locales[i]), "utf-8");
+            }
+
+            if (!this.translationStatus[locales[i]]) {
+                this.type.addTranslationStatus({
+                    path: pathName,
+                    locale: locales[i],
+                    fullyTranslated: false
+                });
             }
         }
     }

--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -1,7 +1,7 @@
 /*
  * MarkdownFileType.js - Represents a collection of Markdown files
  *
- * Copyright © 2019, Box, Inc.
+ * Copyright © 2019-2020, Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -34,7 +34,6 @@ var MarkdownFileType = function(project) {
     this.datatype = "markdown";
     this.parent.call(this, project);
     this.extensions = [ ".md", ".markdown", ".mdown", ".mkd", ".rst", ".rmd" ];
-    
 
     this.fileInfo = {
         translated: [],

--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -34,6 +34,12 @@ var MarkdownFileType = function(project) {
     this.datatype = "markdown";
     this.parent.call(this, project);
     this.extensions = [ ".md", ".markdown", ".mdown", ".mkd", ".rst", ".rmd" ];
+    
+
+    this.fileInfo = {
+        translated: [],
+        untranslated: []
+    }
 };
 
 MarkdownFileType.prototype = new FileType();
@@ -93,8 +99,18 @@ MarkdownFileType.prototype.newFile = function(path) {
     return new MarkdownFile(this.project, path, this);
 };
 
-MarkdownFileType.prototype.projectClose = function(path) {
-    
+
+MarkdownFileType.prototype.addTranslationStatus = function(fileInfo) {
+    if (fileInfo.fullyTranslated) {
+        this.fileInfo.translated.push(fileInfo.path);
+    } else {
+        this.fileInfo.untranslated.push(fileInfo.path);
+    }
+};
+
+MarkdownFileType.prototype.projectClose = function() {
+    var fileName = path.join(this.project.root, "translation-status.json");
+    fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
 };
 
 /**

--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -19,12 +19,9 @@
 
 var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
 var utils = require("./utils.js");
-var TranslationSet = require("./TranslationSet.js");
 var MarkdownFile = require("./MarkdownFile.js");
 var FileType = require("./FileType.js");
 var ResourceFactory = require("./ResourceFactory.js");
@@ -94,6 +91,10 @@ MarkdownFileType.prototype.write = function() {
 
 MarkdownFileType.prototype.newFile = function(path) {
     return new MarkdownFile(this.project, path, this);
+};
+
+MarkdownFileType.prototype.projectClose = function(path) {
+    
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2815,7 +2815,7 @@ module.exports.markdown = {
     testMarkdownFileLocalizeFile: function(test) {
         test.expect(5);
 
-        var mf = new MarkdownFile(p, "./md/test1.md");
+        var mf = new MarkdownFile(p, "./md/test1.md", mdft);
         test.ok(mf);
 
         // should read the file
@@ -2981,7 +2981,7 @@ module.exports.markdown = {
     testMarkdownFileLocalizeFileWithFrontMatter: function(test) {
         test.expect(5);
 
-        var mf = new MarkdownFile(p, "./md/test3.md");
+        var mf = new MarkdownFile(p, "./md/test3.md", mdft);
         test.ok(mf);
 
         // should read the file
@@ -3101,7 +3101,7 @@ module.exports.markdown = {
     testMarkdownFileLocalizeNoStrings: function(test) {
         test.expect(3);
 
-        var mf = new MarkdownFile(p, "./md/nostrings.md");
+        var mf = new MarkdownFile(p, "./md/nostrings.md", mdft);
         test.ok(mf);
 
         // should read the file
@@ -3976,8 +3976,8 @@ module.exports.markdown = {
 
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
-
-        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
+        var mdft2 = new MarkdownFileType(p2);
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft2);
         test.ok(mf);
 
         // should read the file
@@ -4042,8 +4042,8 @@ module.exports.markdown = {
 
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
-
-        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
+        var mdft2 = new MarkdownFileType(p2);
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft2);
         test.ok(mf);
 
         // should read the file
@@ -4076,8 +4076,8 @@ module.exports.markdown = {
 
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
-
-        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
+        var mdft2 = new MarkdownFileType(p2);
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft2);
         test.ok(mf);
 
         // should read the file

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1,7 +1,7 @@
 /*
  * testMarkdownFile.js - test the Markdown file handler object.
  *
- * Copyright © 2019, Box, Inc.
+ * Copyright © 2019-2020, Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3977,7 +3977,7 @@ module.exports.markdown = {
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
 
-        var mf = new MarkdownFile(p2, "./notrans.md");
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
         test.ok(mf);
 
         // should read the file
@@ -4043,7 +4043,7 @@ module.exports.markdown = {
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
 
-        var mf = new MarkdownFile(p2, "./notrans.md");
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
         test.ok(mf);
 
         // should read the file
@@ -4077,7 +4077,7 @@ module.exports.markdown = {
         // this subproject has the "fullyTranslated" flag set to true
         var p2 = ProjectFactory("./testfiles/md/subproject", {});
 
-        var mf = new MarkdownFile(p2, "./notrans.md");
+        var mf = new MarkdownFile(p2, "./notrans.md", mdft);
         test.ok(mf);
 
         // should read the file

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+var fs = require("fs");
+
 if (!MarkdownFileType) {
     var MarkdownFileType = require("../lib/MarkdownFileType.js");
     var WebProject =  require("../lib/WebProject.js");
@@ -32,9 +34,9 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
+        var mdft = new MarkdownFileType(p);
 
-        test.ok(htf);
+        test.ok(mdft);
 
         test.done();
     },
@@ -48,10 +50,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.md"));
+        test.ok(mdft.handles("foo.md"));
 
         test.done();
     },
@@ -65,10 +67,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.markdown"));
+        test.ok(mdft.handles("foo.markdown"));
 
         test.done();
     },
@@ -82,10 +84,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.mdown"));
+        test.ok(mdft.handles("foo.mdown"));
 
         test.done();
     },
@@ -99,10 +101,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.mkd"));
+        test.ok(mdft.handles("foo.mkd"));
 
         test.done();
     },
@@ -116,10 +118,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.rst"));
+        test.ok(mdft.handles("foo.rst"));
 
         test.done();
     },
@@ -133,10 +135,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.rmd"));
+        test.ok(mdft.handles("foo.rmd"));
 
         test.done();
     },
@@ -150,10 +152,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("foo.tml"));
+        test.ok(!mdft.handles("foo.tml"));
 
         test.done();
     },
@@ -167,10 +169,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("a/b/c/foo.md"));
+        test.ok(mdft.handles("a/b/c/foo.md"));
 
         test.done();
     },
@@ -184,10 +186,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("en-GB/a/b/c/foo.md"));
+        test.ok(!mdft.handles("en-GB/a/b/c/foo.md"));
 
         test.done();
     },
@@ -201,10 +203,10 @@ module.exports.markdownfiletype = {
             locales:["en-GB"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("zh-Hans-CN/a/b/c/foo.md"));
+        test.ok(!mdft.handles("zh-Hans-CN/a/b/c/foo.md"));
 
         test.done();
     },
@@ -219,10 +221,10 @@ module.exports.markdownfiletype = {
             flavors: ["ASDF"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("en-ZA-ASDF/a/b/c/foo.md"));
+        test.ok(!mdft.handles("en-ZA-ASDF/a/b/c/foo.md"));
 
         test.done();
     },
@@ -237,10 +239,10 @@ module.exports.markdownfiletype = {
             flavors: ["ASDF"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("zh-Hant-HK-ASDF/a/b/c/foo.md"));
+        test.ok(!mdft.handles("zh-Hant-HK-ASDF/a/b/c/foo.md"));
 
         test.done();
     },
@@ -255,10 +257,10 @@ module.exports.markdownfiletype = {
             flavors: ["ASDF"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("en-US/a/b/c/foo.md"));
+        test.ok(mdft.handles("en-US/a/b/c/foo.md"));
 
         test.done();
     },
@@ -273,11 +275,11 @@ module.exports.markdownfiletype = {
             flavors: ["ASDF"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
         // md has the form of an iso language name, but it is not a real language
-        test.ok(htf.handles("md/a/b/c/foo.md"));
+        test.ok(mdft.handles("md/a/b/c/foo.md"));
 
         test.done();
     },
@@ -292,12 +294,63 @@ module.exports.markdownfiletype = {
             flavors: ["ASDF"]
         });
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
         // en-AA looks like a real locale, but it is not because XX is not a country code
-        test.ok(htf.handles("en-XX/a/b/c/foo.md"));
+        test.ok(mdft.handles("en-XX/a/b/c/foo.md"));
+
+        test.done();
+    },
+
+    testMarkdownFileTypeProjectClose: function(test) {
+        test.expect(3);
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
+
+        var statii = [
+            {path: "fr-FR/a/b/c.md", locale: "fr-FR", fullyTranslated: false},
+            {path: "de-DE/a/b/c.md", locale: "de-DE", fullyTranslated: true},
+            {path: "ja-JP/a/b/c.md", locale: "ja-JP", fullyTranslated: false},
+            {path: "fr-FR/x/y.md", locale: "fr-FR", fullyTranslated: true},
+            {path: "de-DE/x/y.md", locale: "de-DE", fullyTranslated: false},
+            {path: "ja-JP/x/y.md", locale: "ja-JP", fullyTranslated: true}
+        ];
+        statii.forEach(function(status) {
+            mdft.addTranslationStatus(status);
+        });
+
+        mdft.projectClose();
+
+        test.ok(fs.existsSync("./testfiles/translation-status.json"));
+
+        var contents = fs.readFileSync("./testfiles/translation-status.json", "utf-8");
+        var actual = JSON.parse(contents);
+
+        var expected = {
+            translated: [
+                "de-DE/a/b/c.md",
+                "fr-FR/x/y.md",
+                "ja-JP/x/y.md"
+            ],
+            untranslated: [
+                "fr-FR/a/b/c.md",
+                "ja-JP/a/b/c.md",
+                "de-DE/x/y.md"
+            ]
+        };
+
+        test.deepEqual(actual, expected);
 
         test.done();
     }
+
 };

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -1,7 +1,7 @@
 /*
  * testMarkdownFileType.js - test the Markdown file type handler object.
  *
- * Copyright © 2019, Box, Inc.
+ * Copyright © 2019-2020, Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testfiles/md/subproject/notrans.md
+++ b/test/testfiles/md/subproject/notrans.md
@@ -1,0 +1,10 @@
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+==================================
+
+This is some text. This is more text. Pretty, pretty text.
+
+This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+
+This is the last bit of localizable text.
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.

--- a/test/testfiles/md/subproject/project.json
+++ b/test/testfiles/md/subproject/project.json
@@ -1,0 +1,22 @@
+{
+    "name": "Loctool Test",
+    "id": "loctest2",
+    "projectType": "web",
+    "pseudoLocale": "de-DE",
+    "resourceDirs": {
+        "yml": "config/locales",
+        "js": "public/localized_js"
+    },
+    "schema": "./appinfo.schema.json",
+    "excludes": [
+    ],
+    "includes": [
+        "config/notifications.yml"
+    ],
+    "settings": {
+        "locales": ["en-GB", "es-US", "zh-Hans-CN"],
+        "markdown": {
+            "fullyTranslated": true
+        }
+    }
+}


### PR DESCRIPTION
- if it is not fully translated, the entire file will be produced in the source language instead. (ie. it is a copy of the original source file)
- add a setting in project.json to turn this on:
```json
"settings": {
  "markdown": {
    "fullyTranslated": true
  }
}
```
- the markdown code now produces a file in the project root called "translation-status.json" which documents which md files were fully translated and which were not:
```json
{
  "translated": [
    "array of path names ..."
  ],
  "untranslated": [
    "array of path names ..."
  ]
}
```