### PR TITLE
Add a function to delete registered resource class which cause an error while running tcs

### DIFF
--- a/lib/ResourceFactory.js
+++ b/lib/ResourceFactory.js
@@ -92,6 +92,7 @@ ResourceFactory.registerDataType = function(datatype, resClass, cls) {
 };
 
 /**
+ * Note) This is for passing unit tests. It's not intended to use general case.
  * Un Register the given data type to the given resource class.
  * @param {String} datatype the type to unregister
 */

--- a/lib/ResourceFactory.js
+++ b/lib/ResourceFactory.js
@@ -92,6 +92,18 @@ ResourceFactory.registerDataType = function(datatype, resClass, cls) {
 };
 
 /**
+ * Un Register the given data type to the given resource class.
+ * @param {String} datatype the type to unregister
+*/
+
+ResourceFactory.unregisterDataType = function(datatype) {
+    if (classHash[datatype]) {
+        delete classHash[datatype];
+        logger.trace("Datatype " + datatype + " resource class is unregisted ");
+    }
+};
+
+/**
  * Assign the given resource type name to the resource class for a particular
  * file type. The file type is the type of the resource being extracted,
  * such as "javascript" or "php", which comes from the file type plugin

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -41,7 +41,11 @@ function diff(a, b) {
     }
 }
 
-module.exports.xliff = {
+module.exports.xliff20 = {
+    setUp: function(callback) {
+        ResourceFactory.unregisterDataType("x-android-resource");
+        callback();
+    },
     testXliff20Constructor: function(test) {
         test.expect(1);
 
@@ -2515,10 +2519,9 @@ module.exports.xliff = {
     testXliff20AddTranslationUnitRightResourceTypesContextString: function(test) {
         test.expect(5);
 
-        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
-
         var x = new Xliff({version: "2.0"});
         test.ok(x);
+        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
 
         x.addTranslationUnit(new TranslationUnit({
             "source": "a",

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -2519,9 +2519,10 @@ module.exports.xliff20 = {
     testXliff20AddTranslationUnitRightResourceTypesContextString: function(test) {
         test.expect(5);
 
+        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
+
         var x = new Xliff({version: "2.0"});
         test.ok(x);
-        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
 
         x.addTranslationUnit(new TranslationUnit({
             "source": "a",


### PR DESCRIPTION
Test files between testXliff.js and testXliff2.0 had been the same module export name. So tests were not run all cases properly. 
I've fixed the testXliff20 name, then it fails some test case due to the following line.
`ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);`
https://github.com/iLib-js/loctool/blob/development/test/testXliff.js#L2517 line.

```
error: 
TypeError: classes[resClass] is not a constructor
    at ResourceFactory (/home/goun/Source/opensource_iLib/loctool2/lib/ResourceFactory.js:70:12)
    at Xliff.convertTransUnit (/home/goun/Source/opensource_iLib/loctool2/lib/Xliff.js:331:15)
    at Xliff.getTranslationSet (/home/goun/Source/opensource_iLib/loctool2/lib/Xliff.js:411:32)
    at Xliff.getResources (/home/goun/Source/opensource_iLib/loctool2/lib/Xliff.js:291:20)
    at Object.testXliff20DeserializeWithArraysAndTranslations (/home/goun/Source/opensource_iLib/loctool2/test/testXliff20.js:1757:25)
```

In order to fix it, I've newly defined `unregisterDataType` and fixed codes to run test cases correctly.
Not sure if it's a proper approach or not.