### PR TITLE
Cleanup

### DIFF
--- a/lib/AndroidFlavors.js
+++ b/lib/AndroidFlavors.js
@@ -1,7 +1,7 @@
 /*
  * AndroidFlavors.js - find and report on Android flavors
  *
- * Copyright © 2017, HealthTap, Inc.
+ * Copyright © 2017, 2020, HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,12 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var log4js = require("log4js");
+// var log4js = require("log4js");
 var path = require("path");
 
-var utils = require("./utils.js");
 var BuildGradle = require("./BuildGradle.js");
 
-var logger = log4js.getLogger("loctool.lib.AndroidFlavors");
+// var logger = log4js.getLogger("loctool.lib.AndroidFlavors");
 
 /**
  * @class Represents a set of Android flavors.

--- a/lib/AndroidLayoutFileType.js
+++ b/lib/AndroidLayoutFileType.js
@@ -1,7 +1,7 @@
 /*
  * AndroidLayoutFileType.js - tool to extract resources from source code
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
 var utils = require("./utils.js");

--- a/lib/AndroidProject.js
+++ b/lib/AndroidProject.js
@@ -1,7 +1,7 @@
 /*
  * AndroidProject.js - represents an Android project
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
 var log4js = require("log4js");
 
 var Project = require("./Project.js");

--- a/lib/AndroidResourceFile.js
+++ b/lib/AndroidResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * AndroidResourceFile.js - represents an Android strings.xml resource file
  *
- * Copyright © 2016-2017,2019 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ var ContextResourceString = require("../lib/ContextResourceString.js");
 var ResourceString = require("../lib/ResourceString.js");
 var ResourceArray = require("../lib/ResourceArray.js");
 var ResourcePlural = require("../lib/ResourcePlural.js");
-var Set = require("../lib/Set.js");
 var utils = require("../lib/utils.js");
 var TranslationSet = require("../lib/TranslationSet.js")
 

--- a/lib/AndroidResourceFileType.js
+++ b/lib/AndroidResourceFileType.js
@@ -1,7 +1,7 @@
 /*
  * AndroidResourceFileType.js - manages a collection of android resource files
  *
- * Copyright © 2016-2017,2019 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 

--- a/lib/BuildGradle.js
+++ b/lib/BuildGradle.js
@@ -1,7 +1,7 @@
 /*
  * BuildGradle.js - read a build.gradle file and return info about the Android project
  *
- * Copyright © 2017, HealthTap, Inc.
+ * Copyright © 2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-var log4js = require("log4js");
+// var log4js = require("log4js");
 var bgr = require("build-gradle-reader");
 var path = require("path");
 var fs = require("fs");
 
-var logger = log4js.getLogger("loctool.lib.BuildGradle");
+// var logger = log4js.getLogger("loctool.lib.BuildGradle");
 
 /**
  * Create a new instance that represents a build.gradle file.

--- a/lib/CSV.js
+++ b/lib/CSV.js
@@ -1,7 +1,7 @@
 /*
  * CSV.js - convert a CSV to json and back
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@
  * limitations under the License.
  */
 
-var log4js = require("log4js");
+// var log4js = require("log4js");
 
-var utils = require("./utils.js");
-
-var logger = log4js.getLogger("loctool.lib.CSV");
+// var logger = log4js.getLogger("loctool.lib.CSV");
 
 var whiteSpaceChars = [' ', '\t', '\f', '\n', '\r', '\v'];
 

