### PR TITLE
Add an option to load additional config file

### DIFF
--- a/lib/ProjectFactory.js
+++ b/lib/ProjectFactory.js
@@ -27,7 +27,7 @@ var ObjectiveCProject = require("./ObjectiveCProject.js");
 var SwiftProject = require("./SwiftProject.js");
 
 var CustomProject = require("./CustomProject.js");
-
+var JSUtils = require("ilib/lib/JSUtils.js");
 var logger = log4js.getLogger("loctool.lib.ProjectFactory");
 
 var projectTypes = {
@@ -53,12 +53,23 @@ var projectCache = {};
  * of a project.
  */
 var ProjectFactory = function ProjectFactory(dir, settings) {
+    var configData;
+    if (settings.configFile) {
+        if (fs.existsSync(settings.configFile)) {
+            var config = fs.readFileSync(settings.configFile, 'utf8');
+            configData = JSON.parse(config);
+        }
+    }
     var pathName = path.join(dir, "project.json");
     logger.debug("checking for the existence of " + pathName);
     if (fs.existsSync(pathName)) {
         var data = fs.readFileSync(pathName, 'utf8');
         if (data.length > 0) {
             var projectProps = JSON.parse(data);
+            if (configData) {
+                projectProps = JSUtils.merge(configData, projectProps);
+            }
+            //projectProps.settings = JSUtils.merge(projectProps.settings, settings);
             projectProps.settings = _mergeSettings(projectProps.settings, settings);
             settings = settings || {locales:[""]};
             var project, projectType = projectTypes[projectProps.projectType];

--- a/lib/ProjectFactory.js
+++ b/lib/ProjectFactory.js
@@ -69,7 +69,7 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
             if (configData) {
                 projectProps = JSUtils.merge(configData, projectProps);
             }
-            //projectProps.settings = JSUtils.merge(projectProps.settings, settings);
+            //projectProps.settings = JSUtils.merge(projectProps.settings, settings); // could be replaced after ilib 14.7.0
             projectProps.settings = _mergeSettings(projectProps.settings, settings);
             settings = settings || {locales:[""]};
             var project, projectType = projectTypes[projectProps.projectType];

--- a/loctool.js
+++ b/loctool.js
@@ -60,6 +60,8 @@ function usage() {
         "  run only the parts of the loctool that are needed at the moment.\n" +
         "-h or --help\n" +
         "  this help\n" +
+        "-c or --config\n" +
+        "  Place a specific location for `project.json` instead of the project root.\n" +
         "-i or --identify\n" +
         "  Identify resources where possible by marking up the translated files with \n" +
         "  the resource key.\n" +
@@ -155,6 +157,8 @@ for (var i = 0; i < argv.length; i++) {
         settings.xliffVersion = 2;
     } else if (val === "-p" || val === "--pull") {
         settings.pull = true;
+    } else if (val === "-c" || val === "--config") {
+        settings.configFile = argv[++i];
     } else if (val === "-l" || val === "--locales") {
         if (i < argv.length && argv[i+1]) {
             settings.locales = argv[++i].split(",");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testProjectFactory.js
+++ b/test/testProjectFactory.js
@@ -140,6 +140,16 @@ module.exports.projectfactory = {
         // should be relative to the root of the project
         test.equal(project.xliffsOut, '/foo/asdf');
         test.done();
+    },
+    testProjectFactoryConfigFile: function(test){
+        test.expect(3);
+        var settings = {
+            configFile: './testfiles/xliff20/project.json'
+        };
+        var project = ProjectFactory('./testfiles', settings);
+        test.ok(project);
+        test.equal(project.options.id, 'loctest');
+        test.equal(project.options.projectType, 'web');
+        test.done();
     }
-
 };

--- a/test/testfiles/xliff20/project.json
+++ b/test/testfiles/xliff20/project.json
@@ -1,0 +1,9 @@
+{
+    "name": "TestSample",
+    "id": "TestSample",
+    "projectType": "web",
+    "pseudoLocale": "zxx-XX",
+    "resourceDirs": {
+        "json": "resources"
+    }
+}


### PR DESCRIPTION
Add an option to load additional config file (it could have  platform general info i.e) sourceLocale, pseudo locale
If it has, it load first, then loads the app's root project config file then merges.
This PR  works in the following the first case only now.

we need to consider two cases:
1) Point additional  config files then merge with app root's config file
2) Specify a directory to put a config file outside of the app directory instead place the app's root

