### PR TITLE
Fix to work split mode properly with xliff 2.0 format 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,121 +19,121 @@ limitations under the License.
 -->
 
 <project name="loctool" default="test">
-	<!-- =================================================================== -->
-	<!-- properties                                                          -->
-	<!-- =================================================================== -->
+    <!-- =================================================================== -->
+    <!-- properties                                                          -->
+    <!-- =================================================================== -->
 
-	<!-- Give user a chance to override properties without editing this file -->
-	<!-- (and without typing -D each time it compiles it)                    -->
-	<property file="build.properties"/>
-	<property file="version.properties"/>
+    <!-- Give user a chance to override properties without editing this file -->
+    <!-- (and without typing -D each time it compiles it)                    -->
+    <property file="build.properties"/>
+    <property file="version.properties"/>
 
-	<!-- Properties that can be overridden -->
-	<!-- directories -->
-	<property name="build.base"						value="${basedir}"/>
-	<property name="build.lib"						value="${build.base}/lib"/>
-	<property name="build.test"						value="${build.base}/test"/>
-	<property name="build.jsdoc"                    value="${build.base}/jsdoc"/>
+    <!-- Properties that can be overridden -->
+    <!-- directories -->
+    <property name="build.base"						value="${basedir}"/>
+    <property name="build.lib"						value="${build.base}/lib"/>
+    <property name="build.test"						value="${build.base}/test"/>
+    <property name="build.jsdoc"                    value="${build.base}/jsdoc"/>
 
-	<target name="clean" description="Remove all generated files to start from scratch">
-		<delete dir="${build.jsdoc}"/>
-	</target>
+    <target name="clean" description="Remove all generated files to start from scratch">
+        <delete dir="${build.jsdoc}"/>
+    </target>
 
-	<target name="prepare" description="Prepare all directories that are needed before the project can be built">
-	</target>
+    <target name="prepare" description="Prepare all directories that are needed before the project can be built">
+    </target>
 
-	<target name="testjsdoc" description="test whether or not the jsdocs need to be rebuilt">
-		<uptodate
+    <target name="testjsdoc" description="test whether or not the jsdocs need to be rebuilt">
+        <uptodate
                 property="jsdoc.not.needed"
                 targetfile="${build.jsdoc}/index.html">
-			<srcfiles dir="${build.lib}" includes="**/*.js"/>
-		</uptodate>
-	</target>
+            <srcfiles dir="${build.lib}" includes="**/*.js"/>
+        </uptodate>
+    </target>
 
-	<target name="doc"
+    <target name="doc"
             depends="prepare,testjsdoc"
             description="creates jsdoc for all local javascript files in this project"
             unless="jsdoc.not.needed">
-		<delete dir="${build.jsdoc}"/>
-		<mkdir dir="${build.jsdoc}"/>
-		<echo>Executing jsdoc ... </echo>
-		<java dir="${build.base}" jar="${JSDOCDIR}/jsrun.jar" fork="true">
-			<jvmarg value="-Djsdoc.dir=${JSDOCDIR}"/>
-			<jvmarg value="-Djsdoc.template.dir=${JSDOCDIR}/templates/jsdoc"/>
-			<jvmarg value="-Xmx1024m"/>
-			<jvmarg value="-XX:MaxPermSize=96m"/>
-			<arg value="${JSDOCDIR}/app/run.js"/>
-			<arg value="--directory=${build.jsdoc}"/>
-			<arg value="--recurse=100"/>
-			<arg value="--encoding=utf-8"/>
-			<arg value="${build.lib}"/>
-		</java>
-	</target>
+        <delete dir="${build.jsdoc}"/>
+        <mkdir dir="${build.jsdoc}"/>
+        <echo>Executing jsdoc ... </echo>
+        <java dir="${build.base}" jar="${JSDOCDIR}/jsrun.jar" fork="true">
+            <jvmarg value="-Djsdoc.dir=${JSDOCDIR}"/>
+            <jvmarg value="-Djsdoc.template.dir=${JSDOCDIR}/templates/jsdoc"/>
+            <jvmarg value="-Xmx1024m"/>
+            <jvmarg value="-XX:MaxPermSize=96m"/>
+            <arg value="${JSDOCDIR}/app/run.js"/>
+            <arg value="--directory=${build.jsdoc}"/>
+            <arg value="--recurse=100"/>
+            <arg value="--encoding=utf-8"/>
+            <arg value="${build.lib}"/>
+        </java>
+    </target>
 
-	<macrodef name="debug.loctool.base" description="Debug the whole loc tool">
-		<attribute name="dir"/>
-		<sequential>
-			<echo>Dir is @{dir}</echo>
-			<exec osfamily="unix" executable="${node}/bin/node" dir="@{dir}" failifexecutionfails="true" failonerror="true">
-				<env key="PATH" path="${node}/bin:${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="--inspect-brk"/>
-				<arg line="../loctool/loctool.js"/>
-			</exec>
-			<exec osfamily="windows" executable="${node}/bin/node.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
-				<env key="PATH" path="${node}/bin;${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="--inspect-brk"/>
-				<arg line="../loctool/loctool.js"/>
-			</exec>
-		</sequential>
-	</macrodef>
-	
-	<target name="debug.loctool">
-		<debug.loctool.base dir="${user.dir}" />
-	</target>
+    <macrodef name="debug.loctool.base" description="Debug the whole loc tool">
+        <attribute name="dir"/>
+        <sequential>
+            <echo>Dir is @{dir}</echo>
+            <exec osfamily="unix" executable="${node}/bin/node" dir="@{dir}" failifexecutionfails="true" failonerror="true">
+                <env key="PATH" path="${node}/bin:${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="--inspect-brk"/>
+                <arg line="../loctool/loctool.js"/>
+            </exec>
+            <exec osfamily="windows" executable="${node}/bin/node.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
+                <env key="PATH" path="${node}/bin;${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="--inspect-brk"/>
+                <arg line="../loctool/loctool.js"/>
+            </exec>
+        </sequential>
+    </macrodef>
 
-	<macrodef name="run">
-		<attribute name="executable"/>
-		<attribute name="script"/>
-		<attribute name="args"/>
-		<attribute name="dir"/>
-		<sequential>
-			<exec osfamily="unix" executable="@{executable}" dir="@{dir}" failifexecutionfails="true" failonerror="true">
-				<env key="PATH" path="${node}/bin:${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="@{args}"/>
-				<arg line="@{script}"/>
-			</exec>
-			<exec osfamily="windows" executable="@{executable}.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
-				<env key="PATH" path="${node}/bin;${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="@{args}"/>
-				<arg line="@{script}"/>
-			</exec>
-		</sequential>
-	</macrodef>
+    <target name="debug.loctool">
+        <debug.loctool.base dir="${user.dir}" />
+    </target>
 
