### PR TITLE
Add a condition to set xliffPath value

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Build 015
 Published as version 2.8.2
 
 Bug Fixes:
-- Fix a problem where the xliff path is incorrectly converted when the path is absolute.
+- Fixed a problem where the xliff path is incorrectly converted when the path is absolute.
+- Added a condition not to see a warning message when xliff file is loading.
 
 
 Build 014

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -117,7 +117,7 @@ var Project = function(options, root, settings) {
     this.db = new LocalRepository({
         sourceLocale: this.sourceLocale,
         pseudoLocale: this.pseudoLocale,
-        pathName: path.join(this.xliffsDir, this.options.id + ".xliff"),
+        pathName: ((this.settings.xliffVersion !== 2) ? (path.join(this.xliffsDir, this.options.id + ".xliff")): undefined),
         project: this,
         xliffsDir: this.xliffsDir
     });


### PR DESCRIPTION
The current default value doesn't proper on xliff 2.0 usage case. 
I've added a condition to make valid when the xliff version is not 2.0. It not, It shows a warning message when it tries to load the file. it may confuse people who are not familiar with loctool.