### PR TITLE
Implement path templates

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,20 +4,29 @@ Release Notes for Version 2
 Build 020
 -------
 Published as version 2.11.0
+
 New Features:
 * Added the --exclude flag which excludes a comma-separated list of directories while searching for project.json config files
+* Added support for file path template formatting which plugins can use to generate
+  output file paths for localized files
+
 Bug Fixes:
 
 Build 019
 -------
+
 Published as version 2.10.3
+
 New Features:
+
 Bug Fixes:
 - Added guard code to check if a file really exists in the given path before reading
 
 Build 018
 -------
+
 Published as version 2.10.2
+
 New Features:
 
 Bug Fixes:
@@ -25,6 +34,7 @@ Bug Fixes:
 
 Build 017
 -------
+
 Published as version 2.10.1
 
 New Features:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1949,3 +1949,126 @@ module.exports.formatPath = function (template, parameters) {
 
     return output;
 };
+
+var matchExprs = {
+    "dir": {
+        regex: ".*?",
+        brackets: 0,
+    },
+    "locale": {
+        regex: "([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?",
+        brackets: 5,
+        groups: {
+            language: 1,
+            script: 3,
+            region: 5
+        }
+    },
+    "language": {
+        regex: "([a-z][a-z][a-z]?)",
+        brackets: 1,
+        groups: {
+            language: 1
+        }
+    },
+    "script": {
+        regex: "([A-Z][a-z][a-z][a-z])",
+        brackets: 1,
+        groups: {
+            script: 1
+        }
+    },
+    "region": {
+        regex: "([A-Z][A-Z]|[0-9][0-9][0-9])",
+        brackets: 1,
+        groups: {
+            region: 1
+        }
+    },
+    "localeDir": {
+        regex: "([a-z][a-z][a-z]?)(/([A-Z][a-z][a-z][a-z]))?(/([A-Z][A-Z]|[0-9][0-9][0-9]))?",
+        brackets: 5,
+        groups: {
+            language: 1,
+            script: 3,
+            region: 5
+        }
+    },
+    "localeUnder": {
+        regex: "([a-z][a-z][a-z]?)(_([A-Z][a-z][a-z][a-z]))?(_([A-Z][A-Z]|[0-9][0-9][0-9]))?",
+        brackets: 5,
+        groups: {
+            language: 1,
+            script: 3,
+            region: 5
+        }
+    },
+};
+
+/**
+ * Return a locale encoded in the path using template to parse that path.
+ * See {#formatPath} for the full description of the syntax of the template.
+ * @param {String} template template for the output file
+ * @param {String} pathname path to the source file
+ * @returns {String} the locale within the path
+ */
+module.exports.getLocaleFromPath = function(template, pathname) {
+    var regex = "";
+    var matchGroups = {};
+    var totalBrackets = 0;
+
+    if (!template) {
+        template = defaultMappings["**/*.json"].template;
+    }
+
+    for (var i = 0; i < template.length; i++) {
+        if ( template[i] !== '[' ) {
+            regex += template[i];
+        } else {
+            var start = ++i;
+            while (i < template.length && template[i] !== ']') {
+                i++;
+            }
+            var keyword = template.substring(start, i);
+            switch (keyword) {
+                case 'filename':
+                    regex += path.basename(pathname);
+                    break;
+                case 'extension':
+                    var base = path.basename(pathname);
+                    regex += base.substring(base.lastIndexOf('.')+1);
+                    break;
+                case 'basename':
+                    regex += path.basename(pathname, ".json");
+                    break;
+                default:
+                    regex += matchExprs[keyword].regex;
+                    for (var prop in matchExprs[keyword].groups) {
+                        matchGroups[prop] = totalBrackets + matchExprs[keyword].groups[prop];
+                    }
+                    totalBrackets += matchExprs[keyword].brackets;
+                    break;
+            }
+        }
+    }
+
+    var re = new RegExp(regex, "u");
+    var match;
+
+    if ((match = re.exec(pathname)) !== null) {
+        var groups = {};
+        var found = false;
+        for (var groupName in matchGroups) {
+            if (match[matchGroups[groupName]]) {
+                groups[groupName] = match[matchGroups[groupName]];
+                found = true;
+            }
+        }
+        if (found) {
+            var l = new Locale(groups.language, groups.region, undefined, groups.script);
+            return l.getSpec();
+        }
+    }
+
+    return "";
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,7 @@
  */
 
 var fs = require("fs");
+var path = require("path");
 var Locale = require("ilib/lib/Locale");
 var isAlnum = require("ilib/lib/isAlnum.js");
 var isIdeo = require("ilib/lib/isIdeo.js");
@@ -1849,4 +1850,102 @@ module.exports.escapeInvalidChars = function (str) {
 module.exports.nodeMajorVersion = function() {
     var firstdot = process.versions.node.indexOf('.');
     return Number(process.versions.node.substring(0, firstdot));
+};
+
+
+/**
+ * Format a file path using a path template and parameters.
+ *
+ * This function is used to generate an output file path for a given
+ * source file path and a locale specifier.
+ * The template replaces strings in square brackets with special values,
+ * and keeps any characters intact that are not in square brackets.
+ * This function recognizes and replaces the following strings in
+ * templates:
+ * - [dir] the original directory where the source file
+ *   came from. This is given as a directory that is relative
+ *   to the root of the project. eg. "foo/bar/strings.json" -> "foo/bar"
+ * - [filename] the file name of the source file. 
+ *   eg. "foo/bar/strings.json" -> "strings.json"
+ * - [basename] the basename of the source file without any extension
+ *   eg. "foo/bar/strings.json" -> "strings"
+ * - [extension] the extension part of the file name of the source file.
+ *   etc. "foo/bar/strings.json" -> "json"
+ * - [locale] the full BCP-47 locale specification for the target locale
+ *   eg. "zh-Hans-CN" -> "zh-Hans-CN"
+ * - [language] the language portion of the full locale
+ *   eg. "zh-Hans-CN" -> "zh"
+ * - [script] the script portion of the full locale
+ *   eg. "zh-Hans-CN" -> "Hans"
+ * - [region] the region portion of the full locale
+ *   eg. "zh-Hans-CN" -> "CN"
+ * - [localeDir] the full locale where each portion of the locale
+ *   is a directory in this order: [langage], [script], [region].
+ *   eg, "zh-Hans-CN" -> "zh/Hans/CN", but "en" -> "en".
+ * - [localeUnder] the full BCP-47 locale specification, but using
+ *   underscores to separate the locale parts instead of dashes.
+ *   eg. "zh-Hans-CN" -> "zh_Hans_CN"
+ *
+ * The parameters may include the following:
+ * - sourcepath - the path to the source file, relative to the root of
+ *   the project
+ * - locale - the locale for the output file path
+ *
+ * @param {string} template the string to escape
+ * @param {Object} parameters the parameters to format into the template
+ * @returns {string} the formatted file path
+ */
+module.exports.formatPath = function (template, parameters) {
+    var pathname = parameters.sourcepath || "";
+    var locale = parameters.locale || "en";
+    var output = "";
+    var l = new Locale(locale);
+
+    for (var i = 0; i < template.length; i++) {
+        if ( template[i] !== '[' ) {
+            output += template[i];
+        } else {
+            var start = ++i;
+            while (i < template.length && template[i] !== ']') {
+                i++;
+            }
+            var keyword = template.substring(start, i);
+            switch (keyword) {
+                case 'dir':
+                    output += path.dirname(pathname);
+                    break;
+                case 'filename':
+                    output += path.basename(pathname);
+                    break;
+                case 'extension':
+                    var base = path.basename(pathname);
+                    output += base.substring(base.lastIndexOf('.')+1);
+                    break;
+                case 'basename':
+                    output += path.basename(pathname, ".json");
+                    break;
+                default:
+                case 'locale':
+                    output += locale;
+                    break;
+                case 'language':
+                    output += l.getLanguage();
+                    break;
+                case 'script':
+                    output += l.getScript();
+                    break;
+                case 'region':
+                    output += l.getRegion();
+                    break;
+                case 'localeDir':
+                    output += l.getSpec().replace(/-/g, '/');
+                    break;
+                case 'localeUnder':
+                    output += l.getSpec().replace(/-/g, '_');
+                    break;
+            }
+        }
+    }
+
+    return output;
 };

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -302,7 +302,6 @@ module.exports.utils = {
         test.done();
     },
 
-/*
     testGetLocaleFromPathDir: function(test) {
         test.expect(1);
 
@@ -430,5 +429,4 @@ module.exports.utils = {
 
         test.done();
     }
-*/
 }

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -190,6 +190,245 @@ module.exports.utils = {
         test.equal(utils.trimEscaped(undefined), undefined);
 
         test.done();
-    }
+    },
 