-	<macrodef name="debug">
-		<attribute name="script"/>
-		<attribute name="dir"/>
-		<sequential>
-			<exec osfamily="unix" executable="${node}/bin/node" dir="@{dir}" failifexecutionfails="true" failonerror="true">
-				<env key="PATH" path="${node}/bin:${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="--inspect-brk"/>
-				<arg line="${nodeunit}/bin/nodeunit"/>
-				<arg line="@{script}"/>
-			</exec>
-			<exec osfamily="windows" executable="${node}/bin/node.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
-				<env key="PATH" path="${node}/bin;${env.PATH}"/>
-				<env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
-				<arg line="--inspect-brk"/>
-				<arg line="${nodeunit}/bin/nodeunit"/>
-				<arg line="@{script}"/>
-			</exec>
-		</sequential>
-	</macrodef>
+    <macrodef name="run">
+        <attribute name="executable"/>
+        <attribute name="script"/>
+        <attribute name="args"/>
+        <attribute name="dir"/>
+        <sequential>
+            <exec osfamily="unix" executable="@{executable}" dir="@{dir}" failifexecutionfails="true" failonerror="true">
+                <env key="PATH" path="${node}/bin:${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="@{args}"/>
+                <arg line="@{script}"/>
+            </exec>
+            <exec osfamily="windows" executable="@{executable}.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
+                <env key="PATH" path="${node}/bin;${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="@{args}"/>
+                <arg line="@{script}"/>
+            </exec>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="debug">
+        <attribute name="script"/>
+        <attribute name="dir"/>
+        <sequential>
+            <exec osfamily="unix" executable="${node}/bin/node" dir="@{dir}" failifexecutionfails="true" failonerror="true">
+                <env key="PATH" path="${node}/bin:${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="--inspect-brk"/>
+                <arg line="${nodeunit}/bin/nodeunit"/>
+                <arg line="@{script}"/>
+            </exec>
+            <exec osfamily="windows" executable="${node}/bin/node.exe" dir="@{dir}" failifexecutionfails="true"  failonerror="true">
+                <env key="PATH" path="${node}/bin;${env.PATH}"/>
+                <env key="LOG4JS_CONFIG" value="${build.test}/log4js.json"/>
+                <arg line="--inspect-brk"/>
+                <arg line="${nodeunit}/bin/nodeunit"/>
+                <arg line="@{script}"/>
+            </exec>
+        </sequential>
+    </macrodef>
 
     <target name="test.resource" description="Run only the resource tests">
         <run script="${build.test}/testResource.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
@@ -143,105 +143,105 @@ limitations under the License.
         <debug script="${build.test}/testResource.js" dir="${build.test}"/>
     </target>
 
-	<target name="test.resourcestring" description="Run only the resource string tests">
-		<run script="${build.test}/testResourceString.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
-	</target>
+    <target name="test.resourcestring" description="Run only the resource string tests">
+        <run script="${build.test}/testResourceString.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
 
-	<target name="debug.resourcestring" description="Debug only the resource string tests">
-		<debug script="${build.test}/testResourceString.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.resourcestring" description="Debug only the resource string tests">
+        <debug script="${build.test}/testResourceString.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.resourcearray" description="Run only the resource array tests">
-		<run script="${build.test}/testResourceArray.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
-	</target>
+    <target name="test.resourcearray" description="Run only the resource array tests">
+        <run script="${build.test}/testResourceArray.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
 
-	<target name="debug.resourcearray" description="Debug only the resource array tests">
-		<debug script="${build.test}/testResourceArray.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.resourcearray" description="Debug only the resource array tests">
+        <debug script="${build.test}/testResourceArray.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.resourceplural" description="Run only the plural resource tests">
-		<run script="${build.test}/testResourcePlural.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
-	</target>
+    <target name="test.resourceplural" description="Run only the plural resource tests">
+        <run script="${build.test}/testResourcePlural.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
 
-	<target name="debug.resourceplural" description="Debug only the plural resource tests">
-		<debug script="${build.test}/testResourcePlural.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.resourceplural" description="Debug only the plural resource tests">
+        <debug script="${build.test}/testResourcePlural.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.translationset" description="Run only the translation set tests">
-		<run script="${build.test}/testTranslationSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
-	</target>
+    <target name="test.translationset" description="Run only the translation set tests">
+        <run script="${build.test}/testTranslationSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
 
-	<target name="debug.translationset" description="Debug only the translation set tests">
-		<debug script="${build.test}/testTranslationSet.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.translationset" description="Debug only the translation set tests">
+        <debug script="${build.test}/testTranslationSet.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.set" description="Run only the set tests">
-		<run script="${build.test}/testSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
-	</target>
+    <target name="test.set" description="Run only the set tests">
+        <run script="${build.test}/testSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.base}" args="" />
+    </target>
 
-	<target name="test.javafile" description="Run only the java file tests">
-		<run script="${build.test}/testJavaFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javafile" description="Run only the java file tests">
+        <run script="${build.test}/testJavaFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javafile" description="Debug only the java file tests">
-		<debug script="${build.test}/testJavaFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javafile" description="Debug only the java file tests">
+        <debug script="${build.test}/testJavaFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.javafiletype" description="Run only the java file type tests">
-		<run script="${build.test}/testJavaFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javafiletype" description="Run only the java file type tests">
+        <run script="${build.test}/testJavaFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javafiletype" description="Debug only the java file type tests">
-		<debug script="${build.test}/testJavaFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javafiletype" description="Debug only the java file type tests">
+        <debug script="${build.test}/testJavaFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.dbtranslationset" description="Run only the database translation set tests">
-		<run script="${build.test}/testDBTranslationSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.dbtranslationset" description="Run only the database translation set tests">
+        <run script="${build.test}/testDBTranslationSet.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="test.androidlayoutfile" description="Run only the Android layout file tests">
-		<run script="${build.test}/testAndroidLayoutFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidlayoutfile" description="Run only the Android layout file tests">
+        <run script="${build.test}/testAndroidLayoutFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidlayoutfile" description="Debug only the android layout file tests">
-		<debug script="${build.test}/testAndroidLayoutFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidlayoutfile" description="Debug only the android layout file tests">
+        <debug script="${build.test}/testAndroidLayoutFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.androidlayoutfiletype" description="Run only the Android layout file type tests">
-		<run script="${build.test}/testAndroidLayoutFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidlayoutfiletype" description="Run only the Android layout file type tests">
+        <run script="${build.test}/testAndroidLayoutFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidlayoutfiletype" description="Debug only the android layout file type tests">
-		<debug script="${build.test}/testAndroidLayoutFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidlayoutfiletype" description="Debug only the android layout file type tests">
+        <debug script="${build.test}/testAndroidLayoutFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.androidresourcefile" description="Run only the Android resource file tests">
-		<run script="${build.test}/testAndroidResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidresourcefile" description="Run only the Android resource file tests">
+        <run script="${build.test}/testAndroidResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidresourcefile" description="Debug only the android resource file tests">
-		<debug script="${build.test}/testAndroidResourceFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidresourcefile" description="Debug only the android resource file tests">
+        <debug script="${build.test}/testAndroidResourceFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.androidresourcefiletype" description="Run only the Android resource file type tests">
-		<run script="${build.test}/testAndroidResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidresourcefiletype" description="Run only the Android resource file type tests">
+        <run script="${build.test}/testAndroidResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidresourcefiletype" description="Debug only the android resource file type tests">
-		<debug script="${build.test}/testAndroidResourceFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidresourcefiletype" description="Debug only the android resource file type tests">
+        <debug script="${build.test}/testAndroidResourceFileType.js" dir="${build.test}"/>
+    </target>
 
     <target name="test.generatemode" description="Run only the generate mode tests">
         <run script="${build.test}/testGenerateMode.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
     </target>
 
-	<target name="test.xliff" description="Run only the xliff tests">
+    <target name="test.xliff" description="Run only the xliff tests">
         <run script="${build.test}/testXliff.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    </target>
 
