### PR TITLE
Fix a problem where the xliff path is incorrectly converted when it is absolute.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 015
+-------
+
+Published as version 2.8.2
+
+Bug Fixes:
+- Fix a problem where the xliff path is incorrectly converted when the path is absolute.
+
+
 Build 014
 -------
 

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -84,10 +84,18 @@ var Project = function(options, root, settings) {
     }
 
     // where the translation xliff files are read from
-    this.xliffsDir = path.join(this.root, (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || '.');
+    if (this.settings.xliffsDir && path.isAbsolute(this.settings.xliffsDir)) {
+        this.xliffsDir = (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || this.root;
+    } else {
+        this.xliffsDir = path.join(this.root, (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || '.');
+    }
 
     // where the xliff files are written to
-    this.xliffsOut = path.join(this.root, (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || '.');
+    if (this.settings.xliffsOut && path.isAbsolute(this.settings.xliffsOut)) {
+        this.xliffsOut = (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || this.root;
+    } else{
+        this.xliffsOut = path.join(this.root, (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || '.');
+    }
 
     // generate a localization resource only. not create any other files after running loctool
     this.localizeOnly = (options.settings && options.settings.localizeOnly) || this.settings.localizeOnly;

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -35,6 +35,13 @@ var mm = require("micromatch");
 
 var logger = log4js.getLogger("loctool.lib.Project");
 
+function smartJoin(parent, child) {
+    if (path.isAbsolute(child)) {
+        return child;
+    }
+    return path.join(parent, child);
+}
+
 /**
  * @class Represent a loctool project.
  *
@@ -77,25 +84,17 @@ var Project = function(options, root, settings) {
     this.settings = JSUtils.merge((settings || {}), options.settings);
 
     this.root = root;  // where localizable files live
-    this.target = path.join(this.root, this.settings.targetDir || '.'); // where localized stuff is written
+    this.target = smartJoin(this.root, this.settings.targetDir || '.'); // where localized stuff is written
 
     if (typeof options.schema !== "undefined") {
         this.schema = options.schema;
     }
 
     // where the translation xliff files are read from
-    if (this.settings.xliffsDir && path.isAbsolute(this.settings.xliffsDir)) {
-        this.xliffsDir = (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || this.root;
-    } else {
-        this.xliffsDir = path.join(this.root, (options.settings && options.settings.xliffsDir) || this.settings.xliffsDir || '.');
-    }
+    this.xliffsDir = smartJoin(this.root, this.settings.xliffsDir || '.');
 
     // where the xliff files are written to
-    if (this.settings.xliffsOut && path.isAbsolute(this.settings.xliffsOut)) {
-        this.xliffsOut = (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || this.root;
-    } else{
-        this.xliffsOut = path.join(this.root, (options.settings && options.settings.xliffsOut) || this.settings.xliffsOut || '.');
-    }
+    this.xliffsOut = smartJoin(this.root, this.settings.xliffsOut || '.');
 
     // generate a localization resource only. not create any other files after running loctool
     this.localizeOnly = (options.settings && options.settings.localizeOnly) || this.settings.localizeOnly;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testLocalRepository.js
+++ b/test/testLocalRepository.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var path = require('path');
 
 if (!LocalRepository) {
     var LocalRepository = require("../lib/LocalRepository.js");
@@ -101,7 +100,7 @@ module.exports.localrepository = {
 
         var repo = new LocalRepository({
             sourceLocale: "en-US",
-            xliffsDir: path.join(process.env.PWD, "./testfiles/xliffs")
+            xliffsDir: "./testfiles/xliffs"
         });
 
         test.ok(repo);

--- a/test/testLocalRepository.js
+++ b/test/testLocalRepository.js
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+var path = require('path');
 
 if (!LocalRepository) {
     var LocalRepository = require("../lib/LocalRepository.js");
@@ -100,7 +101,7 @@ module.exports.localrepository = {
 
         var repo = new LocalRepository({
             sourceLocale: "en-US",
-            xliffsDir: "./testfiles/xliffs"
+            xliffsDir: path.join(process.env.PWD, "./testfiles/xliffs")
         });
 
         test.ok(repo);

--- a/test/testProjectFactory.js
+++ b/test/testProjectFactory.js
@@ -114,23 +114,33 @@ module.exports.projectfactory = {
         test.done();
     },
 
-    testProjectFactoryAbsolutePathXliffsDir: function(test){
+    testProjectFactoryAbsolutePathTargetDir: function(test){
         test.expect(2);
-        var xliffAbslutePath = path.join(process.env.PWD, 'asdf')
-        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsDir': xliffAbslutePath});
+        var targetAbsolutePath = '/foo/asdf';
+        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'targetDir': targetAbsolutePath});
         test.ok(project);
         // should be relative to the root of the project
-        test.equal(project.xliffsDir, path.join(process.env.PWD, 'asdf'));
+        test.equal(project.target, '/foo/asdf');
+        test.done();
+    },
+
+    testProjectFactoryAbsolutePathXliffsDir: function(test){
+        test.expect(2);
+        var xliffAbsolutePath = '/foo/asdf';
+        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsDir': xliffAbsolutePath});
+        test.ok(project);
+        // should be relative to the root of the project
+        test.equal(project.xliffsDir, '/foo/asdf');
         test.done();
     },
 
     testProjectFactoryAbsolutePathxliffsOut: function(test){
         test.expect(2);
-        var xliffAbslutePath = path.join(process.env.PWD, 'blah')
-        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsOut': xliffAbslutePath});
+        var xliffAbsolutePath = '/foo/asdf';
+        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsOut': xliffAbsolutePath});
         test.ok(project);
         // should be relative to the root of the project
-        test.equal(project.xliffsOut, path.join(process.env.PWD, 'blah'));
+        test.equal(project.xliffsOut, '/foo/asdf');
         test.done();
     }
 

--- a/test/testProjectFactory.js
+++ b/test/testProjectFactory.js
@@ -4,8 +4,6 @@
  * Copyright © 2017, 2020 Healthtap, Inc. All Rights Reserved.
  */
 
- var path = require('path');
-
 if (!ProjectFactory) {
     var ProjectFactory= require("../lib/ProjectFactory.js");
 }

--- a/test/testProjectFactory.js
+++ b/test/testProjectFactory.js
@@ -4,6 +4,8 @@
  * Copyright © 2017, 2020 Healthtap, Inc. All Rights Reserved.
  */
 
+ var path = require('path');
+
 if (!ProjectFactory) {
     var ProjectFactory= require("../lib/ProjectFactory.js");
 }
@@ -109,6 +111,26 @@ module.exports.projectfactory = {
         test.ok(project);
         // should be relative to the root of the project
         test.equal(project.xliffsOut, 'testfiles/blah');
+        test.done();
+    },
+
+    testProjectFactoryAbsolutePathXliffsDir: function(test){
+        test.expect(2);
+        var xliffAbslutePath = path.join(process.env.PWD, 'asdf')
+        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsDir': xliffAbslutePath});
+        test.ok(project);
+        // should be relative to the root of the project
+        test.equal(project.xliffsDir, path.join(process.env.PWD, 'asdf'));
+        test.done();
+    },
+
+    testProjectFactoryAbsolutePathxliffsOut: function(test){
+        test.expect(2);
+        var xliffAbslutePath = path.join(process.env.PWD, 'blah')
+        var project = ProjectFactory('./testfiles', {'locales': ['def'], 'xliffsOut': xliffAbslutePath});
+        test.ok(project);
+        // should be relative to the root of the project
+        test.equal(project.xliffsOut, path.join(process.env.PWD, 'blah'));
         test.done();
     }
 


### PR DESCRIPTION
The latest change occurs in an error.
When xliff file path is absolute, and the root is "." Joining two-path isn't appropriate.