--- a/lib/ContextResourceString.js
+++ b/lib/ContextResourceString.js
@@ -1,7 +1,7 @@
 /*
  * ContextResourceString.js - represents an string in a Android file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 var log4js = require("log4js");
 
 var ResourceString = require("./ResourceString.js");
-var utils = require("./utils.js");
 
 var logger = log4js.getLogger("loctool.lib.ContextResourceString");
 

--- a/lib/DBTranslationSet.js
+++ b/lib/DBTranslationSet.js
@@ -1,7 +1,7 @@
 /*
  * DBTranslationSet.js - a collection of resource strings backed by a database
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 var mysql = require("mysql2");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var ResourceFactory = require("./ResourceFactory.js");
 
 var logger = log4js.getLogger("loctool.lib.DBTranslationSet");

--- a/lib/HTMLFile.js
+++ b/lib/HTMLFile.js
@@ -1,7 +1,7 @@
 /*
  * HTMLFile.js - plugin to extract resources from an HTML file
  *
- * Copyright © 2018-2019, Box, Inc.
+ * Copyright © 2018-2019, 2020 Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ var path = require("path");
 var log4js = require("log4js");
 var htmlParser = require("html-parser");
 var jsstl = require("js-stl");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var he = require("he");
 var MessageAccumulator = require("message-accumulator").default;

--- a/lib/HTMLFileType.js
+++ b/lib/HTMLFileType.js
@@ -1,7 +1,7 @@
 /*
  * HTMLFileType.js - Represents a collection of HTML files
  *
- * Copyright © 2018, Box, Inc.
+ * Copyright © 2018, 2020 Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,8 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
-var TranslationSet = require("./TranslationSet.js");
 var HTMLFile = require("./HTMLFile.js");
 var FileType = require("./FileType.js");
 var ResourceFactory = require("./ResourceFactory.js");

--- a/lib/HTMLTemplateFile.js
+++ b/lib/HTMLTemplateFile.js
@@ -1,7 +1,7 @@
 /*
  * HTMLTemplateFile.js - plugin to extract resources from an HTML template source code file
  *
- * Copyright © 2016-2017, 2019 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ var path = require("path");
 var log4js = require("log4js");
 var htmlParser = require("html-parser");
 var jsstl = require("js-stl");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 
 var Queue = jsstl.Queue;

--- a/lib/HTMLTemplateFileType.js
+++ b/lib/HTMLTemplateFileType.js
@@ -1,7 +1,7 @@
 /*
  * HTMLTemplateFileType.js - Represents a collection of java files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,8 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var HTMLTemplateFile = require("./HTMLTemplateFile.js");
 var FileType = require("./FileType.js");

--- a/lib/HamlFile.js
+++ b/lib/HamlFile.js
@@ -1,7 +1,7 @@
 /*
  * HamlFile.js - plugin to extract resources from a Haml source code file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 var fs = require("fs");
 var path = require("path");
 var utils = require("./utils.js");
-var ilib = require("ilib");
 var IString = require("ilib/lib/IString.js");
 var isSpace = require("ilib/lib/isSpace.js");
 var log4js = require("log4js");

--- a/lib/HamlFileType.js
+++ b/lib/HamlFileType.js
@@ -1,7 +1,7 @@
 /*
  * HamlFileType.js - Represents a collection of Haml files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,10 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
 var log4js = require("log4js");
-const spawnSync = require('child_process').spawnSync;
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var HamlFile = require("./HamlFile.js");
-var YamlResourceFile = require("./YamlResourceFile.js");
 var FileType = require("./FileType.js");
 var ResourceFactory = require("./ResourceFactory.js");
 var ResourceString = require("./ResourceString.js");

--- a/lib/IosLayoutResourceString.js
+++ b/lib/IosLayoutResourceString.js
@@ -1,7 +1,7 @@
 /*
  * IosLayoutResourceString.js - represents an string in a resource file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 var log4js = require("log4js");
 
 var ResourceString = require("./ResourceString.js");
-var utils = require("./utils.js");
 
 var logger = log4js.getLogger("loctool.lib.IosLayoutResourceString");
 

--- a/lib/IosStringsFile.js
+++ b/lib/IosStringsFile.js
@@ -1,7 +1,7 @@
 /*
  * IosStringsFile.js - represents an iOS strings resource file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,10 @@
 
 var fs = require("fs");
 var path = require("path");
-var xml2json = require('xml2json');
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
-var PrettyData = require("pretty-data").pd;
 var log4js = require("log4js");
 
-var ResourceString = require("./ResourceString.js");
-var ResourceArray = require("./ResourceArray.js");
-var ResourcePlural = require("./ResourcePlural.js");
 var IosLayoutResourceString = require("./IosLayoutResourceString.js");
-var Set = require("./Set.js");
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js")
 

--- a/lib/IosStringsFileType.js
+++ b/lib/IosStringsFileType.js
@@ -1,7 +1,7 @@
 /*
  * IosStringsFileType.js - manages a collection of iOS strings resource files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,10 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var IosStringsFile = require("./IosStringsFile.js");
 var TranslationSet = require("./TranslationSet.js");
 var FileType = require("./FileType.js");

--- a/lib/JavaFileType.js
+++ b/lib/JavaFileType.js
@@ -1,7 +1,7 @@
 /*
  * JavaFileType.js - Represents a collection of java files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
 var utils = require("./utils.js");

--- a/lib/JavaScriptFileType.js
+++ b/lib/JavaScriptFileType.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptFileType.js - Represents a collection of java files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
 var utils = require("./utils.js");

--- a/lib/JavaScriptResourceFile.js
+++ b/lib/JavaScriptResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptResourceFile.js - represents an Android strings.xml resource file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,9 @@
 
 var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
-var PrettyData = require("pretty-data").pd;
 var log4js = require("log4js");
 
-var ResourceString = require("./ResourceString.js");
-var ResourceArray = require("./ResourceArray.js");
-var ResourcePlural = require("./ResourcePlural.js");
-var Set = require("./Set.js");
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js")
 

--- a/lib/JavaScriptResourceFileType.js
+++ b/lib/JavaScriptResourceFileType.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptResourceFileType.js - manages a collection of android resource files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,10 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var JavaScriptResourceFile = require("./JavaScriptResourceFile.js");
-var TranslationSet = require("./TranslationSet.js");
 var FileType = require("./FileType.js");
-var ResourceFactory = require("./ResourceFactory.js");
-var ResourceString = require("./ResourceString.js");
 
 var logger = log4js.getLogger("loctool.lib.JavaScriptResourceFileType");
 

--- a/lib/JsxFileType.js
+++ b/lib/JsxFileType.js
@@ -1,7 +1,7 @@
 /*
  * JsxFileType.js - Represents a collection of jsxjava files
  *
- * Copyright © 2018, HealthTap, Inc.
+ * Copyright © 2018, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,7 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
 var utils = require("./utils.js");

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -1,7 +1,7 @@
 /*
  * LocalRepository.js - a collection of resource strings backed by a local set of files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,6 @@ var log4js = require("log4js");
 
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
-var ResourceString = require("./ResourceString.js");
-var ResourceArray = require("./ResourceArray.js");
-var ResourcePlural = require("./ResourcePlural.js");
 var Xliff = require("./Xliff.js");
 
 var logger = log4js.getLogger("loctool.lib.LocalRepository");

--- a/lib/ObjectiveCFileType.js
+++ b/lib/ObjectiveCFileType.js
@@ -1,7 +1,7 @@
 /*
  * ObjectiveCFileType.js - Represents a collection of objective C files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,8 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var ObjectiveCFile = require("./ObjectiveCFile.js");
 var FileType = require("./FileType.js");

--- a/lib/ObjectiveCProject.js
+++ b/lib/ObjectiveCProject.js
@@ -1,7 +1,7 @@
 /*
  * ObjectiveCProject.js - represents an iOS project using Objective C
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,9 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-// const spawnSync = require('child_process').spawnSync;
-
 var Project = require("./Project.js");
 var ObjectiveCFileType = require("./ObjectiveCFileType.js");
 var IosStringsFileType = require("./IosStringsFileType.js");
-// var XliffFileType = require("./XliffFileType.js");
-var TranslationSet = require("./TranslationSet.js");
 var log4js = require("log4js");
 
 var logger = log4js.getLogger("loctool.lib.ObjectiveCProject");

--- a/lib/OldHamlFile.js
+++ b/lib/OldHamlFile.js
@@ -1,7 +1,7 @@
 /*
  * OldHamlFile.js - plugin to extract resources from a Haml source code file
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-var utils = require("./utils.js");
-var ResourceString = require("./ResourceString.js");
 var TranslationSet = require("./TranslationSet.js");
 var log4js = require("log4js");
 

--- a/lib/OldHamlFileType.js
+++ b/lib/OldHamlFileType.js
@@ -1,7 +1,7 @@
 /*
  * OldHamlFileType.js - Represents a collection of Haml files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ var path = require("path");
 var log4js = require("log4js");
 const spawnSync = require('child_process').spawnSync;
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var OldHamlFile = require("./OldHamlFile.js");
 var YamlResourceFile = require("./YamlResourceFile.js");

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -31,7 +31,6 @@ var ResourceFactory = require("./ResourceFactory.js");
 var PseudoFactory = require("./PseudoFactory.js");
 var Xliff = require("./Xliff.js");
 var log4js = require("log4js");
-var mm = require("micromatch");
 
 var logger = log4js.getLogger("loctool.lib.Project");
 

--- a/lib/Pseudo.js
+++ b/lib/Pseudo.js
@@ -1,7 +1,7 @@
 /*
  * Pseudo.js - super class for all pseudo localization classes
  *
- * Copyright © 2016-2018, HealthTap, Inc.
+ * Copyright © 2016-2018, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-var ilib = require("ilib");
 
 /**
  * @class A resource bundle-like class that all other

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -2,7 +2,7 @@
  * PseudoFactory.js - class that creates the right type of pseudo localization
  * resource bundle for the given locale
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ var log4js = require("log4js");
 var WordBasedPseudo = require("./WordBasedPseudo.js");
 var PseudoHant = require("./PseudoHant.js");
 var RegularPseudo = require("./RegularPseudo.js");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale");
 
 var logger = log4js.getLogger("loctool.lib.PseudoFactory");

--- a/lib/RegularPseudo.js
+++ b/lib/RegularPseudo.js
@@ -2,7 +2,7 @@
  * RegularPseudo.js - pseudo localize a US English string using
  * ilib's pseudolocalization routines
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-var ilib = require("ilib");
 var ResBundle = require("ilib/lib/ResBundle");
 var Pseudo = require("./Pseudo.js");
 

--- a/lib/RubyFileType.js
+++ b/lib/RubyFileType.js
@@ -1,7 +1,7 @@
 /*
  * RubyFileType.js - Represents a collection of Ruby files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,8 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var RubyFile = require("./RubyFile.js");
 var FileType = require("./FileType.js");

--- a/lib/SwiftFileType.js
+++ b/lib/SwiftFileType.js
@@ -1,7 +1,7 @@
 /*
  * SwiftFileType.js - Represents a collection of Swift files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,8 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var SwiftFile = require("./SwiftFile.js");
 var FileType = require("./FileType.js");

--- a/lib/SwiftProject.js
+++ b/lib/SwiftProject.js
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-// const spawnSync = require('child_process').spawnSync;
 var log4js = require("log4js");
 
 var Project = require("./Project.js");
@@ -28,7 +25,6 @@ var SwiftFileType = require("./SwiftFileType.js");
 var IosStringsFileType = require("./IosStringsFileType.js");
 var JavaScriptFileType = require("./JavaScriptFileType.js");
 var JavaScriptResourceFileType = require("./JavaScriptResourceFileType.js");
-var TranslationSet = require("./TranslationSet.js");
 
 var logger = log4js.getLogger("loctool.lib.SwiftProject");
 

--- a/lib/TranslationSet.js
+++ b/lib/TranslationSet.js
@@ -1,7 +1,7 @@
 /*
  * TranslationSet.js - a collection of resource strings
  *
- * Copyright © 2016-2017, 2019 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ var log4js = require("log4js");
 var ilib = require("ilib");
 var JSUtils = require("ilib/lib/JSUtils");
 
-var utils = require("./utils.js");
 var Set = require("./Set.js");
 
 var logger = log4js.getLogger("loctool.lib.TranslationSet");

--- a/lib/WebProject.js
+++ b/lib/WebProject.js
@@ -1,7 +1,7 @@
 /*
  * WebProject.js - represents a Ruby on Rails web project
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-
 var Project = require("./Project.js");
 var HTMLFileType = require("./HTMLFileType.js");
 var HTMLTemplateFileType = require("./HTMLTemplateFileType.js");
@@ -33,7 +30,6 @@ var JavaScriptFileType = require("./JavaScriptFileType.js");
 var JsxFileType = require("./JsxFileType.js");
 var JavaScriptResourceFileType = require("./JavaScriptResourceFileType.js");
 var MarkdownFileType = require("./MarkdownFileType.js");
-var TranslationSet = require("./TranslationSet.js");
 var log4js = require("log4js");
 
 var logger = log4js.getLogger("loctool.lib.WebProject");

--- a/lib/XliffFile.js
+++ b/lib/XliffFile.js
@@ -1,7 +1,7 @@
 /*
  * XliffFile.js - represents xliff translations resource file
  *
- * Copyright © 2016-2017, 2019 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,8 @@
 
 var fs = require("fs");
 var path = require("path");
-var xml2json = require('xml2json');
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
-var PrettyData = require("pretty-data").pd;
 var log4js = require("log4js");
 
-var ResourceString = require("./ResourceString.js");
-var ResourceArray = require("./ResourceArray.js");
-var ResourcePlural = require("./ResourcePlural.js");
-var Set = require("./Set.js");
 var Xliff = require("./Xliff.js");
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js")

--- a/lib/XliffFileType.js
+++ b/lib/XliffFileType.js
@@ -1,7 +1,7 @@
 /*
  * XliffFileType.js - Represents a collection of Xliff files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,10 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
 var log4js = require("log4js");
 const spawnSync = require('child_process').spawnSync;
-var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale.js");
 
-var utils = require("./utils.js");
-var TranslationSet = require("./TranslationSet.js");
-var HamlFile = require("./HamlFile.js");
 var XliffFile = require("./XliffFile.js");
 var FileType = require("./FileType.js");
 

--- a/lib/YamlFile.js
+++ b/lib/YamlFile.js
@@ -6,7 +6,7 @@
  * writing out a parallel yml file with the same structure, but translated
  * content.
  *
- * Copyright © 2016-2018, HealthTap, Inc.
+ * Copyright © 2016-2018, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,8 @@ var fs = require("fs");
 var path = require("path");
 var jsyaml = require("js-yaml");
 
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var ContextResourceString = require("./ContextResourceString.js");
-var Set = require("./Set.js");
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js")
 var log4js = require("log4js");

--- a/lib/YamlFileType.js
+++ b/lib/YamlFileType.js
@@ -1,7 +1,7 @@
 /*
  * YamlFileType.js - manages a collection of yaml files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
-var path = require("path");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 

--- a/lib/YamlResourceFile.js
+++ b/lib/YamlResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * YamlResourceFile.js - represents a yaml resource file
  *
- * Copyright © 2016-2017, 2020  HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,10 @@
 
 var fs = require("fs");
 var path = require("path");
-//var YAML = require("yaml-js");
-//var yamljs = require("yamljs");
 var jsyaml = require("js-yaml");
 
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var ContextResourceString = require("./ContextResourceString.js");
-var ResourceArray = require("./ResourceArray.js");
-var ResourcePlural = require("./ResourcePlural.js");
-var Set = require("./Set.js");
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js")
 var log4js = require("log4js");

--- a/lib/YamlResourceFileType.js
+++ b/lib/YamlResourceFileType.js
@@ -1,7 +1,7 @@
 /*
  * YamlResourceFileType.js - manages a collection of yaml resource files
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,10 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale.js");
 var log4js = require("log4js");
 
-var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
 var YamlResourceFile = require("./YamlResourceFile.js");
 var FileType = require("./FileType.js");

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 /*
  * utils.js - various utilities
  *
- * Copyright © 2016-2019, HealthTap, Inc.
+ * Copyright © 2016-2020, HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
  */
 
 var fs = require("fs");