-	<target name="debug.xliff" description="Debug only the tests for the xliff object">
+    <target name="debug.xliff" description="Debug only the tests for the xliff object">
         <debug script="${build.test}/testXliff.js" dir="${build.test}"/>
-	</target>
+    </target>
 
     <target name="test.xliff2" description="Run only the xliff 2.0 tests">
         <run script="${build.test}/testXliff20.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
@@ -251,41 +251,45 @@ limitations under the License.
         <run script="${build.test}/testXliffMerge.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
     </target>
 
+    <target name="test.xliffsplit" description="Run only the xliff merge tests">
+        <run script="${build.test}/testXliffSplit.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
     <target name="debug.xliff2" description="Debug only the tests for the xliff 2.0 object">
         <debug script="${build.test}/testXliff20.js" dir="${build.test}"/>
     </target>
 
-	<target name="test.localrepository" description="Run only the tests for the local repository">
-		<run script="${build.test}/testLocalRepository.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.localrepository" description="Run only the tests for the local repository">
+        <run script="${build.test}/testLocalRepository.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.localrepository" description="Debug only the tests for the local repository">
-		<debug script="${build.test}/testLocalRepository.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.localrepository" description="Debug only the tests for the local repository">
+        <debug script="${build.test}/testLocalRepository.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.utils" description="Run only the tests for the utils">
-		<run script="${build.test}/testUtils.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.utils" description="Run only the tests for the utils">
+        <run script="${build.test}/testUtils.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.utils" description="Debug only the tests for the utils">
-		<debug script="${build.test}/testUtils.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.utils" description="Debug only the tests for the utils">
+        <debug script="${build.test}/testUtils.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.javascriptfile" description="Run only the tests for the JavaScript file object">
-		<run script="${build.test}/testJavaScriptFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javascriptfile" description="Run only the tests for the JavaScript file object">
+        <run script="${build.test}/testJavaScriptFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javascriptfile" description="Debug only the tests for the JavaScript file object">
-		<debug script="${build.test}/testJavaScriptFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javascriptfile" description="Debug only the tests for the JavaScript file object">
+        <debug script="${build.test}/testJavaScriptFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.javascriptfiletype" description="Run only the tests for the JavaScript file type">
-		<run script="${build.test}/testJavaScriptFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javascriptfiletype" description="Run only the tests for the JavaScript file type">
+        <run script="${build.test}/testJavaScriptFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javascriptfiletype" description="Debug only the tests for the JavaScript file type">
-		<debug script="${build.test}/testJavaScriptFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javascriptfiletype" description="Debug only the tests for the JavaScript file type">
+        <debug script="${build.test}/testJavaScriptFileType.js" dir="${build.test}"/>
+    </target>
 
     <target name="test.htmlfile" description="Run only the tests for the HTML file">
         <run script="${build.test}/testHTMLFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
@@ -303,21 +307,21 @@ limitations under the License.
         <debug script="${build.test}/testHTMLFileType.js" dir="${build.test}"/>
     </target>
 
-	<target name="test.htmltemplatefile" description="Run only the tests for the HTML templates">
-		<run script="${build.test}/testHTMLTemplateFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.htmltemplatefile" description="Run only the tests for the HTML templates">
+        <run script="${build.test}/testHTMLTemplateFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.htmltemplatefile" description="Debug only the tests for the HTML templates">
-		<debug script="${build.test}/testHTMLTemplateFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.htmltemplatefile" description="Debug only the tests for the HTML templates">
+        <debug script="${build.test}/testHTMLTemplateFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.htmltemplatefiletype" description="Run only the tests for the HTML template file type">
-		<run script="${build.test}/testHTMLTemplateFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.htmltemplatefiletype" description="Run only the tests for the HTML template file type">
+        <run script="${build.test}/testHTMLTemplateFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.htmltemplatefiletype" description="Debug only the tests for the HTML template file type">
-		<debug script="${build.test}/testHTMLTemplateFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.htmltemplatefiletype" description="Debug only the tests for the HTML template file type">
+        <debug script="${build.test}/testHTMLTemplateFileType.js" dir="${build.test}"/>
+    </target>
 
     <target name="test.markdownfile" description="Run only the tests for the Markdown file">
         <run script="${build.test}/testMarkdownFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
@@ -335,173 +339,173 @@ limitations under the License.
         <debug script="${build.test}/testMarkdownFileType.js" dir="${build.test}"/>
     </target>
 
