### PR TITLE
 Added the --exclude flag to use while project.json file searching

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 2
 ============================
 
+Build 020
+-------
+Published as version 2.11.0
+New Features:
+* Added the --exclude flag which excludes a comma-separated list of directories while searching for project.json config files
+Bug Fixes:
+
 Build 019
 -------
 Published as version 2.10.3

--- a/loctool.js
+++ b/loctool.js
@@ -145,7 +145,7 @@ var settings = {
     xliffVersion: 1.2,
     localizeOnly: false,
     projectType: "web",
-    exclude: ["node_modules", ".git", ".svn"]
+    exclude: ["**/node_modules", "**/.git", "**/.svn"]
 };
 
 var options = [];
@@ -402,7 +402,7 @@ function walk(dir, project) {
             if (project) {
                 if (project.options.excludes) {
                     logger.trace("There are excludes. Relpath is " + relPath);
-                    if (mm.any(relPath, project.options.excludes)) {
+                    if (mm.isMatch(relPath, project.options.excludes)) {
                         included = false;
                     }
                 }
@@ -410,36 +410,36 @@ function walk(dir, project) {
                 // override the excludes
                 if (project.options.includes) {
                     logger.trace("There are includes. Relpath is " + relPath);
-                    if (mm.any(relPath, project.options.includes)) {
+                    if (mm.isMatch(relPath, project.options.includes)) {
                         included = true;
                     }
                 }
             } else {
-                if (!settings.exclude.includes(pathName)) {
-                    if (included) {
-                        logger.trace("Included.");
-                        if (fs.existsSync(pathName)) {
-                            stat = fs.statSync(pathName);
-                            if (stat && stat.isDirectory()) {
-                                logger.info(pathName);
-                                walk(pathName, project);
-                            } else {
-                                if (project) {
-                                    logger.info(relPath);
-                                    project.addPath(relPath);
-                                } else {
-                                    logger.trace("Ignoring non-project file: " + relPath);
-                                }
-                            }
-                        } else {
-                            logger.warn("File " + pathName + " does not exist.");
-                        }
+                if (mm.isMatch(relPath, settings.exclude)) {
+                    included = false;
+                }
+            }
+
+            if (included) {
+                logger.trace("Included.");
+                if (fs.existsSync(pathName)) {
+                    stat = fs.statSync(pathName);
+                    if (stat && stat.isDirectory()) {
+                        logger.info(pathName);
+                        walk(pathName, project);
                     } else {
-                        logger.trace("Excluded.");
+                        if (project) {
+                            logger.info(relPath);
+                            project.addPath(relPath);
+                        } else {
+                            logger.trace("Ignoring non-project file: " + relPath);
+                        }
                     }
                 } else {
-                    logger.trace("Excluded directories.");
+                    logger.warn("File " + pathName + " does not exist.");
                 }
+            } else {
+                logger.trace("Excluded.");
             }
         });
     }

--- a/loctool.js
+++ b/loctool.js
@@ -2,7 +2,7 @@
 /*
  * loctool.js - tool to extract resources from source code
  *
- * Copyright © 2016-2017, 2019-2020, HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2021, HealthTap, Inc. and JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,6 +103,8 @@ function usage() {
         "  Specify the dir where the generation output should go. (Default is resources/) \n" +
         "--xliffResName\n" +
         "  Specify the resource filename used during resource file generation. (Default is strings.json) \n" +
+        "--exclude\n" +
+        "  exclude a comma-separated list of directories while searching for project.json config files \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    init  [project-name] - initialize the current directory as a loctool project\n" +
@@ -142,7 +144,8 @@ var settings = {
     xliffsDir: ".",
     xliffVersion: 1.2,
     localizeOnly: false,
-    projectType: "web"
+    projectType: "web",
+    exclude: ["node_modules", ".git", ".svn"]
 };
 
 var options = [];
@@ -240,7 +243,16 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
-    } else {
+    } else if (val === "--exclude") {
+        if (i+1 < argv.length && argv[i+1]) {
+            var excludeList = argv[++i].split(",");
+            var temp = settings.exclude.concat(excludeList);
+            settings.exclude = temp.filter(function(item,index){
+                return temp.indexOf(item) === index;
+            })
+        }
+    }
+     else {
         options.push(val);
     }
 }
@@ -402,28 +414,30 @@ function walk(dir, project) {
                         included = true;
                     }
                 }
-            }
-
-            if (included) {
-                logger.trace("Included.");
-                if (fs.existsSync(pathName)) {
-                    stat = fs.statSync(pathName);
-                    if (stat && stat.isDirectory()) {
-                        logger.info(pathName);
-                        walk(pathName, project);
-                    } else {
-                        if (project) {
-                            logger.info(relPath);
-                            project.addPath(relPath);
-                        } else {
-                            logger.trace("Ignoring non-project file: " + relPath);
-                        }
-                    }
-                } else {
-                    logger.warn("File " + pathName + " does not exist.");
-                }
             } else {
-                logger.trace("Excluded.");
+                if (!settings.exclude.includes(pathName)) {
+                    if (included) {
+                        logger.trace("Included.");
+                        if (fs.existsSync(pathName)) {
+                            stat = fs.statSync(pathName);
+                            if (stat && stat.isDirectory()) {
+                                logger.info(pathName);
+                                walk(pathName, project);
+                            } else {
+                                if (project) {
+                                    logger.info(relPath);
+                                    project.addPath(relPath);
+                                } else {
+                                    logger.trace("Ignoring non-project file: " + relPath);
+                                }
+                            }
+                        } else {
+                            logger.warn("File " + pathName + " does not exist.");
+                        }
+                    } else {
+                        logger.trace("Excluded.");
+                    }
+                }
             }
         });
     }

--- a/loctool.js
+++ b/loctool.js
@@ -437,6 +437,8 @@ function walk(dir, project) {
                     } else {
                         logger.trace("Excluded.");
                     }
+                } else {
+                    logger.trace("Excluded directories.");
                 }
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.10.3",
+    "version": "2.11.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
* Added the --exclude flag which excludes a comma-separated list of directories while searching for project.json config files
* `node_moduels/, .git, .svn`  are already excluded in the code. developers can add other lists through `--exclude` flag