### PR TITLE
Added the --xliffSyle flag to specify customize xliff format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.project
 jsdoc
 java/bin
 build.properties

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.project
 jsdoc
 java/bin
 build.properties

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 021
+-------
+Published as version 2.12.0
+New Features:
+Added the --xliffStyle flag which specifies customized xliff format
+
+Bug Fixes:
+
+
 Build 020
 -------
 Published as version 2.11.0

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -534,7 +534,8 @@ Project.prototype.close = function(cb) {
                 logger.info("Writing out the modern translation strings to " + modernPath);
                 var modernXliff = new Xliff({
                     pathName: modernPath,
-                    version: this.settings.xliffVersion
+                    version: this.settings.xliffVersion,
+                    style: this.settings.xliffStyle
                 });
                 modernXliff.addSet(this.fileTypes[i].modern);
                 fs.writeFileSync(modernPath, modernXliff.serialize(true), "utf-8");
@@ -560,7 +561,8 @@ Project.prototype.close = function(cb) {
             var extractedXliff = new Xliff({
                 pathName: extractedPath,
                 allowDups: true,
-                version: this.settings.xliffVersion
+                version: this.settings.xliffVersion,
+                style: this.settings.xliffStyle
             });
             extractedXliff.addSet(extracted);
             fs.writeFileSync(extractedPath, extractedXliff.serialize(true), "utf-8");
@@ -585,7 +587,8 @@ Project.prototype.close = function(cb) {
                             project: this.name,
                             pathName: newPath,
                             sourceLocale: this.sourceLocale,
-                            version: this.settings.xliffVersion
+                            version: this.settings.xliffVersion,
+                            style: this.settings.xliffStyle
                         });
 
                         resources.forEach(function(res) {

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -1117,8 +1117,7 @@ Xliff.prototype.serialize = function(untranslated) {
     if (this.tu && this.tu.length > 0) {
         units = units.concat(this.tu);
     }
-
-    return ((this.version < 2) ? this.toString1(units) : (this.style == "standard" ? this.toString2(units): this.toStringCustom(units)));
+    return ((this.version < 2) ? this.toString1(units) : (this.style == "custom" ? this.toStringCustom(units): this.toString2(units)));
 };
 
 /**

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -130,6 +130,7 @@ var Xliff = function Xliff(options) {
         this.sourceLocale = options.sourceLocale;
         this.project = options.project;
         this.allowDups = options.allowDups;
+        this.style =  options.style || "standard";
         if (typeof(options.version) !== 'undefined') {
             this.version = Number.parseFloat(options.version);
         }
@@ -917,6 +918,154 @@ Xliff.prototype.toString2 = function(units) {
 };
 
 /**
+ * Serialize this xliff instance as an customized xliff 2.0 format string.
+ * @param {Array.<TranslationUnit>} units an array of units to convert to a string
+ * @return {String} the current instance encoded as an customized xliff 2.0
+ * format string
+ */
+Xliff.prototype.toStringCustom = function(units) {
+    console.log("!! toStringCustom");
+    var sourceLocale = units[0].sourceLocale;
+    var targetLocale = units[0].targetLocale;
+
+    units = units.filter(function(unit) {
+        return unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale);
+    });
+
+    var json = {
+        xliff: {
+            _attributes: {
+                "version": versionString(this.version),
+                "srcLang": sourceLocale,
+            }
+        }
+    };
+
+    if (targetLocale) {
+        json.xliff._attributes.trgLang = targetLocale;
+    }
+
+    json.xliff._attributes["xmlns:l"] = "http://ilib-js.com/loctool";
+
+    logger.trace("Units to write out is " + JSON.stringify(units, undefined, 4));
+
+    // now finally add each of the units to the json
+
+    var files = {};
+    var index = 1;
+    var fileIndex = 1;
+    var datatype;
+    var groupIndex = 1;
+
+    for (var i = 0; i < units.length; i++) {
+        var tu = units[i];
+        if (!tu) {
+            console.log("undefined?");
+        }
+        var hashKey = tu.project;
+        var file = files[hashKey];
+        if (!file) {
+            files[hashKey] = file = {
+                _attributes: {
+                    "id": tu.project + "_f" + fileIndex++,
+                    "original": tu.project
+                },
+                group : [
+                    {
+                        _attributes: {
+                            "id": tu.project + "_g" + groupIndex++,
+                            "name": tu.datatype || "javascript"
+                        },
+                        unit: []
+                    }
+                ]
+            };
+        }
+
+        var tujson = {
+            _attributes: {
+                "id": (tu.id || index++),
+                "name": (tu.source !== tu.key) ? escapeAttr(tu.key) : undefined,
+            }
+        };
+
+        if (tu.comment) {
+            tujson.notes = {
+                "note": [
+                    {
+                        _attributes: {
+                            "appliesTo": "source"
+                        },
+                        "_text": tu.comment
+                    }
+                ]
+            };
+        }
+
+        tujson.segment = [
+            {
+                "source": {
+                    "_text": tu.source
+                }
+            }
+        ];
+
+        if (tu.id && tu.id > index) {
+            index = tu.id + 1;
+        }
+
+        if (tu.target) {
+            tujson.segment[0].target = {
+                _attributes: {
+                    state: tu.state,
+                },
+                "_text": tu.target
+            };
+        }
+
+        datatype = tu.datatype || "javascript";
+        if (!files[hashKey].group) {
+            files[hashKey].group = [];
+        }
+
+        var groupSet = {
+            _attributes: {},
+            unit: []
+        }
+
+        var existGroup = files[hashKey].group.filter(function(item) {
+            if (item._attributes.name === datatype) {
+                return item;
+            }
+        })
+
+        if (existGroup.length > 0) {
+            existGroup[0].unit.push(tujson);
+        } else {
+            groupSet._attributes.id = tu.project+ "_g" + groupIndex++;
+            groupSet._attributes.name = datatype;
+            files[hashKey].group.push(groupSet);
+            groupSet.unit.push(tujson);
+        }
+    }
+
+    // sort the file tags so that they come out in the same order each time
+    if (!json.xliff.file) {
+        json.xliff.file = [];
+    }
+    Object.keys(files).sort().forEach(function(fileHashKey) {
+        json.xliff.file.push(files[fileHashKey]);
+    });
+
+    var xml = '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+        compact: true,
+        spaces: 2
+    });
+
+    return xml;
+}
+
+/**
  * Serialize this xliff instance to a string that contains
  * the xliff format xml text.
  *
@@ -970,7 +1119,7 @@ Xliff.prototype.serialize = function(untranslated) {
         units = units.concat(this.tu);
     }
 
-    return (this.version < 2) ? this.toString1(units) : this.toString2(units);
+    return ((this.version < 2) ? this.toString1(units) : (this.style == "standard" ? this.toString2(units): this.toStringCustom(units)));
 };
 
 /**

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -924,7 +924,6 @@ Xliff.prototype.toString2 = function(units) {
  * format string
  */
 Xliff.prototype.toStringCustom = function(units) {
-    console.log("!! toStringCustom");
     var sourceLocale = units[0].sourceLocale;
     var targetLocale = units[0].targetLocale;
 

--- a/lib/XliffMerge.js
+++ b/lib/XliffMerge.js
@@ -34,7 +34,8 @@ var XliffMerge = function XliffMerge(settings) {
 
     var target = new Xliff({
         path: settings.outfile,
-        version: settings.xliffVersion
+        version: settings.xliffVersion,
+        style: settings.xliffStyle
     });
 
     settings.infiles.forEach(function (file) {
@@ -42,7 +43,8 @@ var XliffMerge = function XliffMerge(settings) {
             logger.info("Merging " + file + " ...");
             var data = fs.readFileSync(file, "utf-8");
             var xliff = new Xliff({
-                version: settings.xliffVersion
+                version: settings.xliffVersion,
+                style: settings.xliffStyle
             });
             xliff.deserialize(data);
             target.addTranslationUnits(xliff.getTranslationUnits());

--- a/lib/XliffSplit.js
+++ b/lib/XliffSplit.js
@@ -41,7 +41,8 @@ var XliffSplit = function XliffSplit(settings) {
         if (fs.existsSync(file)) {
             var data = fs.readFileSync(file, "utf-8");
             var xliff = new Xliff({
-                version: settings.xliffVersion
+                version: settings.xliffVersion,
+                style: settings.xliffStyle
             });
             xliff.deserialize(data);
             superset = superset.concat(xliff.getTranslationUnits());
@@ -66,7 +67,8 @@ _parse1 = function(superset, settings) {
         if (!file) {
             file = cache[key] = new Xliff({
                 path: "./" + key + ".xliff",
-                version: settings.xliffVersion
+                version: settings.xliffVersion,
+                style: settings.xliffStyle
             });
             logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
         }
@@ -103,7 +105,8 @@ _parse2 = function(superset, settings) {
         if (!file) {
             file = cache[key] = new Xliff({
                 path: path.join(prjXliffPath, unit.targetLocale + ".xliff"),
-                version: settings.xliffVersion
+                version: settings.xliffVersion,
+                style: settings.xliffStyle
             });
             logger.trace("new xliff is " + JSON.stringify(file, undefined, 4));
         }

--- a/loctool.js
+++ b/loctool.js
@@ -105,7 +105,7 @@ function usage() {
         "--exclude\n" +
         "  exclude a comma-separated list of directories while searching for project.json config files \n" +
         "--xliffStyle\n" +
-        "  Specify the Xliff format style. (Default is standard) \n" +
+        "  Specify the Xliff format style. It can have standard or custom. (Default is standard) \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    init  [project-name] - initialize the current directory as a loctool project\n" +
@@ -244,7 +244,10 @@ for (var i = 0; i < argv.length; i++) {
             usage();
         }
     } else if (val === "--xliffStyle") {
-        settings.xliffStyle = argv[++i];
+        var candidate = ["standard", "custom"];
+        if (candidate.indexOf(argv[++i]) !== -1) {
+            settings.xliffStyle = argv[++i];
+        }
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
     } else if (val === "--exclude") {

--- a/loctool.js
+++ b/loctool.js
@@ -29,7 +29,6 @@ var mm = require("micromatch");
 
 var ProjectFactory = require("./lib/ProjectFactory.js");
 var GenerateModeProcess = require("./lib/GenerateModeProcess.js");
-var Xliff = require("./lib/Xliff.js");
 
 var XliffMerge = require("./lib/XliffMerge.js");
 var XliffSplit = require("./lib/XliffSplit.js");
@@ -105,6 +104,8 @@ function usage() {
         "  Specify the resource filename used during resource file generation. (Default is strings.json) \n" +
         "--exclude\n" +
         "  exclude a comma-separated list of directories while searching for project.json config files \n" +
+        "--xliffStyle\n" +
+        "  Specify the Xliff format style. (Default is standard) \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    init  [project-name] - initialize the current directory as a loctool project\n" +
@@ -143,6 +144,7 @@ var settings = {
     targetDir: ".",            // target directory for all output files
     xliffsDir: ".",
     xliffVersion: 1.2,
+    xliffStyle: "standard",
     localizeOnly: false,
     projectType: "web",
     exclude: ["**/node_modules", "**/.git", "**/.svn"]
@@ -241,6 +243,8 @@ for (var i = 0; i < argv.length; i++) {
             console.error("Error: -z (--xliffsOut) option requires a directory name argument to follow it.");
             usage();
         }
+    } else if (val === "--xliffStyle") {
+        settings.xliffStyle = argv[++i];
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
     } else if (val === "--exclude") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testXliffMerge.js
+++ b/test/testXliffMerge.js
@@ -291,4 +291,66 @@ module.exports.xliffmerge = {
         test.equal(actual, expected);
         test.done();
     },
+    testXliffMerge_write_en_US_CustomStyle_wrongStyle: function(test) {
+        test.expect(2);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.xliffStyle = "custommm";
+        settings.infiles = [
+            "testfiles/xliff20/app1/en-US.xliff",
+            "testfiles/xliff20/app2/en-US.xliff",
+        ];
+
+        var target = XliffMerge(settings);
+        test.ok(target);
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+        '  <file original="app1" l:project="app1">\n' +
+        '    <group id="group_1" name="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1a</source>\n' +
+        '          <target>app1:String 1a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1b</source>\n' +
+        '          <target>app1:String 1b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '    <group id="group_2" name="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1c</source>\n' +
+        '          <target>app1:String 1c</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '  <file original="app2" l:project="app2">\n' +
+        '    <group id="group_3" name="javascript">\n' +
+        '      <unit id="app2_1" type="res:string" l:datatype="javascript">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2a</source>\n' +
+        '          <target>app2: String 2a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app2_2" type="res:string" l:datatype="javascript">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2b</source>\n' +
+        '          <target>app2: String 2b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        test.equal(actual, expected);
+        test.done();
+    },
 };

--- a/test/testXliffMerge.js
+++ b/test/testXliffMerge.js
@@ -229,4 +229,66 @@ module.exports.xliffmerge = {
         test.ok(fs.existsSync("./testfiles/xliff20/output-ko-KR.xliff"));
         test.done();
     },
+    testXliffMerge_write_en_US_CustomStyle: function(test) {
+        test.expect(2);
+
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.xliffStyle = "custom";
+        settings.infiles = [
+            "testfiles/xliff20/app1/en-US.xliff",
+            "testfiles/xliff20/app2/en-US.xliff",
+        ];
+
+        var target = XliffMerge(settings);
+        test.ok(target);
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+        '  <file id="app1_f1" original="app1">\n' +
+        '    <group id="app1_g1" name="cpp">\n' +
+        '      <unit id="app1_1">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1a</source>\n' +
+        '          <target>app1:String 1a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app1_2">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1b</source>\n' +
+        '          <target>app1:String 1b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '    <group id="app1_g2" name="x-json">\n' +
+        '      <unit id="app1_3">\n' +
+        '        <segment>\n' +
+        '          <source>app1:String 1c</source>\n' +
+        '          <target>app1:String 1c</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '  <file id="app2_f2" original="app2">\n' +
+        '    <group id="app2_g3" name="javascript">\n' +
+        '      <unit id="app2_1">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2a</source>\n' +
+        '          <target>app2: String 2a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app2_2">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2b</source>\n' +
+        '          <target>app2: String 2b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        test.equal(actual, expected);
+        test.done();
+    },
 };

--- a/test/testXliffSplit.js
+++ b/test/testXliffSplit.js
@@ -150,6 +150,43 @@ module.exports.xliffsplit = {
         test.equal(actual, expected);
         test.done();
     },
+    testXliffSplitdistritueSerialize3_xliffStyle: function(test) {
+        test.expect(2);
+        var settings = {};
+        settings.xliffVersion = 2;
+        settings.infiles = [
+            "testfiles/xliff20/merge-en-US-style.xliff",
+        ];
+        settings.xliffStyle = "custom"
+        var superset = XliffSplit(settings);
+        var result = XliffSplit.distribute(superset, settings);
+        test.ok(result);
+
+        var actual = result["app2"].serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+        '  <file id="app2_f1" original="app2">\n' +
+        '    <group id="app2_g1" name="javascript">\n' +
+        '      <unit id="app2_1">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2a</source>\n' +
+        '          <target>app2: String 2a</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '      <unit id="app2_2">\n' +
+        '        <segment>\n' +
+        '          <source>app2: String 2b</source>\n' +
+        '          <target>app2: String 2b</target>\n' +
+        '        </segment>\n' +
+        '      </unit>\n' +
+        '    </group>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        test.equal(actual, expected);
+        test.done();
+    },
     testXliffSplitWrite: function(test) {
         test.expect(3);
         rmrf("testfiles/xliff20/splitTest/app1/en-US.xliff");

--- a/test/testfiles/xliff20/merge-en-US-style.xliff
+++ b/test/testfiles/xliff20/merge-en-US-style.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="cpp">
+      <unit id="app1_1">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_2">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="group_2" name="x-json">
+      <unit id="app1_3">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file original="app2" l:project="app2">
+    <group id="group_3" name="javascript">
+      <unit id="app2_1">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_2">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/test/testfiles/xliff20/output-style-en-US.xliff
+++ b/test/testfiles/xliff20/output-style-en-US.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="app1_f1" original="app1">
+    <group id="app1_g1" name="cpp">
+    </group>
+    <group id="app1_g2" name="javascript">
+      <unit id="app1_app1_1">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_app1_2">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+      <unit id="app1_app1_3">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file id="app2_f2" original="app2">
+    <group id="app2_g3" name="javascript">
+      <unit id="app2_app2_1">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_app2_2">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
I've added a new `--xliffSyle` flag to specify customized xliff format. (I wanted to avoid specific platform name)
The current xliff format is `standard` style, and except for the case, it works differently (work as webOS xliff expected)