-	<target name="test.objectivecfile" description="Run only the tests for the Objective C file">
-		<run script="${build.test}/testObjectiveCFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.objectivecfile" description="Run only the tests for the Objective C file">
+        <run script="${build.test}/testObjectiveCFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.objectivecfile" description="Debug only the tests for the Objective C file">
-		<debug script="${build.test}/testObjectiveCFile.js" dir="${build.test}"/>
-	</target>
-	
-	<target name="test.objectivecfiletype" description="Run only the tests for the Objective C file type">
-		<run script="${build.test}/testObjectiveCFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="debug.objectivecfile" description="Debug only the tests for the Objective C file">
+        <debug script="${build.test}/testObjectiveCFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="debug.objectivecfiletype" description="Debug only the tests for the Objective C file type">
-		<debug script="${build.test}/testObjectiveCFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="test.objectivecfiletype" description="Run only the tests for the Objective C file type">
+        <run script="${build.test}/testObjectiveCFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="test.swiftfile" description="Run only the tests for the Swift file">
-		<run script="${build.test}/testSwiftFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="debug.objectivecfiletype" description="Debug only the tests for the Objective C file type">
+        <debug script="${build.test}/testObjectiveCFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="debug.swiftfile" description="Debug only the tests for the Swift file">
-		<debug script="${build.test}/testSwiftFile.js" dir="${build.test}"/>
-	</target>
-	
-	<target name="test.swiftfiletype" description="Run only the tests for the Swift file type">
-		<run script="${build.test}/testSwiftFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.swiftfile" description="Run only the tests for the Swift file">
+        <run script="${build.test}/testSwiftFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.swiftfiletype" description="Debug only the tests for the Swift file type">
-		<debug script="${build.test}/testSwiftFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.swiftfile" description="Debug only the tests for the Swift file">
+        <debug script="${build.test}/testSwiftFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.iosstringsfile" description="Run only the tests for the strings resource file">
-		<run script="${build.test}/testIosStringsFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.swiftfiletype" description="Run only the tests for the Swift file type">
+        <run script="${build.test}/testSwiftFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.iosstringsfile" description="Debug only the tests for the strings resource file">
-		<debug script="${build.test}/testIosStringsFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.swiftfiletype" description="Debug only the tests for the Swift file type">
+        <debug script="${build.test}/testSwiftFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.iosstringsfiletype" description="Run only the tests for the strings resource file type">
-		<run script="${build.test}/testIosStringsFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.iosstringsfile" description="Run only the tests for the strings resource file">
+        <run script="${build.test}/testIosStringsFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.iosstringsfiletype" description="Debug only the tests for the strings resource file type">
-		<debug script="${build.test}/testIosStringsFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.iosstringsfile" description="Debug only the tests for the strings resource file">
+        <debug script="${build.test}/testIosStringsFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.javascriptresourcefile" description="Run only the tests for the JavaScript resource file object">
-		<run script="${build.test}/testJavaScriptResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.iosstringsfiletype" description="Run only the tests for the strings resource file type">
+        <run script="${build.test}/testIosStringsFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javascriptresourcefile" description="Debug only the tests for the JavaScript resource file object">
-		<debug script="${build.test}/testJavaScriptResourceFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.iosstringsfiletype" description="Debug only the tests for the strings resource file type">
+        <debug script="${build.test}/testIosStringsFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.javascriptresourcefiletype" description="Run only the tests for the JavaScript resource file type object">
-		<run script="${build.test}/testJavaScriptResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javascriptresourcefile" description="Run only the tests for the JavaScript resource file object">
+        <run script="${build.test}/testJavaScriptResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.javascriptresourcefiletype" description="Debug only the tests for the JavaScript resource file type object">
-		<debug script="${build.test}/testJavaScriptResourceFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javascriptresourcefile" description="Debug only the tests for the JavaScript resource file object">
+        <debug script="${build.test}/testJavaScriptResourceFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.yamlfile" description="Run only the tests for the Yaml file object">
-		<run script="${build.test}/testYamlFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.javascriptresourcefiletype" description="Run only the tests for the JavaScript resource file type object">
+        <run script="${build.test}/testJavaScriptResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.yamlfile" description="Debug only the tests for the Yaml file object">
-		<debug script="${build.test}/testYamlFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.javascriptresourcefiletype" description="Debug only the tests for the JavaScript resource file type object">
+        <debug script="${build.test}/testJavaScriptResourceFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.yamlfiletype" description="Run only the tests for the Yaml file type object">
-		<run script="${build.test}/testYamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.yamlfile" description="Run only the tests for the Yaml file object">
+        <run script="${build.test}/testYamlFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.yamlfiletype" description="Debug only the tests for the Yaml file type object">
-		<debug script="${build.test}/testYamlFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.yamlfile" description="Debug only the tests for the Yaml file object">
+        <debug script="${build.test}/testYamlFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.yamlresourcefile" description="Run only the tests for the Yaml resource file object">
-		<run script="${build.test}/testYamlResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.yamlfiletype" description="Run only the tests for the Yaml file type object">
+        <run script="${build.test}/testYamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.yamlresourcefile" description="Debug only the tests for the Yaml resource file object">
-		<debug script="${build.test}/testYamlResourceFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.yamlfiletype" description="Debug only the tests for the Yaml file type object">
+        <debug script="${build.test}/testYamlFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.yamlresourcefiletype" description="Run only the tests for the Yaml resource file type object">
-		<run script="${build.test}/testYamlResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.yamlresourcefile" description="Run only the tests for the Yaml resource file object">
+        <run script="${build.test}/testYamlResourceFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.yamlresourcefiletype" description="Debug only the tests for the Yaml resource file type object">
-		<debug script="${build.test}/testYamlResourceFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.yamlresourcefile" description="Debug only the tests for the Yaml resource file object">
+        <debug script="${build.test}/testYamlResourceFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.csv" description="Run only the tests for the csv object">
-		<run script="${build.test}/testCSV.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.yamlresourcefiletype" description="Run only the tests for the Yaml resource file type object">
+        <run script="${build.test}/testYamlResourceFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.csv" description="Debug only the tests for the csv object">
-		<debug script="${build.test}/testCSV.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.yamlresourcefiletype" description="Debug only the tests for the Yaml resource file type object">
+        <debug script="${build.test}/testYamlResourceFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.csvfile" description="Run only the tests for the csv file object">
-		<run script="${build.test}/testCSVFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.csv" description="Run only the tests for the csv object">
+        <run script="${build.test}/testCSV.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.csvfile" description="Debug only the tests for the csv file object">
-		<debug script="${build.test}/testCSVFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.csv" description="Debug only the tests for the csv object">
+        <debug script="${build.test}/testCSV.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.rubyfile" description="Run only the tests for the Ruby file object">
-		<run script="${build.test}/testRubyFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.csvfile" description="Run only the tests for the csv file object">
+        <run script="${build.test}/testCSVFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.rubyfile" description="Debug only the tests for the Ruby file object">
-		<debug script="${build.test}/testRubyFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.csvfile" description="Debug only the tests for the csv file object">
+        <debug script="${build.test}/testCSVFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.rubyfiletype" description="Run only the tests for the Ruby file type object">
-		<run script="${build.test}/testRubyFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.rubyfile" description="Run only the tests for the Ruby file object">
+        <run script="${build.test}/testRubyFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.rubyfiletype" description="Debug only the tests for the Ruby file type object">
-		<debug script="${build.test}/testRubyFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.rubyfile" description="Debug only the tests for the Ruby file object">
+        <debug script="${build.test}/testRubyFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.hamlfile" description="Run only the haml file tests">
-		<run script="${build.test}/testHamlFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.rubyfiletype" description="Run only the tests for the Ruby file type object">
+        <run script="${build.test}/testRubyFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.hamlfile" description="Debug only the haml file tests">
-		<debug script="${build.test}/testHamlFile.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.rubyfiletype" description="Debug only the tests for the Ruby file type object">
+        <debug script="${build.test}/testRubyFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.hamlfiletype" description="Run only the tests for the haml file type">
-		<run script="${build.test}/testHamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.hamlfile" description="Run only the haml file tests">
+        <run script="${build.test}/testHamlFile.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.hamlfiletype" description="Debug only the tests for the haml file type">
-		<debug script="${build.test}/testHamlFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.hamlfile" description="Debug only the haml file tests">
+        <debug script="${build.test}/testHamlFile.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.oldhamlfiletype" description="Run only the tests for the old haml file type">
-		<run script="${build.test}/testOldHamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.hamlfiletype" description="Run only the tests for the haml file type">
+        <run script="${build.test}/testHamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.oldhamlfiletype" description="Debug only the tests for the old haml file type">
-		<debug script="${build.test}/testOldHamlFileType.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.hamlfiletype" description="Debug only the tests for the haml file type">
+        <debug script="${build.test}/testHamlFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.pseudobritish" description="Run only the tests for the pseudo british localizer">
-		<run script="${build.test}/testPseudoBritish.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.oldhamlfiletype" description="Run only the tests for the old haml file type">
+        <run script="${build.test}/testOldHamlFileType.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.pseudobritish" description="Debug only the tests for the pseudo british localizer">
-		<debug script="${build.test}/testPseudoBritish.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.oldhamlfiletype" description="Debug only the tests for the old haml file type">
+        <debug script="${build.test}/testOldHamlFileType.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.pseudocanadian" description="Run only the tests for the pseudo canadian localizer">
-		<run script="${build.test}/testPseudoCanadian.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.pseudobritish" description="Run only the tests for the pseudo british localizer">
+        <run script="${build.test}/testPseudoBritish.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.pseudocanadian" description="Debug only the tests for the pseudo canadian localizer">
-		<debug script="${build.test}/testPseudoCanadian.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.pseudobritish" description="Debug only the tests for the pseudo british localizer">
+        <debug script="${build.test}/testPseudoBritish.js" dir="${build.test}"/>
+    </target>
+
+    <target name="test.pseudocanadian" description="Run only the tests for the pseudo canadian localizer">
+        <run script="${build.test}/testPseudoCanadian.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.pseudocanadian" description="Debug only the tests for the pseudo canadian localizer">
+        <debug script="${build.test}/testPseudoCanadian.js" dir="${build.test}"/>
+    </target>
 
     <target name="test.project" description="Run only the tests for the project object">
         <run script="${build.test}/testProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
