### PR TITLE
Added guard code to check if a file really exists in the given path before reading

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 2
 ============================
 
+Build 019
+-------
+Published as version 2.10.3
+New Features:
+Bug Fixes:
+- Added guard code to check if a file really exists in the given path before reading
+
 Build 018
 -------
 Published as version 2.10.2

--- a/loctool.js
+++ b/loctool.js
@@ -406,17 +406,21 @@ function walk(dir, project) {
 
             if (included) {
                 logger.trace("Included.");
-                stat = fs.statSync(pathName);
-                if (stat && stat.isDirectory()) {
-                    logger.info(pathName);
-                    walk(pathName, project);
-                } else {
-                    if (project) {
-                        logger.info(relPath);
-                        project.addPath(relPath);
+                if (fs.existsSync(pathName)) {
+                    stat = fs.statSync(pathName);
+                    if (stat && stat.isDirectory()) {
+                        logger.info(pathName);
+                        walk(pathName, project);
                     } else {
-                        logger.trace("Ignoring non-project file: " + relPath);
+                        if (project) {
+                            logger.info(relPath);
+                            project.addPath(relPath);
+                        } else {
+                            logger.trace("Ignoring non-project file: " + relPath);
+                        }
                     }
+                } else {
+                    logger.warn("File " + pathName + " does not exist.");
                 }
             } else {
                 logger.trace("Excluded.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
* Added guard code to check if a file really exists in the given path before reading

even though my previous patch is applied, still get a random build error like below:

```
| DEBUG: Executing shell function do_generate_webos_localization
| NOTE: Generating localized files
| NOTE: - xliff file name : addressbook
| NOTE: - source dir: /data001/jenkins/gecko/build-webos-auto/BUILD/work/sa8155-webos-linux/com.webos.app.avn.addressbook/0.0.1-1-r0/git
| NOTE: Normal Mode ...
| 03:32:32 ERROR loctool.loctool: caught exception: Error: ENOENT: no such file or directory, stat 'npm-shrinkwrap.json.orig'
| 03:32:32 ERROR loctool.loctool: Error: ENOENT: no such file or directory, stat 'npm-shrinkwrap.json.orig'
```