### PR TITLE
Added guard code to prevent an error when read directory returns an empty 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,14 @@
 Release Notes for Version 2
 ============================
 
+Build 018
+-------
+Published as version 2.10.2
+New Features:
+
+Bug Fixes:
+- Added guard code to prevent an error when read directory list returns empty
+
 Build 017
 -------
 Published as version 2.10.1

--- a/loctool.js
+++ b/loctool.js
@@ -380,7 +380,7 @@ function walk(dir, project) {
     var list = fs.readdirSync(dir);
     var pathName, relPath, included, stat;
 
-    if (list) {
+    if (list && list.length !== 0) {
         list.sort().forEach(function (file) {
             var root = project ? project.getRoot() : settings.rootDir;
             pathName = path.join(dir, file);

--- a/loctool.js
+++ b/loctool.js
@@ -380,47 +380,49 @@ function walk(dir, project) {
     var list = fs.readdirSync(dir);
     var pathName, relPath, included, stat;
 
-    list.sort().forEach(function (file) {
-        var root = project ? project.getRoot() : settings.rootDir;
-        pathName = path.join(dir, file);
-        relPath = path.relative(root, pathName);
-        included = true;
+    if (list) {
+        list.sort().forEach(function (file) {
+            var root = project ? project.getRoot() : settings.rootDir;
+            pathName = path.join(dir, file);
+            relPath = path.relative(root, pathName);
+            included = true;
 
-        if (project) {
-            if (project.options.excludes) {
-                logger.trace("There are excludes. Relpath is " + relPath);
-                if (mm.any(relPath, project.options.excludes)) {
-                    included = false;
+            if (project) {
+                if (project.options.excludes) {
+                    logger.trace("There are excludes. Relpath is " + relPath);
+                    if (mm.any(relPath, project.options.excludes)) {
+                        included = false;
+                    }
+                }
+
+                // override the excludes
+                if (project.options.includes) {
+                    logger.trace("There are includes. Relpath is " + relPath);
+                    if (mm.any(relPath, project.options.includes)) {
+                        included = true;
+                    }
                 }
             }
 
-            // override the excludes
-            if (project.options.includes) {
-                logger.trace("There are includes. Relpath is " + relPath);
-                if (mm.any(relPath, project.options.includes)) {
-                    included = true;
-                }
-            }
-        }
-
-        if (included) {
-            logger.trace("Included.");
-            stat = fs.statSync(pathName);
-            if (stat && stat.isDirectory()) {
-                logger.info(pathName);
-                walk(pathName, project);
-            } else {
-                if (project) {
-                    logger.info(relPath);
-                    project.addPath(relPath);
+            if (included) {
+                logger.trace("Included.");
+                stat = fs.statSync(pathName);
+                if (stat && stat.isDirectory()) {
+                    logger.info(pathName);
+                    walk(pathName, project);
                 } else {
-                    logger.trace("Ignoring non-project file: " + relPath);
+                    if (project) {
+                        logger.info(relPath);
+                        project.addPath(relPath);
+                    } else {
+                        logger.trace("Ignoring non-project file: " + relPath);
+                    }
                 }
+            } else {
+                logger.trace("Excluded.");
             }
-        } else {
-            logger.trace("Excluded.");
-        }
-    });
+        });
+    }
 
     if (projectRoot) {
         logger.info('Project "' + project.options.name + '" is done.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
* Added guard code to prevent an error when read directory returns an empty list
I've faced the following error once among many builds. looks like it occurs an error around https://github.com/iLib-js/loctool/blob/development/loctool.js#L383 line. 