@@ -511,61 +515,61 @@ limitations under the License.
         <debug script="${build.test}/testProject.js" dir="${build.test}"/>
     </target>
 
-	<target name="test.projectfactory" description="Run only the tests for the project factory object">
-		<run script="${build.test}/testProjectFactory.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.projectfactory" description="Run only the tests for the project factory object">
+        <run script="${build.test}/testProjectFactory.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.projectfactory" description="Debug only the tests for the project factory object">
-		<debug script="${build.test}/testProjectFactory.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.projectfactory" description="Debug only the tests for the project factory object">
+        <debug script="${build.test}/testProjectFactory.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.pseudonewzealand" description="Run only the tests for the pseudo New Zealand localizer">
-		<run script="${build.test}/testPseudoNewZealand.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.pseudonewzealand" description="Run only the tests for the pseudo New Zealand localizer">
+        <run script="${build.test}/testPseudoNewZealand.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.pseudonewzealand" description="Debug only the tests for the pseudo New Zealand localizer">
-		<debug script="${build.test}/testPseudoNewZealand.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.pseudonewzealand" description="Debug only the tests for the pseudo New Zealand localizer">
+        <debug script="${build.test}/testPseudoNewZealand.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.pseudohant" description="Run only the tests for the pseudo Hant localizer">
-		<run script="${build.test}/testPseudoHant.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.pseudohant" description="Run only the tests for the pseudo Hant localizer">
+        <run script="${build.test}/testPseudoHant.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.pseudohant" description="Debug only the tests for the pseudo Hant localizer">
-		<debug script="${build.test}/testPseudoHant.js" dir="${build.test}"/>
-	</target>
-	
-	<target name="test.buildgradle" description="Run only the tests for the build gradle object">
-		<run script="${build.test}/testBuildGradle.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="debug.pseudohant" description="Debug only the tests for the pseudo Hant localizer">
+        <debug script="${build.test}/testPseudoHant.js" dir="${build.test}"/>
+    </target>
 
-	<target name="debug.buildgradle" description="Debug only the tests for the build gradle object">
-		<debug script="${build.test}/testBuildGradle.js" dir="${build.test}"/>
-	</target>
-	
-	<target name="test.androidproject" description="Run only the tests for the Android project object">
-		<run script="${build.test}/testAndroidProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.buildgradle" description="Run only the tests for the build gradle object">
+        <run script="${build.test}/testBuildGradle.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidproject" description="Debug only the tests for the Android project object">
-		<debug script="${build.test}/testAndroidProject.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.buildgradle" description="Debug only the tests for the build gradle object">
+        <debug script="${build.test}/testBuildGradle.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.androidflavors" description="Run only the tests for the Android flavors object">
-		<run script="${build.test}/testAndroidFlavors.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidproject" description="Run only the tests for the Android project object">
+        <run script="${build.test}/testAndroidProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.androidflavors" description="Debug only the tests for the Android flavors object">
-		<debug script="${build.test}/testAndroidFlavors.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidproject" description="Debug only the tests for the Android project object">
+        <debug script="${build.test}/testAndroidProject.js" dir="${build.test}"/>
+    </target>
 
-	<target name="test.webproject" description="Run only the tests for the Web project object">
-		<run script="${build.test}/testWebProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
-	</target>
+    <target name="test.androidflavors" description="Run only the tests for the Android flavors object">
+        <run script="${build.test}/testAndroidFlavors.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
 
-	<target name="debug.webproject" description="Debug only the tests for the Web project object">
-		<debug script="${build.test}/testWebProject.js" dir="${build.test}"/>
-	</target>
+    <target name="debug.androidflavors" description="Debug only the tests for the Android flavors object">
+        <debug script="${build.test}/testAndroidFlavors.js" dir="${build.test}"/>
+    </target>
+
+    <target name="test.webproject" description="Run only the tests for the Web project object">
+        <run script="${build.test}/testWebProject.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.webproject" description="Debug only the tests for the Web project object">
+        <debug script="${build.test}/testWebProject.js" dir="${build.test}"/>
+    </target>
 
     <target name="test.pseudofactory" description="Run only the tests for the PseudoFactory object">
         <run script="${build.test}/testPseudoFactory.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
@@ -607,57 +611,57 @@ limitations under the License.
         <debug script="${build.test}/testResourceFactory.js" dir="${build.test}"/>
     </target>
 
-	<target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.xliff2,test.xliffmerge,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject,test.project">
-	</target>
+    <target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.xliff2,test.xliffmerge,test.xliffsplit,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject,test.project">
+    </target>
 
-	<macrodef name="runsql">
-		<attribute name="file"/>
-		<attribute name="username"/>
-		<attribute name="password"/>
-		<attribute name="host"/>
-		<attribute name="database"/>
-		<sequential>
-			<exec osfamily="unix" executable="mysql" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{file}">
-				<arg line="-u" />
-				<arg line="@{username}" />
-				<arg line="@{password}" />
-				<arg line="-v" />
-				<arg line="--host=@{host}" />
-				<arg line="@{database}" />
-			</exec>
-			<exec osfamily="mac" executable="mysql" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{username}">
-				<arg line="-u" />
-				<arg line="@{username}" />
-				<arg line="@{password}" />
-				<arg line="-v" />
-				<arg line="--host=@{host}" />
-				<arg line="@{database}" />
-			</exec>
-			<exec osfamily="windows" executable="mysql.exe" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{file}">
-				<arg line="-u" />
-				<arg line="@{username}" />
-				<arg line="@{password}" />
-				<arg line="-v" />
-				<arg line="--host=@{host}" />
-				<arg line="@{database}" />
-			</exec>
-		</sequential>
-	</macrodef>
+    <macrodef name="runsql">
+        <attribute name="file"/>
+        <attribute name="username"/>
+        <attribute name="password"/>
+        <attribute name="host"/>
+        <attribute name="database"/>
+        <sequential>
+            <exec osfamily="unix" executable="mysql" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{file}">
+                <arg line="-u" />
+                <arg line="@{username}" />
+                <arg line="@{password}" />
+                <arg line="-v" />
+                <arg line="--host=@{host}" />
+                <arg line="@{database}" />
+            </exec>
+            <exec osfamily="mac" executable="mysql" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{username}">
+                <arg line="-u" />
+                <arg line="@{username}" />
+                <arg line="@{password}" />
+                <arg line="-v" />
+                <arg line="--host=@{host}" />
+                <arg line="@{database}" />
+            </exec>
+            <exec osfamily="windows" executable="mysql.exe" dir="${build.base}/db" failifexecutionfails="true" failonerror="true" input="@{file}">
+                <arg line="-u" />
+                <arg line="@{username}" />
+                <arg line="@{password}" />
+                <arg line="-v" />
+                <arg line="--host=@{host}" />
+                <arg line="@{database}" />
+            </exec>
+        </sequential>
+    </macrodef>
 
-	<target name="createdb" description="Create the data base for the development environment">
-		<runsql username="root" password="-p" file="${build.base}/db/createdb.sql" host="localhost" database="" />
-	</target>
+    <target name="createdb" description="Create the data base for the development environment">
+        <runsql username="root" password="-p" file="${build.base}/db/createdb.sql" host="localhost" database="" />
+    </target>
 
