### PR TITLE
Fix a bug where xliff output was not correct for plural resources

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,9 @@ New Features:
 
 Bug Fixes:
 - Updated the code that the key value would be written in xliff only if it's different from the source
+- Fixed a bug where plural resources for a locale that has a different number of plural categories than
+  the source language would never show those plurals in the xliff output. Now the plurals output of
+  xliff files follows the plural categories available in the target language instead of the source language.
 
 Build 019
 -------

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -1,7 +1,7 @@
 /*
  * Xliff.js - model an xliff file
  *
- * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2021 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -568,19 +568,20 @@ Xliff.prototype._convertResource = function(res) {
             var sp = res.getSourcePlurals();
             var tp = res.getTargetPlurals();
 
-            for (var p in sp) {
-                if (sp[p]) {
+            if (!tp || utils.isEmpty(tp)) {
+                for (var p in sp) {
                     var newtu = tu.clone();
                     newtu.source = sp[p];
-
-                    if (tp && tp[p]) {
-                        newtu.target = tp[p];
-                        newtu.quantity = p;
-                    }
                     newtu.quantity = p;
                     units.push(newtu);
-                } else {
-                    logger.warn("Translated plural  " + res.getKey() + " has no source plural, quantity " + p + ": " + JSON.stringify(res, undefined, 4));
+                }
+            } else {
+                for (var p in tp) {
+                    var newtu = tu.clone();
+                    newtu.source = sp[p] || sp.other;
+                    newtu.target = tp[p];
+                    newtu.quantity = p;
+                    units.push(newtu);
                 }
             }
             break;

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -1,7 +1,7 @@
 /*
  * testXliff.js - test the Xliff object.
  *
- * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2021 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1028,6 +1028,63 @@ module.exports.xliff = {
                 '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
                 '        <source>There are {n} objects.</source>\n' +
                 '        <target state="new">Da gibts {n} Objekten.</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
+        test.expect(2);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Имеется {n} объект.",
+                "few": "Есть {n} объекта.",
+                "other": "Всего {n} объектов."
+            },
+            targetLocale: "ru-RU",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="ru-RU" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '        <target state="new">Имеется {n} объект.</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="few">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target state="new">Есть {n} объекта.</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target state="new">Всего {n} объектов.</target>\n' +
                 '      </trans-unit>\n' +
                 '    </body>\n' +
                 '  </file>\n' +

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -1,7 +1,7 @@
 /*
  * testXliff20.js - test the Xliff 2.0 object.
  *
- * Copyright © 2019 JEDLSoft
+ * Copyright © 2019,2021 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1256,6 +1256,69 @@ module.exports.xliff20 = {
                 '        <segment>\n' +
                 '          <source>There are {n} objects.</source>\n' +
                 '          <target state="new">Da gibts {n} Objekten.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Имеется {n} объект.",
+                "few": "Есть {n} объекта.",
+                "other": "Всего {n} объектов."
+            },
+            targetLocale: "ru-RU",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="ruby">\n' +
+                '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
+                '        <segment>\n' +
+                '          <source>There is 1 object.</source>\n' +
+                '          <target state="new">Имеется {n} объект.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="few">\n' +
+                '        <segment>\n' +
+                '          <source>There are {n} objects.</source>\n' +
+                '          <target state="new">Есть {n} объекта.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="3" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
+                '        <segment>\n' +
+                '          <source>There are {n} objects.</source>\n' +
+                '          <target state="new">Всего {n} объектов.</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '    </group>\n' +


### PR DESCRIPTION
The xliff output for a set of plural resources would have translation units only for the source language instead of for the target language. That means if the target language had a different set of plurals than English, you would never see them in the xliff output.

For example, English has the "one" and "other" categories, but Russian has the "one", "few", and "other" categories. In this case, the xliff output would only have translation units for the "one" and "other" categories, and not the "few" category, even though there is a Russian translation available for the "few" category.

In the case where there are no translations, the xliff still only has the translation categories for the source language as it was before.