+    testGetLocalizedPathLocaleDir: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('resources/[localeDir]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "resources/de/DE/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathDir: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[localeDir]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "x/y/de/DE/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathBasename: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[localeDir]/tr-[basename].j', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "de/DE/tr-strings.j");
+
+        test.done();
+    },
+
+    testGetLocalizedPathFilename: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[localeDir]/tr-[filename]', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "de/DE/tr-strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathExtension: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[localeDir]/tr-foobar.[extension]', {
+            sourcepath: "x/y/strings.jsn",
+            locale: "de-DE"
+        }), "de/DE/tr-foobar.jsn");
+
+        test.done();
+    },
+
+    testGetLocalizedPathLocale: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[locale]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "x/y/de-DE/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathLanguage: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[language]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "x/y/de/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathRegion: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[region]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "de-DE"
+        }), "x/y/DE/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathScript: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[script]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "zh-Hans-CN"
+        }), "x/y/Hans/strings.json");
+
+        test.done();
+    },
+
+    testGetLocalizedPathLocaleUnder: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/strings_[localeUnder].json', {
+            sourcepath: "x/y/strings.json",
+            locale: "zh-Hans-CN"
+        }), "x/y/strings_zh_Hans_CN.json");
+
+        test.done();
+    },
+
+/*
+    testGetLocaleFromPathDir: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/strings.json', "x/y/strings.json"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasename: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[basename].json', "x/y/strings.json"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathFilename: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[filename]', "x/y/strings.json"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocale: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[locale]/strings.json', "x/y/de-DE/strings.json"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleLong: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[locale]/strings.json', "x/y/zh-Hans-CN/strings.json"), "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleShort: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[locale]/strings.json', "x/y/fr/strings.json"), "fr");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLanguage: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[language]/strings.json', "x/y/de/strings.json"), "de");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathScript: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[language]-[script]/strings.json', "x/y/zh-Hans/strings.json"), "zh-Hans");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathRegion: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[region]/strings.json', "x/y/JP/strings.json"), "JP");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleDir: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[localeDir]/strings.json', "x/y/de/DE/strings.json"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleDirShort: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[localeDir]/strings.json', "x/y/de/strings.json"), "de");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleDirLong: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[localeDir]/strings.json', "x/y/zh/Hans/CN/strings.json"), "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleDirStart: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[localeDir]/strings.json', "de/DE/strings.json"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleUnder: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/strings_[localeUnder].json', "x/y/strings_de_DE.json"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleUnderShort: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/strings_[localeUnder].json', "x/y/strings_de.json"), "de");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathLocaleUnderLong: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/strings_[localeUnder].json', "x/y/strings_zh_Hans_CN.json"), "zh-Hans-CN");
+
+        test.done();
+    }
+*/
 }


### PR DESCRIPTION
This is code and unit tests that is stolen from the json plugin which would be really useful for all the plugins.

Also implemented getLocaleFromPath which determines the locale from a file's path name plus a template for the path name. It uses the template to construct a regular expression that parses the path name looking for the locale.