-	<target name="create.schema" description="Create the schema in the data base for the development environment">
-		<runsql username="ht" password="--password=dYw@j45XKk#$" file="${build.base}/db/createschema.sql" host="localhost" database="translations" />
-	</target>
+    <target name="create.schema" description="Create the schema in the data base for the development environment">
+        <runsql username="ht" password="--password=dYw@j45XKk#$" file="${build.base}/db/createschema.sql" host="localhost" database="translations" />
+    </target>
 
-	<target name="cleardb" description="Initialize the data base for the development environment">
-		<runsql username="ht" 
+    <target name="cleardb" description="Initialize the data base for the development environment">
+        <runsql username="ht"
             password="--password=dYw@j45XKk#$" 
             file="${build.base}/db/cleardb.sql"
             host="localhost"
             database="translations"/>
-	</target>
+    </target>
 
 </project>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 017
+-------
+Published as version 2.10.1
+New Features:
+
+Bug Fixes:
+- Fixed a problem to split xliff 2.0 files
+
+
 Build 016
 -------
 
@@ -13,7 +22,7 @@ Bug Fixes:
 - Updated to remove duplicate locales in a list
 - Fixed a problem to parse xliff 2.0 files
 - Fixed a problem to merge xliff 2.0 files
-- Fixed a problem to split xliff 2.0 files
+
 
 Build 015
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -13,6 +13,7 @@ Bug Fixes:
 - Updated to remove duplicate locales in a list
 - Fixed a problem to parse xliff 2.0 files
 - Fixed a problem to merge xliff 2.0 files
+- Fixed a problem to split xliff 2.0 files
 
 Build 015
 -------