-var ilib = require("ilib");
 var Locale = require("ilib/lib/Locale");
 var isAlnum = require("ilib/lib/isAlnum.js");
 var isIdeo = require("ilib/lib/isIdeo.js");

--- a/loctool.js
+++ b/loctool.js
@@ -40,7 +40,7 @@ var exitValue = 0;
 
 function getVersion() {
     var pkg = require("./package.json");
-    return "loctool v" + pkg.version + " Copyright (c) 2016-2017, 2019, HealthTap, Inc. and JEDLSoft";
+    return "loctool v" + pkg.version + " Copyright (c) 2016-2017, 2019-2020, HealthTap, Inc. and JEDLSoft";
 }
 
 function usage() {

--- a/package.json
+++ b/package.json
@@ -81,10 +81,9 @@
         "remark-parse": "^6.0.3",
         "remark-rehype": "^4.0.1",
         "remark-stringify": "^6.0.4",
-        "tap": "^14.10.7",
         "unified": "^7.1.0",
+        "unist-builder": "^2.0.3",
         "unist-util-filter": "^1.0.2",
-        "unist-util-map": "^1.0.5",
         "xml2json": "^0.11.2"
     },
     "devDependencies": {


### PR DESCRIPTION
- reduce dependencies by removing unused require()
- update copyright notices
- remove unneeded whitespace
- clean up dependencies as well