### PR TITLE
Don't write status when fullyTranslated is not on

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 2
 ============================
 
+Build 014
+-------
+
+Published as version 2.8.1
+
+Bug Fixes:
+- Fix a problem where the MarkdownFileType was producing the translation-status.json file
+  even when the fullyTranslated option is not turned on. If it is not turned on, it is not
+  useful anyways so don't produce it.
+
 Build 013
 -------
 

--- a/lib/MarkdownFileType.js
+++ b/lib/MarkdownFileType.js
@@ -108,8 +108,10 @@ MarkdownFileType.prototype.addTranslationStatus = function(fileInfo) {
 };
 
 MarkdownFileType.prototype.projectClose = function() {
-    var fileName = path.join(this.project.root, "translation-status.json");
-    fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
+    if (this.project.settings && this.project.settings.markdown && this.project.settings.markdown.fullyTranslated) {
+        var fileName = path.join(this.project.root, "translation-status.json");
+        fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
+    }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -303,14 +303,17 @@ module.exports.markdownfiletype = {
         test.done();
     },
 
-    testMarkdownFileTypeProjectClose: function(test) {
+    testMarkdownFileTypeProjectCloseFullyTranslatedOn: function(test) {
         test.expect(3);
 
         var p = new WebProject({
             sourceLocale: "en-US"
         }, "./testfiles", {
             locales:["en-GB"],
-            flavors: ["ASDF"]
+            flavors: ["ASDF"],
+            markdown: {
+                fullyTranslated: true
+            }
         });
 
         var mdft = new MarkdownFileType(p);
@@ -349,6 +352,42 @@ module.exports.markdownfiletype = {
         };
 
         test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileTypeProjectCloseFullyTranslatedOff: function(test) {
+        test.expect(3);
+
+        // clean up first
+        fs.unlinkSync("./testfiles/translation-status.json");
+        test.ok(!fs.existsSync("./testfiles/translation-status.json"));
+
+        var p = new WebProject({
+            sourceLocale: "en-US"
+        }, "./testfiles", {
+            locales:["en-GB"],
+            flavors: ["ASDF"]
+        });
+
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
+
+        var statii = [
+            {path: "fr-FR/a/b/c.md", locale: "fr-FR", fullyTranslated: false},
+            {path: "de-DE/a/b/c.md", locale: "de-DE", fullyTranslated: true},
+            {path: "ja-JP/a/b/c.md", locale: "ja-JP", fullyTranslated: false},
+            {path: "fr-FR/x/y.md", locale: "fr-FR", fullyTranslated: true},
+            {path: "de-DE/x/y.md", locale: "de-DE", fullyTranslated: false},
+            {path: "ja-JP/x/y.md", locale: "ja-JP", fullyTranslated: true}
+        ];
+        statii.forEach(function(status) {
+            mdft.addTranslationStatus(status);
+        });
+
+        mdft.projectClose();
+
+        test.ok(!fs.existsSync("./testfiles/translation-status.json"));
 
         test.done();
     }


### PR DESCRIPTION
The translation-status.json file is only really useful
when the fullyTranslated flag is turned on anyways.