--- a/lib/XliffMerge.js
+++ b/lib/XliffMerge.js
@@ -23,10 +23,10 @@ const Xliff = require("./Xliff");
 var logger = log4js.getLogger("loctool.lib.XliffMerge");
 
 /**
- * Define the process of generate mode
+ * merge the given xliff files to the named outfile
  *
  * @param {Object} settings an object containing the current settings
- * @returns {boolean} true if the process is done
+ * @returns {XliffFile>} xliff file with data merged into one
  * 
  */
 var XliffMerge = function XliffMerge(settings) {
@@ -54,6 +54,12 @@ var XliffMerge = function XliffMerge(settings) {
     return target;
 }
 
+/**
+ * Write the resource file out to disk.
+ *
+ * @param {XliffFile>} xliff file with data merged into one
+ * @return {boolean} true if it is done
+ */
 XliffMerge.write = function (xliff) {
     if (!xliff) return;
     fs.writeFileSync(xliff.getPath(), xliff.serialize(), "utf-8");

--- a/lib/XliffSplit.js
+++ b/lib/XliffSplit.js
@@ -18,6 +18,7 @@
  */
 
 var fs = require("fs");
+var path = require("path");
 var Xliff = require("./Xliff.js");
 
 var log4js = require("log4js");
@@ -80,6 +81,12 @@ _parse1 = function(settings, superset) {
 _parse2 = function(settings, superset) {
     console.log("!!!!");
     var file, cache = {};
+    var output = settings.targetDir || ".";
+    var prjXliffPath;
+
+    if(!fs.existsSync(output)){
+        fs.mkdirSync(output);
+    }
 
     for(var i=0; i < superset.length;i++) {
         unit = superset[i];
@@ -87,9 +94,11 @@ _parse2 = function(settings, superset) {
         key = unit.project;
         console.log("key: ", key);
         file = cache[key];
+        prjXliffPath = path.join(output,key);
+
         if (!file) {
             file = cache[key] = new Xliff({
-                path: "./" + key + ".xliff",
+                path: path.join(prjXliffPath, unit.targetLocale + ".xliff"),
                 version: settings.xliffVersion
             });
             logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
@@ -114,8 +123,13 @@ XliffSplit.distribute = function(settings, superset) {
 }
 
 XliffSplit.write = function(cache) {
+    var xliffDir;
     for(key in cache) {
         file = cache[key];
+        xliffDir = path.dirname(file.getPath());
+        if(!fs.existsSync(xliffDir)){
+            fs.mkdirSync(xliffDir);
+        }
         logger.info("Writing " + file.getPath() + " ...");
         fs.writeFileSync(file.getPath(), file.serialize(), "utf-8");
     }

--- a/lib/XliffSplit.js
+++ b/lib/XliffSplit.js
@@ -1,0 +1,124 @@
+/*
+ * XliffSplit.js - test the split of Xliff object.
+ *
+ * Copyright © 2020, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var Xliff = require("./Xliff.js");
+
+var log4js = require("log4js");
+var logger = log4js.getLogger("loctool.lib.XliffSplit");
+
+/**
+ * Define the process of generate mode
+ *
+ * @param {Project} project the current project
+ * @returns {boolean} true if the process is done
+ * 
+ */
+var XliffSplit = function XliffSplit(settings) {
+    if (!settings) return;
+    
+    var superset = [];
+
+    settings.infiles.forEach(function (file) {
+        logger.info("Reading " + file + " ...");
+        if (fs.existsSync(file)) {
+            var data = fs.readFileSync(file, "utf-8");
+            var xliff = new Xliff({
+                version: settings.xliffVersion
+            });
+            xliff.deserialize(data);
+            superset = superset.concat(xliff.getTranslationUnits());
+        } else {
+            logger.warn("Could not open input file " + file);
+        }
+    });
+    return superset;
+}
+/* 
+* @private 
+*/
+_parse1 = function(settings, superset) {
+    var cache = {};
+
+    for (var i = 0; i < superset.length; i++) {
+        unit = superset[i];
+        logger.trace("unit to distribute is " + JSON.stringify(unit, undefined, 4));
+        key = (settings.splittype === "language") ? unit.targetLocale : unit.project;
+        logger.trace("key is " + key);
+        file = cache[key];
+        if (!file) {
+            file = cache[key] = new Xliff({
+                path: "./" + key + ".xliff",
+                version: settings.xliffVersion
+            });
+            logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
+        }
+        file.addTranslationUnit(unit);
+    }
+    return cache;
+}
+
+/* 
+* @private 
+*/
+_parse2 = function(settings, superset) {
+    console.log("!!!!");
+    var file, cache = {};
+
+    for(var i=0; i < superset.length;i++) {
+        unit = superset[i];
+        logger.trace("unit(xliff 2.0) to distribute is " + JSON.stringify(unit, undefined, 4));
+        key = unit.project;
+        console.log("key: ", key);
+        file = cache[key];
+        if (!file) {
+            file = cache[key] = new Xliff({
+                path: "./" + key + ".xliff",
+                version: settings.xliffVersion
+            });
+            logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
+        }
+        file.addTranslationUnit(unit);
+    }
+    return cache;
+}
+
+XliffSplit.distribute = function(settings, superset) {
+    if(!superset) return;
+    
+    logger.info("Distributing resources ...");
+    
+    if (settings.xliffVersion < 2) {
+        file = _parse1(settings, superset);
+    } else {
+        file = _parse2(settings, superset);
+    }
+
+    return file;    
+}
+
+XliffSplit.write = function(cache) {
+    for(key in cache) {
+        file = cache[key];
+        logger.info("Writing " + file.getPath() + " ...");
+        fs.writeFileSync(file.getPath(), file.serialize(), "utf-8");
+    }
+}
+
+module.exports = XliffSplit;

--- a/lib/XliffSplit.js
+++ b/lib/XliffSplit.js
@@ -54,9 +54,8 @@ var XliffSplit = function XliffSplit(settings) {
 /* 
 * @private 
 */
-_parse1 = function(settings, superset) {
+_parse1 = function(superset, settings) {
     var cache = {};
-
     for (var i = 0; i < superset.length; i++) {
         unit = superset[i];
         logger.trace("unit to distribute is " + JSON.stringify(unit, undefined, 4));
@@ -78,8 +77,7 @@ _parse1 = function(settings, superset) {
 /* 
 * @private 
 */
-_parse2 = function(settings, superset) {
-    console.log("!!!!");
+_parse2 = function(superset, settings) {
     var file, cache = {};
     var output = settings.targetDir || ".";
     var prjXliffPath;
@@ -88,11 +86,15 @@ _parse2 = function(settings, superset) {
         fs.mkdirSync(output);
     }
 
+    if (settings.splittype === "language") {
+        logger.error("When xliff is2.x case, It is only valid a split by project with a merged xliff form.\n");
+        return;
+    }
+
     for(var i=0; i < superset.length;i++) {
         unit = superset[i];
         logger.trace("unit(xliff 2.0) to distribute is " + JSON.stringify(unit, undefined, 4));
         key = unit.project;
-        console.log("key: ", key);
         file = cache[key];
         prjXliffPath = path.join(output,key);
 
@@ -108,15 +110,15 @@ _parse2 = function(settings, superset) {
     return cache;
 }
 
-XliffSplit.distribute = function(settings, superset) {
+XliffSplit.distribute = function(superset, settings) {
     if(!superset) return;
     
     logger.info("Distributing resources ...");
     
     if (settings.xliffVersion < 2) {
-        file = _parse1(settings, superset);
+        file = _parse1(superset, settings);
     } else {
-        file = _parse2(settings, superset);
+        file = _parse2(superset, settings);;
     }
 
     return file;    

--- a/lib/XliffSplit.js
+++ b/lib/XliffSplit.js
@@ -25,10 +25,10 @@ var log4js = require("log4js");
 var logger = log4js.getLogger("loctool.lib.XliffSplit");
 
 /**
- * Define the process of generate mode
+ * split the given xliff files by language or project
  *
- * @param {Project} project the current project
- * @returns {boolean} true if the process is done
+ * @param {Object} settings an object containing the current settings
+ * @returns {Array.<Object>} the translation units in xliff
  * 
  */
 var XliffSplit = function XliffSplit(settings) {
@@ -52,6 +52,7 @@ var XliffSplit = function XliffSplit(settings) {
     return superset;
 }
 /* 
+* Parse xliff 1.x version
 * @private 
 */
 _parse1 = function(superset, settings) {
@@ -75,6 +76,7 @@ _parse1 = function(superset, settings) {
 }
 
 /* 
+* Parse xliff 2.x version
 * @private 
 */
 _parse2 = function(superset, settings) {
@@ -110,20 +112,32 @@ _parse2 = function(superset, settings) {
     return cache;
 }
 
+/**
+ * split the given xliff files by language or project
+ *
+ * @param {Array.<Object>} superset the translation units in this xliff
+ * @param {Object} settings an object containing the current settings
+ * @returns {Object} classified set by given type
+ *
+ */
 XliffSplit.distribute = function(superset, settings) {
+    var file = {};
     if(!superset) return;
-    
     logger.info("Distributing resources ...");
-    
+
     if (settings.xliffVersion < 2) {
         file = _parse1(superset, settings);
     } else {
         file = _parse2(superset, settings);;
     }
-
     return file;    
 }
 
+/**
+ * Write the resource file out to disk.
+ * @param {Object} cache classified set by given type
+ * @return {boolean} true if it is done
+ */
 XliffSplit.write = function(cache) {
     var xliffDir;
     for(key in cache) {
@@ -135,6 +149,7 @@ XliffSplit.write = function(cache) {
         logger.info("Writing " + file.getPath() + " ...");
         fs.writeFileSync(file.getPath(), file.serialize(), "utf-8");
     }
+    return true;
 }
 
 module.exports = XliffSplit;

--- a/loctool.js
+++ b/loctool.js
@@ -32,6 +32,7 @@ var GenerateModeProcess = require("./lib/GenerateModeProcess.js");
 var Xliff = require("./lib/Xliff.js");
 
 var XliffMerge = require("./lib/XliffMerge.js");
+var XliffSplit = require("./lib/XliffSplit.js");
 
 // var Git = require("simple-git");
 
@@ -271,11 +272,11 @@ case "split":
         console.log("Error: must specify a split type and at least one input file.");
         usage();
     }
-    settings.splittype = options[3];
+    settings.splittype = options[3];/*
     if (settings.splittype !== "language" && settings.xliffVersion >= 2) {
         console.log("Error: you cannot split xliff 2.x files by project. They can only be split\nby language.\n\n");
         usage();
-    }
+    }*/
     settings.infiles = options.slice(4);
     settings.infiles.forEach(function (file) {
         if (!fs.existsSync(file)) {
@@ -500,48 +501,8 @@ try {
     case "split":
         settings.splittype = options[3];
         settings.infiles = options.slice(4);
-        var superset = [];
-
-        settings.infiles.forEach(function (file) {
-            logger.info("Reading " + file + " ...");
-            if (fs.existsSync(file)) {
-                var data = fs.readFileSync(file, "utf-8");
-                var xliff = new Xliff();
-                xliff.deserialize(data);
-                superset = superset.concat(xliff.getTranslationUnits());
-            } else {
-                logger.warn("Could not open input file " + file);
-            }
-        });
-
-        var cache = {};
-
-        var res, key, unit;
-        // var file, resources = superset.getAll();
-
-        logger.info("Distributing resources ...");
-        for (var i = 0; i < superset.length; i++) {
-            unit = superset[i];
-            logger.trace("unit to distribute is " + JSON.stringify(unit, undefined, 4));
-            key = (settings.splittype === "language") ? unit.targetLocale : unit.project;
-            logger.trace("key is " + key);
-            file = cache[key];
-            if (!file) {
-                file = cache[key] = new Xliff({
-                    path: "./" + key + ".xliff",
-                    version: settings.xliffVersion
-                });
-                logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
-            }
-            file.addTranslationUnit(unit);
-        }
-
-        for (key in cache) {
-            logger.info("Writing " + file.getPath() + " ...");
-            file = cache[key];
-
-            fs.writeFileSync(file.getPath(), file.serialize(), "utf-8");
-        }
+        var superset = XliffSplit(settings);
+        XliffSplit.write(XliffSplit.distribute(settings,superset));
         break;
 
     case "merge":

--- a/loctool.js
+++ b/loctool.js
@@ -272,11 +272,7 @@ case "split":
         console.log("Error: must specify a split type and at least one input file.");
         usage();
     }
-    settings.splittype = options[3];/*
-    if (settings.splittype !== "language" && settings.xliffVersion >= 2) {
-        console.log("Error: you cannot split xliff 2.x files by project. They can only be split\nby language.\n\n");
-        usage();
-    }*/
+    settings.splittype = options[3];
     settings.infiles = options.slice(4);
     settings.infiles.forEach(function (file) {
         if (!fs.existsSync(file)) {
@@ -502,7 +498,7 @@ try {
         settings.splittype = options[3];
         settings.infiles = options.slice(4);
         var superset = XliffSplit(settings);
-        XliffSplit.write(XliffSplit.distribute(settings,superset));
+        XliffSplit.write(XliffSplit.distribute(superset, settings));
         break;
 
     case "merge":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testGenerateMode.js
+++ b/test/testGenerateMode.js
@@ -85,11 +85,11 @@ module.exports.genmodemode = {
         test.expect(2);
         
         var genmode = new GenerateMode({
-            xliffsDir: "./testfiles/xliff20",
+            xliffsDir: "./testfiles/xliff20/app1",
         });
         test.ok(genmode);
         genmode.init();
-        test.equal(genmode.getResSize(), 4);
+        test.equal(genmode.getResSize(), 5);
         
         test.done();
     }

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -75,6 +75,7 @@ module.exports.files = [
     "testXliff.js",
     "testXliff20.js",
     "testXliffMerge.js",
+    "testXliffSplit.js",
     "testYamlFile.js",
     "testYamlFileType.js",
     "testYamlResourceFile.js",

--- a/test/testXliffSplit.js
+++ b/test/testXliffSplit.js
@@ -1,0 +1,77 @@
+/*
+ * testXliffSplit.js - test the split of Xliff object.
+ *
+ * Copyright © 2020 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!Xliff) {
+    var Xliff = require("../lib/Xliff.js");
+}
+
+if (!XliffSplit) {
+    var XliffSplit = require("../lib/XliffSplit.js");
+}
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+
+module.exports.xliffsplit = {
+    testXliffSplitnoParameter: function(test) {
+        test.expect(1);
+
+        var target = XliffSplit();
+        test.ok(!target);
+        test.done();
+    },
+    testXliffSplit: function(test) {
+        test.expect(1);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/merge-en-US.xliff",
+        ];
+        var target = XliffSplit(settings);
+        test.ok(target);
+        test.done();
+
+    },
+    testXliffSplitdistritue: function(test) {
+        test.expect(1);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/en-US.xliff",
+        ];
+        var superset = XliffSplit(settings);
+        var result = XliffSplit.distribute(superset);
+
+        test.ok(result);
+        test.done();
+
+    }
+};

--- a/test/testXliffSplit.js
+++ b/test/testXliffSplit.js
@@ -16,7 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+var fs = require("fs");
+var Path = require("path");
 if (!Xliff) {
     var Xliff = require("../lib/Xliff.js");
 }
@@ -25,16 +26,9 @@ if (!XliffSplit) {
     var XliffSplit = require("../lib/XliffSplit.js");
 }
 
-function diff(a, b) {
-    var min = Math.min(a.length, b.length);
-
-    for (var i = 0; i < min; i++) {
-        if (a[i] !== b[i]) {
-            console.log("Found difference at character " + i);
-            console.log("a: " + a.substring(i));
-            console.log("b: " + b.substring(i));
-            break;
-        }
+function rmrf(path) {
+    if (fs.existsSync(path)) {
+        fs.unlinkSync(path);
     }
 }
 
@@ -60,18 +54,123 @@ module.exports.xliffsplit = {
 
     },
     testXliffSplitdistritue: function(test) {
-        test.expect(1);
+        test.expect(2);
 
         var settings = {};
         settings.xliffVersion = 2;
         settings.infiles = [
-            "testfiles/xliff20/en-US.xliff",
+            "testfiles/xliff20/merge-en-US.xliff",
         ];
         var superset = XliffSplit(settings);
-        var result = XliffSplit.distribute(superset);
-
+        var result = XliffSplit.distribute(superset, settings);
         test.ok(result);
+        test.equal(Object.keys(result).length, 2); //app1, app2
         test.done();
 
-    }
+    },
+    testXliffSplitdistritueSerialize: function(test) {
+        test.expect(2);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/merge-en-US.xliff",
+        ];
+        var superset = XliffSplit(settings);
+        var result = XliffSplit.distribute(superset, settings);
+        test.ok(result);
+
+        var actual = result["app1"].serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+        '  <file original="app1" l:project="app1">\n' +
+        '    <group id="group_1" name="cpp">\n' +
+        '      <unit id="app1_1" name="app1:String 1a" type="res:string" l:datatype="cpp">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1a</source>\n' +
+        '          <target>app1:String 1a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app1_2" name="app1:String 1b" type="res:string" l:datatype="cpp">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1b</source>\n' +
+        '          <target>app1:String 1b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '    <group id="group_2" name="x-json">\n' +
+        '      <unit id="app1_3" name="app1:String 1c" type="res:string" l:datatype="x-json">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1c</source>\n' +
+        '          <target>app1:String 1c</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        test.equal(actual, expected);
+        test.done();
+    },
+    testXliffSplitdistritueSerialize2: function(test) {
+        test.expect(2);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/merge-en-US.xliff",
+        ];
+        var superset = XliffSplit(settings);
+        var result = XliffSplit.distribute(superset, settings);
+        test.ok(result);
+
+        var actual = result["app2"].serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+        '  <file original="app2" l:project="app2">\n' +
+        '    <group id="group_1" name="javascript">\n' +
+        '      <unit id="app2_1" name="app2: String 2a" type="res:string" l:datatype="javascript">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2a</source>\n' +
+        '          <target>app2: String 2a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app2_2" name="app2: String 2b" type="res:string" l:datatype="javascript">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2b</source>\n' +
+        '          <target>app2: String 2b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        test.equal(actual, expected);
+        test.done();
+    },
+    testXliffSplitWrite: function(test) {
+        test.expect(3);
+        rmrf("testfiles/xliff20/splitTest/app1/en-US.xliff");
+        rmrf("testfiles/xliff20/splitTest/app2/en-US.xliff");
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/merge-en-US.xliff",
+        ];
+        settings.targetDir = "testfiles/xliff20/splitTest";
+        var superset = XliffSplit(settings);
+        var result = XliffSplit.distribute(superset, settings);
+        test.ok(result);
+
+        XliffSplit.write(result);
+        test.ok(fs.existsSync("./testfiles/xliff20/splitTest/app1/en-US.xliff"));
+        test.ok(fs.existsSync("./testfiles/xliff20/splitTest/app2/en-US.xliff"));
+
+        test.done();
+
+    },
 };
+

--- a/test/testfiles/xliff20/merge-en-US.xliff
+++ b/test/testfiles/xliff20/merge-en-US.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="cpp">
+      <unit id="app1_1" name="app1:String 1a" type="res:string" l:datatype="cpp">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_2" name="app1:String 1b" type="res:string" l:datatype="cpp">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="group_2" name="x-json">
+      <unit id="app1_3" name="app1:String 1c" type="res:string" l:datatype="x-json">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file original="app2" l:project="app2">
+    <group id="group_3" name="javascript">
+      <unit id="app2_1" name="app2: String 2a" type="res:string" l:datatype="javascript">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_2" name="app2: String 2b" type="res:string" l:datatype="javascript">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
* Fix to work `split`  mode properly with xliff 2.0 format and separate to function for testing
* Add unit test to verify split mode
* regarding xliff 2.0 case, the project split type is only valid.
usage:
`node loctool.js split project test/testfiles/xliff20/merge-en-US.xliff -2 --targetDir output`

result would be like:
```
 output/app1/en-US.xliff
 output/app2/en-US.xliff
```