### PR TITLE
Implement TMX file code

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -247,6 +247,10 @@ limitations under the License.
         <run script="${build.test}/testXliff20.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
     </target>
 
+    <target name="debug.xliff2" description="Debug only the tests for the xliff 2.0 object">
+        <debug script="${build.test}/testXliff20.js" dir="${build.test}"/>
+    </target>
+
     <target name="test.xliffmerge" description="Run only the xliff merge tests">
         <run script="${build.test}/testXliffMerge.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
     </target>
@@ -255,8 +259,12 @@ limitations under the License.
         <run script="${build.test}/testXliffSplit.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
     </target>
 
-    <target name="debug.xliff2" description="Debug only the tests for the xliff 2.0 object">
-        <debug script="${build.test}/testXliff20.js" dir="${build.test}"/>
+    <target name="test.tmx" description="Run only the tmx tests">
+        <run script="${build.test}/testTMX.js" executable="${nodeunit}/bin/nodeunit" dir="${build.test}" args="" />
+    </target>
+
+    <target name="debug.tmx" description="Debug only the tests for the tmx object">
+        <debug script="${build.test}/testTMX.js" dir="${build.test}"/>
     </target>
 
     <target name="test.localrepository" description="Run only the tests for the local repository">
@@ -611,7 +619,7 @@ limitations under the License.
         <debug script="${build.test}/testResourceFactory.js" dir="${build.test}"/>
     </target>
 
-    <target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.xliff2,test.xliffmerge,test.xliffsplit,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject,test.project">
+    <target name="test" depends="test.translationset,test.set,test.resourcestring,test.resourcearray,test.resourceplural,test.javafile,test.javafiletype,test.androidlayoutfile,test.androidlayoutfiletype,test.androidresourcefile,test.androidresourcefiletype,test.xliff,test.xliff2,test.xliffmerge,test.xliffsplit,test.localrepository,test.utils,test.javascriptfiletype,test.javascriptfile,test.htmlfile,test.htmlfiletype,test.htmltemplatefile,test.htmltemplatefiletype,test.javascriptresourcefile,test.javascriptresourcefiletype,test.objectivecfile,test.objectivecfiletype,test.swiftfile,test.swiftfiletype,test.iosstringsfile,test.iosstringsfiletype,test.rubyfile,test.rubyfiletype,test.yamlfiletype,test.yamlfile,test.hamlfile,test.hamlfiletype,test.oldhamlfiletype,test.yamlresourcefile,test.yamlresourcefiletype,test.pseudobritish,test.pseudocanadian,test.pseudonewzealand,test.pseudohant,test.buildgradle,test.androidproject,test.androidflavors,test.webproject,test.projectfactory,test.pseudofactory,test.jsxfile,test.jsxfiletype,test.markdownfiletype,test.markdownfile,test.resourcefactory,test.customproject,test.project,test.tmx">
     </target>
 
     <macrodef name="runsql">

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,8 +4,13 @@ Release Notes for Version 2
 Build 021
 -------
 Published as version 2.12.0
+
 New Features:
-Added the --xliffStyle flag which specifies customized xliff format
+* Added the --xliffStyle flag which specifies customized xliff format
+* Added support for generating a TMX file out of a set of xliff files.
+    * Added a "tmx" action to the command-line: `loctool tmx output.tmx *.xliff`
+    * The TMX files are not segmented. That is, they contain the full strings
+      that appear in the input xliff files
 
 Bug Fixes:
 

--- a/lib/ResourcePlural.js
+++ b/lib/ResourcePlural.js
@@ -63,17 +63,18 @@ var ResourcePlural = function(props) {
     // deep copy this so that the props can have a different set of
     // plural forms than this instance
     if (props) {
-        var strings = props.sourceStrings || props.strings;
+        var strings = props.sourceStrings || props.sourcePlurals || props.strings;
         if (strings) {
             for (var p in strings) {
                 this.sourceStrings[p] = strings[p];
             }
         }
 
-        if (props.targetStrings) {
+        var targetStrings = props.targetStrings || props.targetPlurals;
+        if (targetStrings) {
             this.targetStrings = {};
-            for (var p in props.targetStrings) {
-                this.targetStrings[p] = props.targetStrings[p];
+            for (var p in targetStrings) {
+                this.targetStrings[p] = targetStrings[p];
             }
         }
     }

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -33,14 +33,170 @@ var logger = log4js.getLogger("loctool.lib.Tmx");
 
 /**
  * @class A class that represents a tmx translation unit variant.
+ *
+ * Options may contain the following properties:
+ * - locale: locale of the target string
+ * - string: the translation for this variant
+ *
+ * @param {Object} options
  */
-var TUV = function Tuv(options) {
+var TranslationVariant = function Tuv(options) {
     this.locale = options.locale;
     this.string = options.string;
 };
 
-var TU = function TU(options) {
+/**
+ * Return a json object that encodes the xml structure of this translation
+ * unit variant. This is used to convert to xml below.
+ *
+ * @returns {Object} a json object which encodes this variant.
+ */
+TranslationVariant.prototype.serialize = function() {
+    return {
+        _attributes: {
+            "xml:lang": this.locale
+        },
+        seg: {
+            "_text": this.string
+        }
+    };
 };
+
+/**
+ * Return a unique hash key for this translation unit variant. The
+ * hash key is calculated from the source string and locale.
+ *
+ * @returns {string} the unique hash key
+ */
+TranslationVariant.prototype.hashKey = function() {
+    return [utils.hashKey(this.string), this.locale].join("_");
+};
+
+/**
+ * @class Represent a translation unit. A translation unit is
+ * a segment in the source language, along with one or
+ * more variants, which are translations to various
+ * target languages. A translation unit may contain more
+ * than one translation for a particular locale, as there
+ * are sometimes more than one translation for a particular
+ * phrase in the source language, depending on the context.
+ *
+ * The options may contain the following properties:
+ * - locale: source locale for this unit
+ * - string: source string in the source language
+ * - datatype: the type of data that this string came from
+ *
+ * @param {Object} options options for this unit
+ */ 
+var TranslationUnit = function TranslationUnit(options) {
+    this.locale = options.locale;
+    this.string = options.string;
+    this.datatype = options.datatype;
+
+    this.variants = [];
+    this.variantHash = {};
+    this.properties = {};
+};
+
+/**
+ * Return a unique hash key for this translation unit. The
+ * hash key is calculated from the source string and locale
+ * and does not depend on the properties or variants in
+ * the unit.
+ *
+ * @returns {string} the unique hash key
+ */
+TranslationUnit.prototype.hashKey = function() {
+    return [utils.hashKey(this.string), this.locale, this.datatype].join("_");
+};
+
+/**
+ * Return the list of variants for this translation unit.
+ * @returns {Array.<TranslationVariant>} the variants for
+ * this translation unit
+ */
+TranslationUnit.prototype.getVariants = function() {
+    return this.variants;
+};
+
+/**
+ * Add a single variant to this translation unit. This variant
+ * is only added if it is unique in this translation unit. That is,
+ * No other variant exists in this unit with the same locale and
+ * string.
+ *
+ * @param {TranslationVariant} variant the variant to add
+ */
+TranslationUnit.prototype.addVariant = function(variant) {
+    var key = variant.hashKey();
+    if (!this.variantHash[key]) {
+        this.variants.push(variant);
+        this.variantHash[key] = variant;
+    }
+}
+
+/**
+ * Add an array of variants to this translation unit. This only
+ * adds a variant if it is unique. That is, the unit is not
+ * added if the locale and string are the same as an existing
+ * variant.
+ *
+ * @param {Array.<TranslationVariant>} variants the array of variants to add
+ */
+TranslationUnit.prototype.addVariants = function(variants) {
+    variants.forEach(function(variant) {
+        this.addVariant(variant);
+    }.bind(this));
+};
+
+/**
+ * Return the list of properties and their values for this translation unit.
+ * @returns {Object} an object mapping properties to values
+ */
+TranslationUnit.prototype.getProperties = function() {
+    return this.properties;
+};
+
+/**
+ * Add a property to this translation unit.
+ * @param {Object} properties an object that maps properties to values
+ */
+TranslationUnit.prototype.addProperties = function(properties) {
+    for (var p in properties) {
+        if (properties[p]) {
+            this.properties[p] = properties[p];
+        }
+    }
+};
+
+/**
+ * Return a json object that encodes the xml structure of this translation
+ * unit. This is used to convert to xml below.
+ *
+ * @returns {Object} a json object which encodes this unit.
+ */
+TranslationUnit.prototype.serialize = function() {
+    var retval = {
+        _attributes: {
+            srclang: this.locale
+        }
+    };
+    for (var p in this.properties) {
+        if (!retval.prop) retval.prop = [];
+        retval.prop.push({
+            _attributes: {
+                type: p
+            },
+            _text: this.properties[p]
+        });
+    }
+    retval.tuv = this.variants.map(function(variant) {
+        return variant.serialize();
+    });
+    
+    return retval;
+};
+
 
 /**
  * @class A class that represents an tmx 1.4b file.
@@ -51,18 +207,17 @@ var TU = function TU(options) {
  *
  * <ul>
  * <li><i>path</i> - the path to the tmx file on disk
- * <li><i>tool-id</i> - the id of the tool that saved this tmx file
- * <li><i>tool-name</i> - the full name of the tool that saved this tmx file
- * <li><i>tool-version</i> - the version of the tool that save this tmx file
- * <li><i>tool-company</i> - the name of the company that made this tool
- * <li><i>copyright</i> - a copyright notice that you would like included into the tmx file
  * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
- * <li><i>allowDups</i> - allow duplicate resources in the tmx. By default, dups are
- * filtered out. This option allows you to have trans-units that represent instances of the
- * same resource in the file with different metadata. For example, two instances of a
- * resource may have different comments which may both be useful to translators or
- * two instances of the same resource may have been extracted from different source files.
  * <li><i>version</i> - The version of tmx that will be produced by this instance.
+ * <li><i>properties</i> - an object containing general string properties that will appear in the header
+ *   of the tmx file. Typical properties are:
+ *   <ul>
+ *     <li><i>tool-id</i> - the id of the tool that saved this tmx file
+ *     <li><i>tool-name</i> - the full name of the tool that saved this tmx file
+ *     <li><i>tool-version</i> - the version of the tool that save this tmx file
+ *     <li><i>tool-company</i> - the name of the company that made this tool
+ *     <li><i>copyright</i> - a copyright notice that you would like included into the tmx file
+ *   </ul>
  * </ul>
  *
  * @constructor
@@ -70,18 +225,12 @@ var TU = function TU(options) {
  * initialize the file, or undefined for a new empty file
  */
 var Tmx = function Tmx(options) {
-    this.version = 1.2;
+    this.version = 1.4;
 
     if (options) {
-        this["tool-id"] = options["tool-id"];
-        this["tool-name"] = options["tool-name"];
-        this["tool-version"] = options["tool-version"];
-        this["tool-company"] = options["tool-company"];
-        this.copyright = options.copyright;
+        this.properties = options.properties;
         this.path = options.path;
         this.sourceLocale = options.sourceLocale;
-        this.project = options.project;
-        this.allowDups = options.allowDups;
         if (typeof(options.version) !== 'undefined') {
             this.version = Number.parseFloat(options.version);
         }
@@ -92,8 +241,6 @@ var Tmx = function Tmx(options) {
     // place to store the translation units
     this.tu = [];
     this.tuhash = {};
-
-    this.ts = new TranslationSet(this.sourceLocale);
 };
 
 /**
@@ -106,10 +253,36 @@ Tmx.prototype.getPath = function() {
 
 /**
  * Set the path to this tmx file.
- * @param {String} the path to the tmx file
+ * @param {String} pathName the path to the tmx file
  */
 Tmx.prototype.setPath = function(pathName) {
     this.path = pathName;
+};
+
+/**
+ * Get the string properties of this tmx file from the
+ * header.
+ * @returns {Object} the string properties of this tmx file
+ */
+Tmx.prototype.getProperties = function() {
+    return this.properties;
+};
+
+/**
+ * Set a string property of this tmx file.
+ * @param {String} property the name of the property to set
+ * @param {String} value the value of the property to set
+ */
+Tmx.prototype.addProperty = function(property, value) {
+    this.properties[property] = value;
+};
+
+/**
+ * Set the string properties of this tmx file.
+ * @param {Object} properties the properties to set
+ */
+Tmx.prototype.setProperties = function(properties) {
+    this.path = properties;
 };
 
 /**
@@ -122,23 +295,6 @@ Tmx.prototype.getTranslationUnits = function() {
 };
 
 /**
- * @private
- * @param project
- * @param context
- * @param sourceLocale
- * @param targetLocale
- * @param key
- * @param type
- * @param path
- * @returns
- */
-Tmx.prototype._hashKey = function(project, context, sourceLocale, targetLocale, key, type, path, ordinal, quantity, flavor) {
-    var key = [key, type || "string", sourceLocale || this.sourceLocale, targetLocale || "", context || "", project, path || "", ordinal || "", quantity || "", flavor || ""].join("_");
-    logger.trace("Hashkey is " + key);
-    return key;
-};
-
-/**
  * Add this translation unit to this tmx.
  *
  * @param {TranslationUnit} unit the translation unit to add to this tmx
@@ -146,35 +302,16 @@ Tmx.prototype._hashKey = function(project, context, sourceLocale, targetLocale, 
 Tmx.prototype.addTranslationUnit = function(unit) {
     logger.trace("Tmx " + this.path + ": Adding translation unit: " + JSON.stringify(unit, undefined, 4));
 
-    var hashKeySource = this._hashKey(unit.project, unit.context, unit.sourceLocale, "", unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor),
-        hashKeyTarget = this._hashKey(unit.project, unit.context, unit.sourceLocale, unit.targetLocale, unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor);
+    var hashKey = unit.hashKey();
 
-    if (unit.targetLocale) {
-        var oldUnit = this.tuhash[hashKeySource];
-        if (oldUnit) {
-            logger.trace("Replacing old source-only unit in favour of this joint source/target unit");
-            this.tuhash[hashKeySource] = undefined;
-            JSUtils.shallowCopy(unit, oldUnit);
-            this.tuhash[hashKeyTarget] = oldUnit;
-            return;
-        }
-    }
-
-    var oldUnit = this.tuhash[hashKeyTarget];
-    if (oldUnit && !this.allowDups) {
-        logger.trace("Merging unit");
-        // update the old unit with this new info
-        JSUtils.shallowCopy(unit, oldUnit);
+    if (this.tuhash[hashKey]) {
+        // existing string, so merge in this unit
+        var existing = this.tuhash[hashKey];
+        existing.addVariants(unit.getVariants());
     } else {
-        if (this.version >= 2 && this.tu.length) {
-            if (this.tu[0].targetLocale !== unit.targetLocale) {
-                throw "Mismatched target locale";
-            }
-        }
-
-        logger.trace("Adding new unit");
+        // new string
         this.tu.push(unit);
-        this.tuhash[hashKeyTarget] = unit;
+        this.tuhash[hashKey] = unit;
     }
 };
 
@@ -185,9 +322,9 @@ Tmx.prototype.addTranslationUnit = function(unit) {
  * @param {Array.<Object>} files the translation units to add to this tmx
  */
 Tmx.prototype.addTranslationUnits = function(units) {
-    for (var i = 0; i < units.length; i++) {
-        this.addTranslationUnit(units[i]);
-    }
+    units.forEach(function(unit) {
+        this.addTranslationUnit(unit);
+    });
 };
 
 /**
@@ -202,189 +339,119 @@ Tmx.prototype.addTranslationUnits = function(units) {
  * @param {Resource} res a resource to add
  */
 Tmx.prototype.addResource = function(res) {
-    if (!res) return;
+    if (!res || res.getSourceLocale() !== this.sourceLocale) return;
 
-    if (res.getTargetLocale() === this.sourceLocale || res.getTargetLocale() === "en") {
-        // don't add this one... cannot translate TO the source locale!
-        return;
-    }
+    var tu;
+    var addTarget = res.getTargetLocale() && res.getTargetLocale() !== this.sourceLocale;
 
-    this.ts.add(res);
-};
-
-/**
- * Add a set of resources to this tmx file. If a resource
- * with the same file, locale, context, and key already
- * exists in this tmx file, it will be
- * replaced instead of adding this unit to the file.
- *
- * @param {TranslationSet} set a set of resources to add
- */
-Tmx.prototype.addSet = function(set) {
-    if (!set) return;
-
-    this.ts.addSet(set);
-};
-
-/**
- * Get the resources from this tmx file with the
- * given criteria. If the criteria object is undefined or empty,
- * then all resources are returned. If the criteria parameter
- * is an object, then only resources with properties
- * that match the properties and values in the criteria
- * object are returned.
- *
- * @param {Object|undefined} criteria an object with criteria for
- * selecting which resources to retrieve
- * @return {Array.<Resource>} an array of resources that match
- * the given criteria.
- */
-Tmx.prototype.getResources = function(criteria) {
-    var set = this.getTranslationSet();
-    if (!criteria) return set.getAll();
-    return set.getBy(criteria);
-};
-
-/**
- * Convert a translation unit to a new loctool resource.
- *
- * @param {TranslationUnit} tu the translation to convert
- * @return {Resource} the corresponding resource
- */
-Tmx.prototype.convertTransUnit = function(tu) {
-    var res;
-
-    switch (tu.resType) {
-    default:
-        res = ResourceFactory({
-            pathName: tu.file,
-            project: tu.project,
-            id: tu.id,
-            key: tu.key,
-            sourceLocale: tu.sourceLocale,
-            source: tu.source,
-            targetLocale: tu.targetLocale,
-            context: tu.context,
-            comment: tu.comment,
-            resType: tu.resType,
-            datatype: tu.datatype,
-            state: tu.state,
-            flavor: tu.flavor
-        });
-
-        if (tu.target) {
-            res.setTarget(tu.target);
-        }
-        break;
-
-    case "array":
-        var arr = [];
-        arr[tu.ordinal] = tu.source;
-        res = ResourceFactory({
-            pathName: tu.file,
-            project: tu.project,
-            id: tu.id,
-            key: tu.key,
-            sourceLocale: tu.sourceLocale,
-            sourceArray: arr,
-            targetLocale: tu.targetLocale,
-            targetArray: [],
-            context: tu.context,
-            comment: tu.comment,
-            resType: tu.resType,
-            datatype: tu.datatype,
-            state: tu.state,
-            flavor: tu.flavor
-        });
-
-        if (tu.target) {
-            res.addTarget(tu.ordinal, tu.target);
-        }
-        break;
-
-    case "plural":
-        var strings = {};
-        strings[tu.quantity] = tu.source;
-        res = ResourceFactory({
-            pathName: tu.file,
-            project: tu.project,
-            id: tu.id,
-            key: tu.key,
-            sourceLocale: tu.sourceLocale,
-            sourceStrings: strings,
-            targetLocale: tu.targetLocale,
-            targetStrings: {},
-            context: tu.context,
-            comment: tu.comment,
-            resType: tu.resType,
-            datatype: tu.datatype,
-            state: tu.state,
-            flavor: tu.flavor
-        });
-
-        if (tu.target) {
-            res.addTarget(tu.quantity, tu.target);
-        }
-        break;
-    }
-
-    return res;
-};
-
-/**
- * Return the translation set containing all of the resources in
- * this tmx file.
- *
- * @returns {TranslationSet} the set of all resources in this file
- */
-Tmx.prototype.getTranslationSet = function() {
-    // if there are translation units, convert them to
-    // resources in a translation set before returning the set.
-    var res;
-
-    if (this.tu) {
-        for (var j = 0; j < this.tu.length; j++) {
-            var comment, tu = this.tu[j];
-            switch (tu.resType) {
-            default:
-                res = this.convertTransUnit(tu);
-                this.ts.add(res);
-                break;
-
-            case "array":
-                var res = this.ts.get(ResourceArray.hashKey(tu.project, tu.context, tu.targetLocale || tu.sourceLocale, tu.key));
-                if (res) {
-                    // if it already exists, amend the existing resource instead of creating a new one
-                    res.addSource(tu.ordinal, tu.source);
-                    if (tu.target) {
-                        res.addTarget(tu.ordinal, tu.target);
-                    }
-                } else {
-                    res = this.convertTransUnit(tu);
-                    this.ts.add(res);
-                }
-                break;
-
-            case "plural":
-                var res = this.ts.get(ResourcePlural.hashKey(tu.project, tu.context, tu.targetLocale || tu.sourceLocale, tu.key));
-                if (res) {
-                    // if it already exists, amend the existing resource instead of creating a new one
-                    res.addSource(tu.quantity, tu.source);
-                    if (tu.target) {
-                        res.addTarget(tu.quantity, tu.target);
-                    }
-                } else {
-                    res = this.convertTransUnit(tu);
-                    this.ts.add(res);
-                }
-                break;
+    switch (res.getType()) {
+        default:
+        case "string":
+            tu = new TranslationUnit({
+                locale: res.getSourceLocale(),
+                string: res.getSource(),
+                datatype: res.getDataType()
+            });
+            tu.addVariant(new TranslationVariant({
+                locale: res.getSourceLocale(),
+                string: res.getSource()
+            }));
+            if (addTarget) {
+                tu.addVariant(new TranslationVariant({
+                    locale: res.getTargetLocale(),
+                    string: res.getTarget()
+                }));
             }
-        }
+            tu.addProperties({
+                "x-context": res.getContext(),
+                "x-flavor": res.getFlavor(),
+                "x-project": res.getProject()
+            });
+            this.addTranslationUnit(tu);
+            break;
 
-        this.tu = undefined;
+        case "array":
+            var srcArr = res.getSourceArray();
+            var tarArr = res.getTargetArray();
+            srcArr.forEach(function(string, index) {
+                tu = new TranslationUnit({
+                    locale: res.getSourceLocale(),
+                    string: string,
+                    datatype: res.getDataType()
+                });
+                tu.addVariant(new TranslationVariant({
+                    locale: res.getSourceLocale(),
+                    string: string
+                }));
+                if (addTarget) {
+                    tu.addVariant(new TranslationVariant({
+                        locale: res.getTargetLocale(),
+                        string: tarArr[index]
+                    }));
+                }
+                tu.addProperties({
+                    "x-context": res.getContext(),
+                    "x-flavor": res.getFlavor(),
+                    "x-project": res.getProject()
+                });
+                this.addTranslationUnit(tu);
+            }.bind(this));
+            break;
+
+        case "plural":
+            var srcPlurals = res.getSourcePlurals();
+            var tarPlurals = res.getTargetPlurals();
+            var other;
+
+            for (var category in srcPlurals) {
+                tu = new TranslationUnit({
+                    locale: res.getSourceLocale(),
+                    string: srcPlurals[category],
+                    datatype: res.getDataType()
+                });
+                tu.addVariant(new TranslationVariant({
+                    locale: res.getSourceLocale(),
+                    string: srcPlurals[category]
+                }));
+                // The target plurals may not contain a translation
+                // for every category that exists in the source
+                // plurals because the target language may use less
+                // categories than the source language. So, we have
+                // to check if the target category exists first before
+                // we attempt to add a variant for it.
+                if (addTarget && tarPlurals[category]) {
+                    tu.addVariant(new TranslationVariant({
+                        locale: res.getTargetLocale(),
+                        string: tarPlurals[category]
+                    }));
+                }
+                if (category === "other") {
+                    other = tu;
+                }
+                tu.addProperties({
+                    "x-context": res.getContext(),
+                    "x-flavor": res.getFlavor(),
+                    "x-project": res.getProject()
+                });
+                this.addTranslationUnit(tu);
+            }
+
+            // if the target plurals has more categories than
+            // the source language, we have to check for those extra
+            // categories and add a variant for each of them to the
+            // translation unit for the "other" category
+            if (addTarget) {
+                for (var category in tarPlurals) {
+                    if (!srcPlurals[category]) {
+                        other.addVariant(new TranslationVariant({
+                            locale: res.getTargetLocale(),
+                            string: tarPlurals[category]
+                        }));
+                    }
+                }
+            }
+            break;
     }
-
-    return this.ts;
 };
 
 /**
@@ -394,176 +461,8 @@ Tmx.prototype.getTranslationSet = function() {
  * @return {number} the number of translation units in this tmx file
  */
 Tmx.prototype.size = function() {
-    return this.ts.size();
+    return this.tu.length;
 };
-
-/**
- * Return a string that can be used as an HTML attribute value.
- * @param {string} str the string to escape
- * @returns {string} the escaped string
- */
-function escapeAttr(str) {
-    if (!str) return;
-    return str.
-        replace(/\n/g, "\\n").
-        replace(/&/g, "&amp;").
-        replace(/"/g, "&quot;").
-        replace(/'/g, "&apos;");
-}
-
-/**
- * Return the original string based on the one that was used as an attribute value.
- * @param {string} str the string to unescape
- * @returns {string} the unescaped string
- */
-function unescapeAttr(str) {
-    if (!str) return;
-    return str.
-        replace(/\\n/g, "\n").
-        replace(/&quot;/g, '"').
-        replace(/&apos;/g, "'").
-        replace(/&amp;/g, "&");
-}
-
-/**
- * Convert a resource into one or more translation units.
- *
- * @private
- * @param {Resource} res the resource to convert
- * @returns {Array.<TranslationUnit>} an array of translation units
- * that represent the resource
- */
-Tmx.prototype._convertResource = function(res) {
-    var units = [], tu;
-
-    try {
-        switch (res.resType) {
-        case "string":
-            tu = new TranslationUnit({
-                project: res.project,
-                key: res.getKey(),
-                file: res.getPath(),
-                sourceLocale: res.getSourceLocale(),
-                source: res.getSource(),
-                targetLocale: res.getTargetLocale(),
-                target: res.getTarget(),
-                state: res.getState(),
-                id: res.getId(),
-                translated: true,
-                context: res.context,
-                comment: res.comment,
-                resType: res.resType,
-                datatype: res.datatype,
-                flavor: res.getFlavor ? res.getFlavor() : undefined
-            });
-            units.push(tu);
-            break;
-
-        case "array":
-            var sarr = res.getSourceArray();
-            var tarr = res.getTargetArray();
-
-            tu = new TranslationUnit({
-                project: res.project,
-                key: res.getKey(),
-                file: res.getPath(),
-                source: " ",
-                sourceLocale: res.getSourceLocale(),
-                targetLocale: res.getTargetLocale(),
-                state: res.getState(),
-                id: res.getId(),
-                translated: true,
-                context: res.context,
-                comment: res.comment,
-                resType: res.resType,
-                datatype: res.datatype,
-                flavor: res.getFlavor ? res.getFlavor() : undefined
-            });
-
-            for (var j = 0; j < sarr.length; j++) {
-                // only output array items that have a translation
-                if (sarr[j]) {
-                    var newtu = tu.clone();
-                    newtu.source = sarr[j];
-                    newtu.ordinal = j;
-
-                    if (tarr && j < tarr.length && tarr[j]) {
-                        newtu.target = tarr[j];
-                    }
-
-                    newtu.ordinal = j;
-                    units.push(newtu);
-                } else if (tarr[j]) {
-                    logger.warn("Translated array  " + res.getKey() + " has no source string at index " + j + ". Cannot translate. Resource is: " + JSON.stringify(res, undefined, 4));
-                }
-            }
-            break;
-
-        case "plural":
-            tu = new TranslationUnit({
-                project: res.project,
-                key: res.getKey(),
-                file: res.getPath(),
-                source: " ",
-                sourceLocale: res.getSourceLocale(),
-                targetLocale: res.getTargetLocale(),
-                state: res.getState(),
-                id: res.getId(),
-                translated: true,
-                context: res.context,
-                comment: res.comment,
-                resType: res.resType,
-                datatype: res.datatype,
-                flavor: res.getFlavor ? res.getFlavor() : undefined
-            });
-
-            var sp = res.getSourcePlurals();
-            var tp = res.getTargetPlurals();
-
-            for (var p in sp) {
-                if (sp[p]) {
-                    var newtu = tu.clone();
-                    newtu.source = sp[p];
-
-                    if (tp && tp[p]) {
-                        newtu.target = tp[p];
-                        newtu.quantity = p;
-                    }
-                    newtu.quantity = p;
-                    units.push(newtu);
-                } else {
-                    logger.warn("Translated plural  " + res.getKey() + " has no source plural, quantity " + p + ": " + JSON.stringify(res, undefined, 4));
-                }
-            }
-            break;
-        }
-    } catch (e) {
-        logger.warn(e);
-        logger.warn(JSON.stringify(res));
-        logger.warn("Skipping that resource.");
-    }
-
-    return units;
-};
-
-/**
- * Convert a resource into translation units.
- *
- * @param {Resource} res the resource to convert
- * @returns {Array.<TranslationUnit>} an array of translation units
- * that represent the resource
- */
-Tmx.prototype.convertResource = function(res) {
-    return this._convertResource(res);
-};
-
-function makeHashKey(res, ordinal, quantity) {
-    return [res.getPath(), res.getKey(), res.getContext(), res.getProject(), ordinal, quantity].join("_");
-}
-
-function makeTUHashKey(tu) {
-    return [tu.file, tu.sourceLocale, tu.targetLocale || "", tu.project].join("_");
-}
 
 function versionString(num) {
     parts = ("" + num).split(".");
@@ -573,111 +472,27 @@ function versionString(num) {
 }
 
 /**
- * Serialize this tmx instance as an tmx 1.2 string.
- * @param {Array.<TranslationUnit>} units an array of units to convert to a string
- * @return {String} the current instance encoded as an tmx 1.2
- * format string
+ * Serialize this tmx instance to a string that contains
+ * the tmx format xml text.
+ *
+ * @return {String} the current instance encoded as an tmx format
+ * xml text
  */
-Tmx.prototype.toString1 = function(units) {
+Tmx.prototype.serialize = function() {
     var json = {
         tmx: {
             _attributes: {
                 version: versionString(this.version)
+            },
+            body: {
             }
         }
     };
 
-    logger.trace("Units to write out is " + JSON.stringify(units, undefined, 4));
-
     // now finally add each of the units to the json
 
-    var files = {};
-    var index = 1;
-
-    for (var i = 0; i < units.length; i++) {
-        var tu = units[i];
-        if (!tu) {
-            console.log("undefined?");
-        }
-        var hashKey = makeTUHashKey(tu);
-        var file = files[hashKey];
-        if (!file) {
-            files[hashKey] = file = {
-                _attributes: {
-                    "original": tu.file,
-                    "source-language": tu.sourceLocale,
-                    "target-language": tu.targetLocale,
-                    "product-name": tu.project,
-                    "x-flavor": tu.flavor
-                }
-            };
-            if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] ||  this["company"]) {
-                file.header = {
-                    "tool": {
-                        _attributes: {
-                            "creationtool": this["tool-name"],
-                            "creationtoolversion": this["tool-version"],
-                            "tool-company": this["tool-company"],
-                            "copyright": this["copyright"]
-                        }
-                    }
-                };
-            }
-            file.body = {};
-        }
-
-        var tujson = {
-            _attributes: {
-                "id": (tu.id || index++),
-                "resname": escapeAttr(tu.key),
-                "restype": tu.resType || "string",
-                "datatype": tu.datatype
-            },
-            "source": {
-                "_text": tu.source
-            }
-        };
-
-        if (tu.id && tu.id > index) {
-            index = tu.id + 1;
-        }
-
-        if (tu.resType === "plural") {
-            tujson._attributes.extype = tu.quantity || "other";
-        }
-        if (tu.resType === "array") {
-            tujson._attributes.extype = tu.ordinal;
-        }
-
-        if (tu.target) {
-            tujson.target = {
-                _attributes: {
-                    state: tu.state
-                },
-                "_text": tu.target
-            };
-        }
-        if (tu.comment) {
-            tujson.note = {
-                "_text": tu.comment
-            };
-        }
-        if (tu.context) {
-            tujson._attributes["x-context"] = tu.context;
-        }
-        if (!file.body["trans-unit"]) {
-            file.body["trans-unit"] = [];
-        }
-
-        file.body["trans-unit"].push(tujson);
-    }
-
-    // sort the file tags so that they come out in the same order each time
-    if (!json.tmx.file) {
-        json.tmx.file = [];
-    }
-    Object.keys(files).sort().forEach(function(fileHashKey) {
-        json.tmx.file.push(files[fileHashKey]);
+    json.tmx.body.tu = this.tu.map(function(unit) {
+        return unit.serialize();
     });
 
     // logger.trace("json is " + JSON.stringify(json, undefined, 4));
@@ -691,152 +506,10 @@ Tmx.prototype.toString1 = function(units) {
 };
 
 /**
- * Serialize this tmx instance to a string that contains
- * the tmx format xml text.
- *
- * @param {boolean} untranslated if true, add the untranslated resources
- * to the tmx file without target tags. Otherwiwe, untranslated
- * resources are skipped.
- * @return {String} the current instance encoded as an tmx format
- * xml text
- */
-Tmx.prototype.serialize = function(untranslated) {
-    var units = [];
-
-    if (this.ts.size() > 0) {
-        // first convert the resources into translation units
-        var resources = this.ts.getAll();
-        var tu;
-
-        if (this.allowDups) {
-            // only look at the initial set of resources
-            var initialLength = resources.length;
-            for (var i = 0; i < initialLength; i++) {
-                var res = resources[i];
-                var instances = res.getInstances();
-                if (instances && instances.length) {
-                    resources = resources.concat(instances);
-                    resources[i].instances = undefined;
-                }
-            }
-        }
-        resources.sort(function(left, right) {
-            if (typeof(left.index) === 'number' && typeof(right.index) === 'number') {
-                return left.index - right.index;
-            }
-            if (typeof(left.id) === 'number' && typeof(right.id) === 'number') {
-                return left.id - right.id;
-            }
-            // no ids and no indexes? Well, then don't rearrange
-            return 0;
-        });
-
-        // now add the translations
-        for (var i = 0; i < resources.length; i++) {
-            var res = resources[i];
-            if (res.getTargetLocale() !== this.sourceLocale) {
-                units = units.concat(this.convertResource(res));
-            }
-        }
-    }
-
-    if (this.tu && this.tu.length > 0) {
-        units = units.concat(this.tu);
-    }
-
-    return this.toString1(units);
-};
-
-/**
- * Parse tmx 1.* files
+ * Parse tmx 1.4 files -- not implemented yet
  * @private
  */
 Tmx.prototype.parse = function(tmx) {
-    if (tmx.file) {
-        var files = ilib.isArray(tmx.file) ? tmx.file : [ tmx.file ];
-        var comment;
-
-        for (var i = 0; i < files.length; i++) {
-            var fileSettings = {};
-            var file = files[i];
-
-            fileSettings = {
-                pathName: file._attributes.original,
-                locale: file._attributes["source-language"],
-                project: file._attributes["product-name"] || file._attributes["original"],
-                targetLocale: file._attributes["target-language"],
-                flavor: file._attributes["x-flavor"]
-            };
-
-            fileSettings.isAsianLocale = utils.isAsianLocale(fileSettings.targetLocale);
-
-            if (file.body && file.body["trans-unit"]) {
-                var units = ilib.isArray(file.body["trans-unit"]) ? file.body["trans-unit"] : [ file.body["trans-unit"] ];
-
-                units.forEach(function(tu) {
-                    if (tu.source && tu.source["_text"] && tu.source["_text"].trim().length > 0) {
-                        var targetString;
-                        if (tu.target) {
-                            if (tu.target["_text"]) {
-                                targetString = tu.target["_text"];
-                            } else if (tu.target.mrk) {
-                                if (ilib.isArray(tu.target.mrk)) {
-                                    var targetSegments = tu.target.mrk.map(function(mrk) {
-                                        return mrk["_text"];
-                                    })
-                                    targetString = targetSegments.join(fileSettings.isAsianLocale ? '' : ' ');
-                                } else {
-                                    targetString = tu.target.mrk["_text"];
-                                }
-                            }
-                        }
-
-                        if (!tu._attributes.resname) {
-                            if (tu.source._attributes && tu.source._attributes["x-key"]) {
-                                tu.source["_text"] = tu.source._attributes["x-key"];
-                                tu._attributes.resname = tu.source._attributes["x-key"];
-                            } else {
-                                tu._attributes.resname = tu.source["_text"];
-                            }
-                        }
-
-                        try {
-                            var unit = new TranslationUnit({
-                                file: fileSettings.pathName,
-                                sourceLocale: fileSettings.locale,
-                                project: fileSettings.project,
-                                id: tu._attributes.id,
-                                key: unescapeAttr(tu._attributes.resname),
-                                source: tu.source["_text"],
-                                context: tu._attributes["x-context"],
-                                comment: comment,
-                                targetLocale: fileSettings.targetLocale,
-                                comment: tu.note && tu.note["_text"],
-                                target: targetString,
-                                resType: tu._attributes.restype,
-                                state: tu.target && tu.target._attributes && tu.target._attributes.state,
-                                datatype: tu._attributes.datatype,
-                                flavor: fileSettings.flavor
-                            });
-                            switch (unit.resType) {
-                            case "array":
-                                unit.ordinal = tu._attributes.extype && Number(tu._attributes.extype).valueOf();
-                                break;
-                            case "plural":
-                                unit.quantity = tu._attributes.extype;
-                                break;
-                            }
-                            this.tu.push(unit);
-                        } catch (e) {
-                            logger.warn("Skipping invalid translation unit found in tmx file.\n" + e);
-                        }
-                    } else {
-                        logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu._attributes.resname);
-                    }
-                }.bind(this));
-            }
-        }
-    }
 };
 
 function makeArray(arrayOrObject) {
@@ -857,13 +530,14 @@ Tmx.prototype.deserialize = function(xml) {
         compact: true
     });
 
+/* not implemented yet
     // logger.trace("json is " + JSON.stringify(json, undefined, 4));
     this.ts = new TranslationSet(this.sourceLocale);
 
     if (json.tmx) {
         if (!json.tmx._attributes ||
                 !json.tmx._attributes.version ||
-                json.tmx._attributes.version !== "1.4b") {
+                json.tmx._attributes.version !== "1.4") {
             logger.error("Unknown tmx version " + json.tmx._attributes.version + ". Cannot continue parsing. Can only parse v1.4b files.");
             return;
         }
@@ -874,6 +548,7 @@ Tmx.prototype.deserialize = function(xml) {
     // logger.trace("this.tu is " + JSON.stringify(this.tu, undefined, 4));
 
     return this.ts;
+*/
 };
 
 /**
@@ -884,7 +559,8 @@ Tmx.prototype.deserialize = function(xml) {
  * @returns {String} the version of this tmx
  */
 Tmx.prototype.getVersion = function() {
-    return this.version || "1.4b";
+    return this.version || "1.4";
 };
+
 
 module.exports = Tmx;

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+var path = require("path");
+var fs = require("fs");
+
 var log4js = require("log4js");
 var xmljs = require("xml-js");
 var ilib = require("ilib");
@@ -291,7 +294,7 @@ Tmx.prototype.addProperty = function(property, value) {
  * @param {Object} properties the properties to set
  */
 Tmx.prototype.setProperties = function(properties) {
-    this.path = properties;
+    this.properties = properties;
 };
 
 /**
@@ -354,7 +357,9 @@ Tmx.prototype.segmentString = function(string, locale) {
 
     var l = new Locale(locale);
     var suppressions = cldrSegmentation.suppressions[l.getLanguage()];
-    return cldrSegmentation.sentenceSplit(string, suppressions);
+    return cldrSegmentation.sentenceSplit(string, suppressions).map(function(str) {
+        return str ? str.trim() : str;
+    });
 };
 
 /**
@@ -645,5 +650,18 @@ Tmx.prototype.getVersion = function() {
     return this.version || "1.4";
 };
 
+/**
+ * Write out the tmx file to the path.
+ * @param {String|undefined} targetDir if the path was given as relative, then
+ * this is the directory that it is relative to. If it was given as absolute,
+ * you can pass in undefined.
+ */
+Tmx.prototype.write = function(targetDir) {
+    if (!this.path) return; // can't write without a path
+    var fullpath = targetDir ? path.join(targetDir, this.path) : this.path;
+    var dir = path.dirname(fullpath);
+    utils.makeDirs(dir);
+    fs.writeFileSync(fullpath, this.serialize(), "utf-8");
+};
 
 module.exports = Tmx;

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -21,6 +21,8 @@ var log4js = require("log4js");
 var xmljs = require("xml-js");
 var ilib = require("ilib");
 var JSUtils = require("ilib/lib/JSUtils");
+var Locale = require("ilib/lib/Locale");
+var cldrSegmentation = require("cldr-segmentation");
 
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
@@ -87,7 +89,7 @@ TranslationVariant.prototype.hashKey = function() {
  * - datatype: the type of data that this string came from
  *
  * @param {Object} options options for this unit
- */ 
+ */
 var TranslationUnit = function TranslationUnit(options) {
     this.locale = options.locale;
     this.string = options.string;
@@ -193,7 +195,7 @@ TranslationUnit.prototype.serialize = function() {
     retval.tuv = this.variants.map(function(variant) {
         return variant.serialize();
     });
-    
+
     return retval;
 };
 
@@ -207,17 +209,20 @@ TranslationUnit.prototype.serialize = function() {
  *
  * <ul>
  * <li><i>path</i> - the path to the tmx file on disk
- * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
- * <li><i>version</i> - The version of tmx that will be produced by this instance.
+ * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself.
+ * Default is "en-US".
+ * <li><i>version</i> - The version of tmx that will be produced by this instance. Default is "1.4".
  * <li><i>properties</i> - an object containing general string properties that will appear in the header
  *   of the tmx file. Typical properties are:
  *   <ul>
- *     <li><i>tool-id</i> - the id of the tool that saved this tmx file
- *     <li><i>tool-name</i> - the full name of the tool that saved this tmx file
- *     <li><i>tool-version</i> - the version of the tool that save this tmx file
- *     <li><i>tool-company</i> - the name of the company that made this tool
- *     <li><i>copyright</i> - a copyright notice that you would like included into the tmx file
+ *     <li><i>creationtool</i> - the full name of the tool that created this tmx file. Default: "loctool"
+ *     <li><i>creationtoolversion</i> - the version of the tool that created this tmx file. Default: the version
+ *         of this loctool
+ *     <li><i>originalFormat</i> - the format of the data before it was transformed into tmx. That can be any
+ *         string.
  *   </ul>
+ * <li><i>segmentation</i> - How the strings should be segmented. Choices are "paragraph" and "sentence."
+ * Default is "paragraph". The tmx settings of "block" and "phrase" are not yet supported.
  * </ul>
  *
  * @constructor
@@ -226,17 +231,21 @@ TranslationUnit.prototype.serialize = function() {
  */
 var Tmx = function Tmx(options) {
     this.version = 1.4;
+    this.properties = {};
+    this.sourceLocale = "en-US";
+    this.segmentation = "paragraph";
 
     if (options) {
-        this.properties = options.properties;
+        this.properties = options.properties || this.properties;
         this.path = options.path;
-        this.sourceLocale = options.sourceLocale;
+        this.sourceLocale = options.sourceLocale || this.sourceLocale;
         if (typeof(options.version) !== 'undefined') {
             this.version = Number.parseFloat(options.version);
         }
+        if (options.segmentation && (options.segmentation === "paragraph" || options.segmentation === "sentence")) {
+            this.segmentation = options.segmentation;
+        }
     }
-
-    this.sourceLocale = this.sourceLocale || "en-US";
 
     // place to store the translation units
     this.tu = [];
@@ -328,6 +337,27 @@ Tmx.prototype.addTranslationUnits = function(units) {
 };
 
 /**
+ * Segment a string according to the rules for the locale, and the style
+ * set for this tmx object, either "paragraph" or "sentence", and return
+ * an array of segments.
+ *
+ * @param {String} string the string to segment
+ * @param {String} locale the locale
+ * @returns {Array.<String>} an array containing one or more strings that
+ * are the segments of the current string
+ */
+Tmx.prototype.segmentString = function(string, locale) {
+    if (!string) return [];
+    if (this.segmentation === "paragraph") {
+        return [string];
+    }
+
+    var l = new Locale(locale);
+    var suppressions = cldrSegmentation.suppressions[l.getLanguage()];
+    return cldrSegmentation.sentenceSplit(string, suppressions);
+};
+
+/**
  * Add a resource to this tmx file. If a resource
  * with the same file, locale, context, and key already
  * exists in this tmx file, what happens to it is
@@ -347,46 +377,22 @@ Tmx.prototype.addResource = function(res) {
     switch (res.getType()) {
         default:
         case "string":
-            tu = new TranslationUnit({
-                locale: res.getSourceLocale(),
-                string: res.getSource(),
-                datatype: res.getDataType()
-            });
-            tu.addVariant(new TranslationVariant({
-                locale: res.getSourceLocale(),
-                string: res.getSource()
-            }));
-            if (addTarget) {
-                tu.addVariant(new TranslationVariant({
-                    locale: res.getTargetLocale(),
-                    string: res.getTarget()
-                }));
-            }
-            tu.addProperties({
-                "x-context": res.getContext(),
-                "x-flavor": res.getFlavor(),
-                "x-project": res.getProject()
-            });
-            this.addTranslationUnit(tu);
-            break;
-
-        case "array":
-            var srcArr = res.getSourceArray();
-            var tarArr = res.getTargetArray();
-            srcArr.forEach(function(string, index) {
+            var translationSegments = addTarget && this.segmentString(res.getTarget(), res.getTargetLocale());
+            var sourceSegments = this.segmentString(res.getSource(), res.getSourceLocale());
+            sourceSegments.forEach(function(segment, i) {
                 tu = new TranslationUnit({
                     locale: res.getSourceLocale(),
-                    string: string,
+                    string: segment,
                     datatype: res.getDataType()
                 });
                 tu.addVariant(new TranslationVariant({
                     locale: res.getSourceLocale(),
-                    string: string
+                    string: segment
                 }));
                 if (addTarget) {
                     tu.addVariant(new TranslationVariant({
                         locale: res.getTargetLocale(),
-                        string: tarArr[index]
+                        string: translationSegments[i]
                     }));
                 }
                 tu.addProperties({
@@ -398,42 +404,84 @@ Tmx.prototype.addResource = function(res) {
             }.bind(this));
             break;
 
+        case "array":
+            var srcArr = res.getSourceArray().map(function(element) {
+                return this.segmentString(element, res.getSourceLocale());
+            }.bind(this));
+            var tarArr = addTarget && res.getTargetArray().map(function(element) {
+                return this.segmentString(element, res.getTargetLocale());
+            }.bind(this));
+            srcArr.forEach(function(element, i) {
+                element.forEach(function(string, j) {
+                    tu = new TranslationUnit({
+                        locale: res.getSourceLocale(),
+                        string: string,
+                        datatype: res.getDataType()
+                    });
+                    tu.addVariant(new TranslationVariant({
+                        locale: res.getSourceLocale(),
+                        string: string
+                    }));
+                    if (addTarget) {
+                        tu.addVariant(new TranslationVariant({
+                            locale: res.getTargetLocale(),
+                            string: tarArr[i][j]
+                        }));
+                    }
+                    tu.addProperties({
+                        "x-context": res.getContext(),
+                        "x-flavor": res.getFlavor(),
+                        "x-project": res.getProject()
+                    });
+                    this.addTranslationUnit(tu);
+                }.bind(this));
+            }.bind(this));
+            break;
+
         case "plural":
             var srcPlurals = res.getSourcePlurals();
             var tarPlurals = res.getTargetPlurals();
-            var other;
+            var other = [];
+            srcPlurals = utils.objectMap(srcPlurals, function(string) {
+                return this.segmentString(string, res.getSourceLocale());
+            }.bind(this));
+            tarPlurals = utils.objectMap(tarPlurals, function(string) {
+                return this.segmentString(string, res.getTargetLocale());
+            }.bind(this));
 
             for (var category in srcPlurals) {
-                tu = new TranslationUnit({
-                    locale: res.getSourceLocale(),
-                    string: srcPlurals[category],
-                    datatype: res.getDataType()
-                });
-                tu.addVariant(new TranslationVariant({
-                    locale: res.getSourceLocale(),
-                    string: srcPlurals[category]
-                }));
-                // The target plurals may not contain a translation
-                // for every category that exists in the source
-                // plurals because the target language may use less
-                // categories than the source language. So, we have
-                // to check if the target category exists first before
-                // we attempt to add a variant for it.
-                if (addTarget && tarPlurals[category]) {
+                srcPlurals[category].forEach(function(string, i) {
+                    tu = new TranslationUnit({
+                        locale: res.getSourceLocale(),
+                        string: string,
+                        datatype: res.getDataType()
+                    });
                     tu.addVariant(new TranslationVariant({
-                        locale: res.getTargetLocale(),
-                        string: tarPlurals[category]
+                        locale: res.getSourceLocale(),
+                        string: string
                     }));
-                }
-                if (category === "other") {
-                    other = tu;
-                }
-                tu.addProperties({
-                    "x-context": res.getContext(),
-                    "x-flavor": res.getFlavor(),
-                    "x-project": res.getProject()
-                });
-                this.addTranslationUnit(tu);
+                    // The target plurals may not contain a translation
+                    // for every category that exists in the source
+                    // plurals because the target language may use less
+                    // categories than the source language. So, we have
+                    // to check if the target category exists first before
+                    // we attempt to add a variant for it.
+                    if (addTarget && tarPlurals[category]) {
+                        tu.addVariant(new TranslationVariant({
+                            locale: res.getTargetLocale(),
+                            string: tarPlurals[category][i]
+                        }));
+                    }
+                    if (category === "other") {
+                        other.push(tu);
+                    }
+                    tu.addProperties({
+                        "x-context": res.getContext(),
+                        "x-flavor": res.getFlavor(),
+                        "x-project": res.getProject()
+                    });
+                    this.addTranslationUnit(tu);
+                }.bind(this));
             }
 
             // if the target plurals has more categories than
@@ -443,10 +491,12 @@ Tmx.prototype.addResource = function(res) {
             if (addTarget) {
                 for (var category in tarPlurals) {
                     if (!srcPlurals[category]) {
-                        other.addVariant(new TranslationVariant({
-                            locale: res.getTargetLocale(),
-                            string: tarPlurals[category]
-                        }));
+                        tarPlurals[category].forEach(function(string, i) {
+                            other[i].addVariant(new TranslationVariant({
+                                locale: res.getTargetLocale(),
+                                string: string
+                            }));
+                        });
                     }
                 }
             }
@@ -471,6 +521,11 @@ function versionString(num) {
     return integral + '.' + fraction;
 }
 
+function getVersion() {
+    var pkg = require("../package.json");
+    return pkg ? pkg.version : undefined;
+}
+
 /**
  * Serialize this tmx instance to a string that contains
  * the tmx format xml text.
@@ -484,10 +539,38 @@ Tmx.prototype.serialize = function() {
             _attributes: {
                 version: versionString(this.version)
             },
+            header: {
+                _attributes: {
+                    segtype: this.segmentation,
+                    creationtool: this.properties.creationtool || "loctool",
+                    creationtoolversion: this.properties.creationtoolversion || getVersion(),
+                    adminlang: "en-US",
+                    srclang: this.locale,
+                    datatype: "unknown"
+                }
+            },
             body: {
             }
         }
     };
+
+    if (this.properties.originalFormat) {
+        json.tmx.header._attributes["o-tmf"] = this.properties.originalFormat;
+    }
+
+    var props = Object.keys(this.properties).forEach(function(prop) {
+        if (prop !== "creationtool" && prop !== "creationtoolversion") {
+            if (!json.tmx.header.prop) {
+                json.tmx.header.prop = [];
+            }
+            json.tmx.header.prop.push({
+                _attributes: {
+                    type: prop
+                },
+                _text: this.properties[prop]
+            });
+        }
+    }.bind(this));
 
     // now finally add each of the units to the json
 

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -1,0 +1,890 @@
+/*
+ * TMX.js - model an tmx file
+ *
+ * Copyright © 2021 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var log4js = require("log4js");
+var xmljs = require("xml-js");
+var ilib = require("ilib");
+var JSUtils = require("ilib/lib/JSUtils");
+
+var utils = require("./utils.js");
+var TranslationSet = require("./TranslationSet.js");
+var ResourcePlural = require("./ResourcePlural.js");
+var ResourceArray = require("./ResourceArray.js");
+var ResourceFactory = require("./ResourceFactory.js");
+var TranslationUnit = require("./Xliff.js").TranslationUnit;
+
+var logger = log4js.getLogger("loctool.lib.Tmx");
+
+/**
+ * @class A class that represents a tmx translation unit variant.
+ */
+var TUV = function Tuv(options) {
+    this.locale = options.locale;
+    this.string = options.string;
+};
+
+var TU = function TU(options) {
+};
+
+/**
+ * @class A class that represents an tmx 1.4b file.
+ * See https://www.gala-global.org/tmx-14b for details on the file format.
+ * The options may be undefined, which represents a new,
+ * clean Tmx instance. The options object may also
+ * be an object with the following properties:
+ *
+ * <ul>
+ * <li><i>path</i> - the path to the tmx file on disk
+ * <li><i>tool-id</i> - the id of the tool that saved this tmx file
+ * <li><i>tool-name</i> - the full name of the tool that saved this tmx file
+ * <li><i>tool-version</i> - the version of the tool that save this tmx file
+ * <li><i>tool-company</i> - the name of the company that made this tool
+ * <li><i>copyright</i> - a copyright notice that you would like included into the tmx file
+ * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
+ * <li><i>allowDups</i> - allow duplicate resources in the tmx. By default, dups are
+ * filtered out. This option allows you to have trans-units that represent instances of the
+ * same resource in the file with different metadata. For example, two instances of a
+ * resource may have different comments which may both be useful to translators or
+ * two instances of the same resource may have been extracted from different source files.
+ * <li><i>version</i> - The version of tmx that will be produced by this instance.
+ * </ul>
+ *
+ * @constructor
+ * @param {Array.<Object>|undefined} options options to
+ * initialize the file, or undefined for a new empty file
+ */
+var Tmx = function Tmx(options) {
+    this.version = 1.2;
+
+    if (options) {
+        this["tool-id"] = options["tool-id"];
+        this["tool-name"] = options["tool-name"];
+        this["tool-version"] = options["tool-version"];
+        this["tool-company"] = options["tool-company"];
+        this.copyright = options.copyright;
+        this.path = options.path;
+        this.sourceLocale = options.sourceLocale;
+        this.project = options.project;
+        this.allowDups = options.allowDups;
+        if (typeof(options.version) !== 'undefined') {
+            this.version = Number.parseFloat(options.version);
+        }
+    }
+
+    this.sourceLocale = this.sourceLocale || "en-US";
+
+    // place to store the translation units
+    this.tu = [];
+    this.tuhash = {};
+
+    this.ts = new TranslationSet(this.sourceLocale);
+};
+
+/**
+ * Get the path to this tmx file.
+ * @returns {String|undefined} the path to this tmx file
+ */
+Tmx.prototype.getPath = function() {
+    return this.path;
+};
+
+/**
+ * Set the path to this tmx file.
+ * @param {String} the path to the tmx file
+ */
+Tmx.prototype.setPath = function(pathName) {
+    this.path = pathName;
+};
+
+/**
+ * Get the translation units in this tmx.
+ *
+ * @returns {Array.<Object>} the translation units in this tmx
+ */
+Tmx.prototype.getTranslationUnits = function() {
+    return this.tu;
+};
+
+/**
+ * @private
+ * @param project
+ * @param context
+ * @param sourceLocale
+ * @param targetLocale
+ * @param key
+ * @param type
+ * @param path
+ * @returns
+ */
+Tmx.prototype._hashKey = function(project, context, sourceLocale, targetLocale, key, type, path, ordinal, quantity, flavor) {
+    var key = [key, type || "string", sourceLocale || this.sourceLocale, targetLocale || "", context || "", project, path || "", ordinal || "", quantity || "", flavor || ""].join("_");
+    logger.trace("Hashkey is " + key);
+    return key;
+};
+
+/**
+ * Add this translation unit to this tmx.
+ *
+ * @param {TranslationUnit} unit the translation unit to add to this tmx
+ */
+Tmx.prototype.addTranslationUnit = function(unit) {
+    logger.trace("Tmx " + this.path + ": Adding translation unit: " + JSON.stringify(unit, undefined, 4));
+
+    var hashKeySource = this._hashKey(unit.project, unit.context, unit.sourceLocale, "", unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor),
+        hashKeyTarget = this._hashKey(unit.project, unit.context, unit.sourceLocale, unit.targetLocale, unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor);
+
+    if (unit.targetLocale) {
+        var oldUnit = this.tuhash[hashKeySource];
+        if (oldUnit) {
+            logger.trace("Replacing old source-only unit in favour of this joint source/target unit");
+            this.tuhash[hashKeySource] = undefined;
+            JSUtils.shallowCopy(unit, oldUnit);
+            this.tuhash[hashKeyTarget] = oldUnit;
+            return;
+        }
+    }
+
+    var oldUnit = this.tuhash[hashKeyTarget];
+    if (oldUnit && !this.allowDups) {
+        logger.trace("Merging unit");
+        // update the old unit with this new info
+        JSUtils.shallowCopy(unit, oldUnit);
+    } else {
+        if (this.version >= 2 && this.tu.length) {
+            if (this.tu[0].targetLocale !== unit.targetLocale) {
+                throw "Mismatched target locale";
+            }
+        }
+
+        logger.trace("Adding new unit");
+        this.tu.push(unit);
+        this.tuhash[hashKeyTarget] = unit;
+    }
+};
+
+
+/**
+ * Add translation units to this tmx.
+ *
+ * @param {Array.<Object>} files the translation units to add to this tmx
+ */
+Tmx.prototype.addTranslationUnits = function(units) {
+    for (var i = 0; i < units.length; i++) {
+        this.addTranslationUnit(units[i]);
+    }
+};
+
+/**
+ * Add a resource to this tmx file. If a resource
+ * with the same file, locale, context, and key already
+ * exists in this tmx file, what happens to it is
+ * determined by the allowDups option. If this is false,
+ * the existing resource will be replaced, and if it
+ * is true, this new resource will be added as an
+ * instance of the existing resource.
+ *
+ * @param {Resource} res a resource to add
+ */
+Tmx.prototype.addResource = function(res) {
+    if (!res) return;
+
+    if (res.getTargetLocale() === this.sourceLocale || res.getTargetLocale() === "en") {
+        // don't add this one... cannot translate TO the source locale!
+        return;
+    }
+
+    this.ts.add(res);
+};
+
+/**
+ * Add a set of resources to this tmx file. If a resource
+ * with the same file, locale, context, and key already
+ * exists in this tmx file, it will be
+ * replaced instead of adding this unit to the file.
+ *
+ * @param {TranslationSet} set a set of resources to add
+ */
+Tmx.prototype.addSet = function(set) {
+    if (!set) return;
+
+    this.ts.addSet(set);
+};
+
+/**
+ * Get the resources from this tmx file with the
+ * given criteria. If the criteria object is undefined or empty,
+ * then all resources are returned. If the criteria parameter
+ * is an object, then only resources with properties
+ * that match the properties and values in the criteria
+ * object are returned.
+ *
+ * @param {Object|undefined} criteria an object with criteria for
+ * selecting which resources to retrieve
+ * @return {Array.<Resource>} an array of resources that match
+ * the given criteria.
+ */
+Tmx.prototype.getResources = function(criteria) {
+    var set = this.getTranslationSet();
+    if (!criteria) return set.getAll();
+    return set.getBy(criteria);
+};
+
+/**
+ * Convert a translation unit to a new loctool resource.
+ *
+ * @param {TranslationUnit} tu the translation to convert
+ * @return {Resource} the corresponding resource
+ */
+Tmx.prototype.convertTransUnit = function(tu) {
+    var res;
+
+    switch (tu.resType) {
+    default:
+        res = ResourceFactory({
+            pathName: tu.file,
+            project: tu.project,
+            id: tu.id,
+            key: tu.key,
+            sourceLocale: tu.sourceLocale,
+            source: tu.source,
+            targetLocale: tu.targetLocale,
+            context: tu.context,
+            comment: tu.comment,
+            resType: tu.resType,
+            datatype: tu.datatype,
+            state: tu.state,
+            flavor: tu.flavor
+        });
+
+        if (tu.target) {
+            res.setTarget(tu.target);
+        }
+        break;
+
+    case "array":
+        var arr = [];
+        arr[tu.ordinal] = tu.source;
+        res = ResourceFactory({
+            pathName: tu.file,
+            project: tu.project,
+            id: tu.id,
+            key: tu.key,
+            sourceLocale: tu.sourceLocale,
+            sourceArray: arr,
+            targetLocale: tu.targetLocale,
+            targetArray: [],
+            context: tu.context,
+            comment: tu.comment,
+            resType: tu.resType,
+            datatype: tu.datatype,
+            state: tu.state,
+            flavor: tu.flavor
+        });
+
+        if (tu.target) {
+            res.addTarget(tu.ordinal, tu.target);
+        }
+        break;
+
+    case "plural":
+        var strings = {};
+        strings[tu.quantity] = tu.source;
+        res = ResourceFactory({
+            pathName: tu.file,
+            project: tu.project,
+            id: tu.id,
+            key: tu.key,
+            sourceLocale: tu.sourceLocale,
+            sourceStrings: strings,
+            targetLocale: tu.targetLocale,
+            targetStrings: {},
+            context: tu.context,
+            comment: tu.comment,
+            resType: tu.resType,
+            datatype: tu.datatype,
+            state: tu.state,
+            flavor: tu.flavor
+        });
+
+        if (tu.target) {
+            res.addTarget(tu.quantity, tu.target);
+        }
+        break;
+    }
+
+    return res;
+};
+
+/**
+ * Return the translation set containing all of the resources in
+ * this tmx file.
+ *
+ * @returns {TranslationSet} the set of all resources in this file
+ */
+Tmx.prototype.getTranslationSet = function() {
+    // if there are translation units, convert them to
+    // resources in a translation set before returning the set.
+    var res;
+
+    if (this.tu) {
+        for (var j = 0; j < this.tu.length; j++) {
+            var comment, tu = this.tu[j];
+            switch (tu.resType) {
+            default:
+                res = this.convertTransUnit(tu);
+                this.ts.add(res);
+                break;
+
+            case "array":
+                var res = this.ts.get(ResourceArray.hashKey(tu.project, tu.context, tu.targetLocale || tu.sourceLocale, tu.key));
+                if (res) {
+                    // if it already exists, amend the existing resource instead of creating a new one
+                    res.addSource(tu.ordinal, tu.source);
+                    if (tu.target) {
+                        res.addTarget(tu.ordinal, tu.target);
+                    }
+                } else {
+                    res = this.convertTransUnit(tu);
+                    this.ts.add(res);
+                }
+                break;
+
+            case "plural":
+                var res = this.ts.get(ResourcePlural.hashKey(tu.project, tu.context, tu.targetLocale || tu.sourceLocale, tu.key));
+                if (res) {
+                    // if it already exists, amend the existing resource instead of creating a new one
+                    res.addSource(tu.quantity, tu.source);
+                    if (tu.target) {
+                        res.addTarget(tu.quantity, tu.target);
+                    }
+                } else {
+                    res = this.convertTransUnit(tu);
+                    this.ts.add(res);
+                }
+                break;
+            }
+        }
+
+        this.tu = undefined;
+    }
+
+    return this.ts;
+};
+
+/**
+ * Return the number of translation units in this tmx
+ * file.
+ *
+ * @return {number} the number of translation units in this tmx file
+ */
+Tmx.prototype.size = function() {
+    return this.ts.size();
+};
+
+/**
+ * Return a string that can be used as an HTML attribute value.
+ * @param {string} str the string to escape
+ * @returns {string} the escaped string
+ */
+function escapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/\n/g, "\\n").
+        replace(/&/g, "&amp;").
+        replace(/"/g, "&quot;").
+        replace(/'/g, "&apos;");
+}
+
+/**
+ * Return the original string based on the one that was used as an attribute value.
+ * @param {string} str the string to unescape
+ * @returns {string} the unescaped string
+ */
+function unescapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/\\n/g, "\n").
+        replace(/&quot;/g, '"').
+        replace(/&apos;/g, "'").
+        replace(/&amp;/g, "&");
+}
+
+/**
+ * Convert a resource into one or more translation units.
+ *
+ * @private
+ * @param {Resource} res the resource to convert
+ * @returns {Array.<TranslationUnit>} an array of translation units
+ * that represent the resource
+ */
+Tmx.prototype._convertResource = function(res) {
+    var units = [], tu;
+
+    try {
+        switch (res.resType) {
+        case "string":
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                sourceLocale: res.getSourceLocale(),
+                source: res.getSource(),
+                targetLocale: res.getTargetLocale(),
+                target: res.getTarget(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+            units.push(tu);
+            break;
+
+        case "array":
+            var sarr = res.getSourceArray();
+            var tarr = res.getTargetArray();
+
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                source: " ",
+                sourceLocale: res.getSourceLocale(),
+                targetLocale: res.getTargetLocale(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+
+            for (var j = 0; j < sarr.length; j++) {
+                // only output array items that have a translation
+                if (sarr[j]) {
+                    var newtu = tu.clone();
+                    newtu.source = sarr[j];
+                    newtu.ordinal = j;
+
+                    if (tarr && j < tarr.length && tarr[j]) {
+                        newtu.target = tarr[j];
+                    }
+
+                    newtu.ordinal = j;
+                    units.push(newtu);
+                } else if (tarr[j]) {
+                    logger.warn("Translated array  " + res.getKey() + " has no source string at index " + j + ". Cannot translate. Resource is: " + JSON.stringify(res, undefined, 4));
+                }
+            }
+            break;
+
+        case "plural":
+            tu = new TranslationUnit({
+                project: res.project,
+                key: res.getKey(),
+                file: res.getPath(),
+                source: " ",
+                sourceLocale: res.getSourceLocale(),
+                targetLocale: res.getTargetLocale(),
+                state: res.getState(),
+                id: res.getId(),
+                translated: true,
+                context: res.context,
+                comment: res.comment,
+                resType: res.resType,
+                datatype: res.datatype,
+                flavor: res.getFlavor ? res.getFlavor() : undefined
+            });
+
+            var sp = res.getSourcePlurals();
+            var tp = res.getTargetPlurals();
+
+            for (var p in sp) {
+                if (sp[p]) {
+                    var newtu = tu.clone();
+                    newtu.source = sp[p];
+
+                    if (tp && tp[p]) {
+                        newtu.target = tp[p];
+                        newtu.quantity = p;
+                    }
+                    newtu.quantity = p;
+                    units.push(newtu);
+                } else {
+                    logger.warn("Translated plural  " + res.getKey() + " has no source plural, quantity " + p + ": " + JSON.stringify(res, undefined, 4));
+                }
+            }
+            break;
+        }
+    } catch (e) {
+        logger.warn(e);
+        logger.warn(JSON.stringify(res));
+        logger.warn("Skipping that resource.");
+    }
+
+    return units;
+};
+
+/**
+ * Convert a resource into translation units.
+ *
+ * @param {Resource} res the resource to convert
+ * @returns {Array.<TranslationUnit>} an array of translation units
+ * that represent the resource
+ */
+Tmx.prototype.convertResource = function(res) {
+    return this._convertResource(res);
+};
+
+function makeHashKey(res, ordinal, quantity) {
+    return [res.getPath(), res.getKey(), res.getContext(), res.getProject(), ordinal, quantity].join("_");
+}
+
+function makeTUHashKey(tu) {
+    return [tu.file, tu.sourceLocale, tu.targetLocale || "", tu.project].join("_");
+}
+
+function versionString(num) {
+    parts = ("" + num).split(".");
+    integral = parts[0].toString();
+    fraction = parts[1] || "0";
+    return integral + '.' + fraction;
+}
+
+/**
+ * Serialize this tmx instance as an tmx 1.2 string.
+ * @param {Array.<TranslationUnit>} units an array of units to convert to a string
+ * @return {String} the current instance encoded as an tmx 1.2
+ * format string
+ */
+Tmx.prototype.toString1 = function(units) {
+    var json = {
+        tmx: {
+            _attributes: {
+                version: versionString(this.version)
+            }
+        }
+    };
+
+    logger.trace("Units to write out is " + JSON.stringify(units, undefined, 4));
+
+    // now finally add each of the units to the json
+
+    var files = {};
+    var index = 1;
+
+    for (var i = 0; i < units.length; i++) {
+        var tu = units[i];
+        if (!tu) {
+            console.log("undefined?");
+        }
+        var hashKey = makeTUHashKey(tu);
+        var file = files[hashKey];
+        if (!file) {
+            files[hashKey] = file = {
+                _attributes: {
+                    "original": tu.file,
+                    "source-language": tu.sourceLocale,
+                    "target-language": tu.targetLocale,
+                    "product-name": tu.project,
+                    "x-flavor": tu.flavor
+                }
+            };
+            if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] ||  this["company"]) {
+                file.header = {
+                    "tool": {
+                        _attributes: {
+                            "creationtool": this["tool-name"],
+                            "creationtoolversion": this["tool-version"],
+                            "tool-company": this["tool-company"],
+                            "copyright": this["copyright"]
+                        }
+                    }
+                };
+            }
+            file.body = {};
+        }
+
+        var tujson = {
+            _attributes: {
+                "id": (tu.id || index++),
+                "resname": escapeAttr(tu.key),
+                "restype": tu.resType || "string",
+                "datatype": tu.datatype
+            },
+            "source": {
+                "_text": tu.source
+            }
+        };
+
+        if (tu.id && tu.id > index) {
+            index = tu.id + 1;
+        }
+
+        if (tu.resType === "plural") {
+            tujson._attributes.extype = tu.quantity || "other";
+        }
+        if (tu.resType === "array") {
+            tujson._attributes.extype = tu.ordinal;
+        }
+
+        if (tu.target) {
+            tujson.target = {
+                _attributes: {
+                    state: tu.state
+                },
+                "_text": tu.target
+            };
+        }
+        if (tu.comment) {
+            tujson.note = {
+                "_text": tu.comment
+            };
+        }
+        if (tu.context) {
+            tujson._attributes["x-context"] = tu.context;
+        }
+        if (!file.body["trans-unit"]) {
+            file.body["trans-unit"] = [];
+        }
+
+        file.body["trans-unit"].push(tujson);
+    }
+
+    // sort the file tags so that they come out in the same order each time
+    if (!json.tmx.file) {
+        json.tmx.file = [];
+    }
+    Object.keys(files).sort().forEach(function(fileHashKey) {
+        json.tmx.file.push(files[fileHashKey]);
+    });
+
+    // logger.trace("json is " + JSON.stringify(json, undefined, 4));
+
+    var xml = '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+        compact: true,
+        spaces: 2
+    });
+
+    return xml;
+};
+
+/**
+ * Serialize this tmx instance to a string that contains
+ * the tmx format xml text.
+ *
+ * @param {boolean} untranslated if true, add the untranslated resources
+ * to the tmx file without target tags. Otherwiwe, untranslated
+ * resources are skipped.
+ * @return {String} the current instance encoded as an tmx format
+ * xml text
+ */
+Tmx.prototype.serialize = function(untranslated) {
+    var units = [];
+
+    if (this.ts.size() > 0) {
+        // first convert the resources into translation units
+        var resources = this.ts.getAll();
+        var tu;
+
+        if (this.allowDups) {
+            // only look at the initial set of resources
+            var initialLength = resources.length;
+            for (var i = 0; i < initialLength; i++) {
+                var res = resources[i];
+                var instances = res.getInstances();
+                if (instances && instances.length) {
+                    resources = resources.concat(instances);
+                    resources[i].instances = undefined;
+                }
+            }
+        }
+        resources.sort(function(left, right) {
+            if (typeof(left.index) === 'number' && typeof(right.index) === 'number') {
+                return left.index - right.index;
+            }
+            if (typeof(left.id) === 'number' && typeof(right.id) === 'number') {
+                return left.id - right.id;
+            }
+            // no ids and no indexes? Well, then don't rearrange
+            return 0;
+        });
+
+        // now add the translations
+        for (var i = 0; i < resources.length; i++) {
+            var res = resources[i];
+            if (res.getTargetLocale() !== this.sourceLocale) {
+                units = units.concat(this.convertResource(res));
+            }
+        }
+    }
+
+    if (this.tu && this.tu.length > 0) {
+        units = units.concat(this.tu);
+    }
+
+    return this.toString1(units);
+};
+
+/**
+ * Parse tmx 1.* files
+ * @private
+ */
+Tmx.prototype.parse = function(tmx) {
+    if (tmx.file) {
+        var files = ilib.isArray(tmx.file) ? tmx.file : [ tmx.file ];
+        var comment;
+
+        for (var i = 0; i < files.length; i++) {
+            var fileSettings = {};
+            var file = files[i];
+
+            fileSettings = {
+                pathName: file._attributes.original,
+                locale: file._attributes["source-language"],
+                project: file._attributes["product-name"] || file._attributes["original"],
+                targetLocale: file._attributes["target-language"],
+                flavor: file._attributes["x-flavor"]
+            };
+
+            fileSettings.isAsianLocale = utils.isAsianLocale(fileSettings.targetLocale);
+
+            if (file.body && file.body["trans-unit"]) {
+                var units = ilib.isArray(file.body["trans-unit"]) ? file.body["trans-unit"] : [ file.body["trans-unit"] ];
+
+                units.forEach(function(tu) {
+                    if (tu.source && tu.source["_text"] && tu.source["_text"].trim().length > 0) {
+                        var targetString;
+                        if (tu.target) {
+                            if (tu.target["_text"]) {
+                                targetString = tu.target["_text"];
+                            } else if (tu.target.mrk) {
+                                if (ilib.isArray(tu.target.mrk)) {
+                                    var targetSegments = tu.target.mrk.map(function(mrk) {
+                                        return mrk["_text"];
+                                    })
+                                    targetString = targetSegments.join(fileSettings.isAsianLocale ? '' : ' ');
+                                } else {
+                                    targetString = tu.target.mrk["_text"];
+                                }
+                            }
+                        }
+
+                        if (!tu._attributes.resname) {
+                            if (tu.source._attributes && tu.source._attributes["x-key"]) {
+                                tu.source["_text"] = tu.source._attributes["x-key"];
+                                tu._attributes.resname = tu.source._attributes["x-key"];
+                            } else {
+                                tu._attributes.resname = tu.source["_text"];
+                            }
+                        }
+
+                        try {
+                            var unit = new TranslationUnit({
+                                file: fileSettings.pathName,
+                                sourceLocale: fileSettings.locale,
+                                project: fileSettings.project,
+                                id: tu._attributes.id,
+                                key: unescapeAttr(tu._attributes.resname),
+                                source: tu.source["_text"],
+                                context: tu._attributes["x-context"],
+                                comment: comment,
+                                targetLocale: fileSettings.targetLocale,
+                                comment: tu.note && tu.note["_text"],
+                                target: targetString,
+                                resType: tu._attributes.restype,
+                                state: tu.target && tu.target._attributes && tu.target._attributes.state,
+                                datatype: tu._attributes.datatype,
+                                flavor: fileSettings.flavor
+                            });
+                            switch (unit.resType) {
+                            case "array":
+                                unit.ordinal = tu._attributes.extype && Number(tu._attributes.extype).valueOf();
+                                break;
+                            case "plural":
+                                unit.quantity = tu._attributes.extype;
+                                break;
+                            }
+                            this.tu.push(unit);
+                        } catch (e) {
+                            logger.warn("Skipping invalid translation unit found in tmx file.\n" + e);
+                        }
+                    } else {
+                        logger.warn("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu._attributes.resname);
+                    }
+                }.bind(this));
+            }
+        }
+    }
+};
+
+function makeArray(arrayOrObject) {
+    return ilib.isArray(arrayOrObject) ? arrayOrObject : [ arrayOrObject ];
+}
+
+/**
+ * Deserialize the given string as an xml file in tmx format
+ * into this tmx instance. If there are any existing translation
+ * units already in this instance, they will be removed first.
+ *
+ * @param {String} xml the tmx format text to parse
+ */
+Tmx.prototype.deserialize = function(xml) {
+    var json = xmljs.xml2js(xml, {
+        trim: false,
+        nativeTypeAttribute: true,
+        compact: true
+    });
+
+    // logger.trace("json is " + JSON.stringify(json, undefined, 4));
+    this.ts = new TranslationSet(this.sourceLocale);
+
+    if (json.tmx) {
+        if (!json.tmx._attributes ||
+                !json.tmx._attributes.version ||
+                json.tmx._attributes.version !== "1.4b") {
+            logger.error("Unknown tmx version " + json.tmx._attributes.version + ". Cannot continue parsing. Can only parse v1.4b files.");
+            return;
+        }
+
+        this.parse(json.tmx);
+    }
+
+    // logger.trace("this.tu is " + JSON.stringify(this.tu, undefined, 4));
+
+    return this.ts;
+};
+
+/**
+ * Return the version of this tmx file. If you deserialize a string into this
+ * instance of Tmx, the version will be reset to whatever is found inside of
+ * the tmx file.
+ *
+ * @returns {String} the version of this tmx
+ */
+Tmx.prototype.getVersion = function() {
+    return this.version || "1.4b";
+};
+
+module.exports = Tmx;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2072,3 +2072,30 @@ module.exports.getLocaleFromPath = function(template, pathname) {
 
     return "";
 };
+
+/**
+ * Recursively visit every node in an object and call the visitor on any
+ * primitive values.
+ * @param {*} object any object, arrary, or primitive
+ * @param {Function(*)} visitor function to call on any primitive
+ * @returns {*} the same type as the original object, but with every
+ * primitive processed by the visitor function
+ */
+module.exports.objectMap = function(object, visitor) {
+    if (isPrimitive(typeof(object))) {
+        return visitor(object);
+    } else if (isArray(object)) {
+        return object.map(function(item) {
+            return objectMap(item, visitor);
+        });
+    } else {
+        var ret = {};
+        for (var prop in object) {
+            if (object.hasOwnProperty(prop)) {
+                ret[prop] = objectMap(object[prop], visitor);
+            }
+        }
+        return ret;
+    }
+}
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2073,6 +2073,10 @@ module.exports.getLocaleFromPath = function(template, pathname) {
     return "";
 };
 
+function isPrimitive(type) {
+    return ["boolean", "number", "integer", "string"].indexOf(type) > -1;
+}
+
 /**
  * Recursively visit every node in an object and call the visitor on any
  * primitive values.
@@ -2081,10 +2085,11 @@ module.exports.getLocaleFromPath = function(template, pathname) {
  * @returns {*} the same type as the original object, but with every
  * primitive processed by the visitor function
  */
-module.exports.objectMap = function(object, visitor) {
+function objectMap(object, visitor) {
+    if (!object) return object;
     if (isPrimitive(typeof(object))) {
         return visitor(object);
-    } else if (isArray(object)) {
+    } else if (Array.isArray(object)) {
         return object.map(function(item) {
             return objectMap(item, visitor);
         });
@@ -2099,3 +2104,4 @@ module.exports.objectMap = function(object, visitor) {
     }
 }
 
+module.exports.objectMap = objectMap;

--- a/loctool.js
+++ b/loctool.js
@@ -43,7 +43,7 @@ var exitValue = 0;
 
 function getVersion() {
     var pkg = require("./package.json");
-    return "loctool v" + pkg.version + " Copyright (c) 2016-2017, 2019-2020, HealthTap, Inc. and JEDLSoft";
+    return "loctool v" + pkg.version + " Copyright (c) 2016-2017, 2019-2021, HealthTap, Inc. and JEDLSoft";
 }
 
 function usage() {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "@babel/preset-env": "^7.10.4",
         "@babel/register": "^7.10.5",
         "build-gradle-reader": "*",
+        "cldr-segmentation": "^2.1.3",
         "he": "^1.2.0",
         "html-parser": "^0.11.0",
         "ilib": "^14.6.0",

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -69,6 +69,7 @@ module.exports.files = [
     "testSet.js",
     "testSwiftFile.js",
     "testSwiftFileType.js",
+    "testTMX.js",
     "testTranslationSet.js",
     "testUtils.js",
     "testWebProject.js",

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -64,19 +64,24 @@ module.exports.tmx = {
     },
 
     testTmxConstructorFull: function(test) {
-        test.expect(7);
+        test.expect(5);
 
         var tmx = new Tmx({
-            creationtool: "loctool",
-            "tool-name": "Localization Tool",
-            creationtoolversion: "1.2.34",
+            properties: {
+	            creationtool: "loctool",
+	            "tool-name": "Localization Tool",
+	            creationtoolversion: "1.2.34",
+            },
             path: "a/b/c.tmx"
         });
         test.ok(tmx);
-
-        test.equal(tmx["creationtool"], "loctool");
-        test.equal(tmx["creationtoolversion"], "1.2.34"),
-        test.equal(tmx.path, "a/b/c.tmx");
+        var props = tmx.getProperties();
+        
+        test.equal(props["creationtool"], "loctool");
+        test.equal(props["creationtoolversion"], "1.2.34");
+        test.equal(props["tool-name"], "Localization Tool");
+        
+        test.equal(tmx.getPath(), "a/b/c.tmx");
 
         test.done();
     },
@@ -151,8 +156,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 1);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -169,7 +173,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceStringWithTranslation: function(test) {
-        test.expect(11);
+        test.expect(12);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -194,8 +198,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 1);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -214,7 +217,7 @@ module.exports.tmx = {
     },
 
     testTmxAddMultipleResourceString: function(test) {
-        test.expect(18);
+        test.expect(19);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -244,7 +247,7 @@ module.exports.tmx = {
         test.equal(units.length, 2);
 
         test.ok(!units[0].comment);
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
@@ -257,7 +260,7 @@ module.exports.tmx = {
         test.equal(variants[0].locale, "en-US");
 
         test.ok(!units[1].comment);
-        props = units[1].getProps();
+        props = units[1].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
@@ -273,7 +276,7 @@ module.exports.tmx = {
     },
 
     testTmxAddMultipleResourceStringWithTranslations: function(test) {
-        test.expect(18);
+        test.expect(23);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -307,7 +310,7 @@ module.exports.tmx = {
         test.equal(units.length, 2);
 
         test.ok(!units[0].comment);
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
@@ -323,7 +326,7 @@ module.exports.tmx = {
         test.equal(variants[1].locale, "de-DE");
 
         test.ok(!units[1].comment);
-        props = units[1].getProps();
+        props = units[1].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
@@ -342,7 +345,7 @@ module.exports.tmx = {
     },
 
     testTmxAddMultipleResourceStringSameSource: function(test) {
-        test.expect(18);
+        test.expect(15);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -376,7 +379,7 @@ module.exports.tmx = {
         test.equal(units.length, 1);
 
         test.ok(!units[0].comment);
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
@@ -400,7 +403,7 @@ module.exports.tmx = {
     },
 
     testTmxAddMultipleResourceStringSameSourceDifferentTranslation: function(test) {
-        test.expect(18);
+        test.expect(14);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -433,17 +436,16 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 2);
+        test.equal(units.length, 1);
 
-        test.ok(!units[0].comment);
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "a");
 
         var variants = units[0].getVariants();
         test.ok(variants);
-        test.equal(variants.length, 2);
+        test.equal(variants.length, 3);
 
         test.equal(variants[0].string, "Asdf asdf");
         test.equal(variants[0].locale, "en-US");
@@ -459,27 +461,17 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddMultipleResourceStringSameSourceDifferentSourceLocale: function(test) {
-        test.expect(18);
+    testTmxAddResourceStringNotSourceLocale: function(test) {
+        test.expect(3);
 
-        var tmx = new Tmx();
-        test.ok(tmx);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            targetLocale: "de-DE",
-            target: "eins zwei drei"
+        var tmx = new Tmx({
+            locale: "en-US"
         });
-
-        tmx.addResource(res);
+        test.ok(tmx);
 
         res = new ResourceString({
             source: "Asdf asdf",
-            sourceLocale: "en-US",
+            sourceLocale: "de-DE",
             key: "foobar",
             pathName: "foo/bar/j.java",
             project: "webapp",
@@ -489,47 +481,17 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
+        // should reject it. Only units with the source
+        // locale of en-US go in this tmx
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 2);
-
-        test.ok(!units[0].comment);
-        var props = units[0].getProps();
-        test.ok(props);
-        test.equal(props["x-project"], "webapp");
-        test.ok(!props["x-context"]);
-
-        var variants = units[0].getVariants();
-        test.ok(variants);
-        test.equal(variants.length, 2);
-
-        test.equal(variants[0].string, "Asdf asdf");
-        test.equal(variants[0].locale, "en-US");
-
-        test.equal(variants[1].string, "eins zwei drei");
-        test.equal(variants[1].locale, "de-DE");
-
-        test.ok(!units[1].comment);
-        props = units[1].getProps();
-        test.ok(props);
-        test.equal(props["x-project"], "webapp");
-        test.ok(!props["x-context"]);
-
-        variants = units[1].getVariants();
-        test.ok(variants);
-        test.equal(variants.length, 2);
-
-        test.equal(variants[0].string, "Asdf asdf");
-        test.equal(variants[0].locale, "de-DE");
-
-        test.equal(variants[1].string, "vier fumpf sechs");
-        test.equal(variants[1].locale, "en-US");
+        test.equal(units.length, 0);
 
         test.done();
     },
 
     testTmxAddMultipleResourceStringHandleDups: function(test) {
-        test.expect(18);
+        test.expect(14);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -564,15 +526,16 @@ module.exports.tmx = {
 
         // should not duplicate the unit or the variants
 
-        test.ok(!units[0].comment);
-        var props = units[0].getProps();
+        test.equal(units[0].string, "Asdf asdf");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.ok(!props["x-context"]);
 
         var variants = units[0].getVariants();
         test.ok(variants);
-        test.equal(variants.length, 1);
+        test.equal(variants.length, 2);
 
         test.equal(variants[0].string, "Asdf asdf");
         test.equal(variants[0].locale, "en-US");
@@ -584,7 +547,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceArray: function(test) {
-        test.expect(11);
+        test.expect(25);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -612,8 +575,9 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 3);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].string, "a");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -626,6 +590,8 @@ module.exports.tmx = {
         test.equal(variants[0].string, "a");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[1].string, "b");
+        test.equal(units[1].locale, "en-US");
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -633,6 +599,8 @@ module.exports.tmx = {
         test.equal(variants[0].string, "b");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[2].string, "c");
+        test.equal(units[2].locale, "en-US");
         variants = units[2].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -644,7 +612,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceArrayWithTranslations: function(test) {
-        test.expect(26);
+        test.expect(31);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -678,8 +646,9 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 3);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].string, "a");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -695,6 +664,8 @@ module.exports.tmx = {
         test.equal(variants[1].string, "x");
         test.equal(variants[1].locale, "de-DE");
 
+        test.equal(units[1].string, "b");
+        test.equal(units[1].locale, "en-US");
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 2);
@@ -705,9 +676,11 @@ module.exports.tmx = {
         test.equal(variants[1].string, "y");
         test.equal(variants[1].locale, "de-DE");
 
+        test.equal(units[2].string, "c");
+        test.equal(units[2].locale, "en-US");
         variants = units[2].getVariants();
         test.ok(variants);
-        test.equal(variants.length, 1);
+        test.equal(variants.length, 2);
 
         test.equal(variants[0].string, "c");
         test.equal(variants[0].locale, "en-US");
@@ -719,7 +692,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceArrayMultiple: function(test) {
-        test.expect(32);
+        test.expect(31);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -766,8 +739,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 6);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -819,7 +791,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceArrayMultipleWithTranslations: function(test) {
-        test.expect(44);
+        test.expect(43);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -878,8 +850,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 6);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -949,7 +920,7 @@ module.exports.tmx = {
     },
 
     testTmxAddResourceArrayMultipleWithTranslationsAndOverlappingSources: function(test) {
-        test.expect(44);
+        test.expect(43);
 
         var tmx = new Tmx();
         test.ok(tmx);
@@ -1006,10 +977,11 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 6);
+        test.equal(units.length, 4);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].string, "a");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1028,6 +1000,8 @@ module.exports.tmx = {
         test.equal(variants[2].string, "p");
         test.equal(variants[2].locale, "de-DE");
 
+        test.equal(units[1].string, "b");
+        test.equal(units[1].locale, "en-US");
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 3);
@@ -1041,6 +1015,8 @@ module.exports.tmx = {
         test.equal(variants[2].string, "q");
         test.equal(variants[2].locale, "de-DE");
 
+        test.equal(units[2].string, "c");
+        test.equal(units[2].locale, "en-US");
         variants = units[2].getVariants();
         test.ok(variants);
         test.equal(variants.length, 2);
@@ -1051,6 +1027,8 @@ module.exports.tmx = {
         test.equal(variants[1].string, "z");
         test.equal(variants[1].locale, "de-DE");
 
+        test.equal(units[3].string, "o");
+        test.equal(units[3].locale, "en-US");
         variants = units[3].getVariants();
         test.ok(variants);
         test.equal(variants.length, 2);
@@ -1064,13 +1042,13 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddResourceString: function(test) {
-        test.expect(7);
+    testTmxAddResourcePlural: function(test) {
+        test.expect(19);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other string"
@@ -1090,10 +1068,11 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 3);
+        test.equal(units.length, 2);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].locale, "en-US");
+        test.equal(units[0].string, "one string");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1106,6 +1085,9 @@ module.exports.tmx = {
         test.equal(variants[0].string, "one string");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[1].locale, "en-US");
+        test.equal(units[1].string, "other string");
+
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -1116,13 +1098,13 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddResourceStringWithTranslations: function(test) {
-        test.expect(20);
+    testTmxAddResourcePluralWithTranslations: function(test) {
+        test.expect(23);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other string"
@@ -1147,10 +1129,11 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 3);
+        test.equal(units.length, 2);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].string, "one string");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1166,6 +1149,8 @@ module.exports.tmx = {
         test.equal(variants[1].string, "ein Zeichenfolge");
         test.equal(variants[1].locale, "de-DE");
 
+        test.equal(units[1].string, "other string");
+        test.equal(units[1].locale, "en-US");
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 2);
@@ -1179,13 +1164,13 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddResourceStringMultiple: function(test) {
-        test.expect(24);
+    testTmxAddResourcePluralMultiple: function(test) {
+        test.expect(31);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1203,7 +1188,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        res = new ResourceString({
+        res = new ResourcePlural({
             sourceStrings: {
                 one: "a string",
                 other: "some strings"
@@ -1223,10 +1208,11 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 6);
+        test.equal(units.length, 4);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        test.equal(units[0].string, "one string");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1239,6 +1225,8 @@ module.exports.tmx = {
         test.equal(variants[0].string, "one string");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[1].string, "other strings");
+        test.equal(units[1].locale, "en-US");
         variants = units[1].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -1246,6 +1234,8 @@ module.exports.tmx = {
         test.equal(variants[0].string, "other strings");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[2].string, "a string");
+        test.equal(units[2].locale, "en-US");
         variants = units[2].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -1253,6 +1243,8 @@ module.exports.tmx = {
         test.equal(variants[0].string, "a string");
         test.equal(variants[0].locale, "en-US");
 
+        test.equal(units[3].string, "some strings");
+        test.equal(units[3].locale, "en-US");
         variants = units[3].getVariants();
         test.ok(variants);
         test.equal(variants.length, 1);
@@ -1263,13 +1255,13 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddResourceStringMultipleWithMoreTranslations: function(test) {
-        test.expect(34);
+    testTmxAddResourcePluralMultipleWithMoreTranslations: function(test) {
+        test.expect(33);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1292,7 +1284,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        res = new ResourceString({
+        res = new ResourcePlural({
             sourceStrings: {
                 one: "a string",
                 other: "many strings"
@@ -1318,10 +1310,9 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 6);
+        test.equal(units.length, 4);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1364,22 +1355,22 @@ module.exports.tmx = {
         test.equal(variants[0].string, "many strings");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "несколько струны");
+        test.equal(variants[1].string, "много струн");
         test.equal(variants[1].locale, "ru-RU");
-
-        test.equal(variants[2].string, "много струн");
+        
+        test.equal(variants[2].string, "несколько струны");
         test.equal(variants[2].locale, "ru-RU");
 
         test.done();
     },
 
-    testTmxAddResourceStringMultipleWithLessTranslations: function(test) {
-        test.expect(34);
+    testTmxAddResourcePluralMultipleWithLessTranslations: function(test) {
+        test.expect(21);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1402,7 +1393,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        res = new ResourceString({
+        res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1426,10 +1417,9 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 6);
+        test.equal(units.length, 2);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1461,13 +1451,13 @@ module.exports.tmx = {
         test.done();
     },
 
-    testTmxAddResourceStringMultipleWithTranslationsAndOverlappingSources: function(test) {
-        test.expect(28);
+    testTmxAddResourcePluralMultipleWithTranslationsAndOverlappingSources: function(test) {
+        test.expect(27);
 
         var tmx = new Tmx();
         test.ok(tmx);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1490,7 +1480,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        res = new ResourceString({
+        res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "some other strings"
@@ -1515,10 +1505,9 @@ module.exports.tmx = {
 
         var units = tmx.getTranslationUnits();
         test.ok(units);
-        test.equal(units.length, 6);
+        test.equal(units.length, 3);
 
-        test.equal(units[0].comment, "this is a comment");
-        var props = units[0].getProps();
+        var props = units[0].getProperties();
         test.ok(props);
         test.equal(props["x-project"], "webapp");
         test.equal(props["x-context"], "asdf");
@@ -1564,8 +1553,8 @@ module.exports.tmx = {
     testTmxSerializeStringMultipleWithTranslations: function(test) {
         test.expect(2);
 
-        var x = new Tmx();
-        test.ok(x);
+        var tmx = new Tmx();
+        test.ok(tmx);
 
         var res = new ResourceString({
             source: "Asdf asdf",
@@ -1597,7 +1586,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        var actual = x.serialize();
+        var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
             '  <body>\n' +
@@ -1620,8 +1609,8 @@ module.exports.tmx = {
     testTmxSerializeString: function(test) {
         test.expect(2);
 
-        var x = new Tmx();
-        test.ok(x);
+        var tmx = new Tmx();
+        test.ok(tmx);
 
         var res = new ResourceString({
             source: "Asdf asdf",
@@ -1647,7 +1636,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        var actual = x.serialize();
+        var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
             '  <body>\n' +
@@ -1674,6 +1663,7 @@ module.exports.tmx = {
 
         diff(actual, expected);
         test.equal(actual, expected);
+
         test.done();
     },
 
@@ -1695,7 +1685,7 @@ module.exports.tmx = {
 
         tmx.addResource(res);
 
-        var res = new ResourceString({
+        var res = new ResourcePlural({
             sourceStrings: {
                 one: "one string",
                 other: "other strings"
@@ -1757,15 +1747,8 @@ module.exports.tmx = {
             '      </tuv>\n' +
             '    </tu>\n' +
             '    <tu srclang="en-US">\n' +
-            '      <prop type="x-project">webapp</prop>\n' +
-            '      <tuv xml:lang="en-US">\n' +
-            '        <seg>baby baby</seg>\n' +
-            '      </tuv>\n' +
-            '      <tuv xml:lang="de-DE">\n' +
-            '        <seg>vier fumpf sechs</seg>\n' +
-            '      </tuv>\n' +
-            '    </tu>\n' +
-            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>one string</seg>\n' +
@@ -1775,6 +1758,8 @@ module.exports.tmx = {
             '      </tuv>\n' +
             '    </tu>\n' +
             '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>other strings</seg>\n' +
@@ -1784,6 +1769,8 @@ module.exports.tmx = {
             '      </tuv>\n' +
             '    </tu>\n' +
             '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>a</seg>\n' +
@@ -1793,6 +1780,8 @@ module.exports.tmx = {
             '      </tuv>\n' +
             '    </tu>\n' +
             '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>b</seg>\n' +
@@ -1802,6 +1791,8 @@ module.exports.tmx = {
             '      </tuv>\n' +
             '    </tu>\n' +
             '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>c</seg>\n' +
@@ -1815,6 +1806,7 @@ module.exports.tmx = {
 
         diff(actual, expected);
         test.equal(actual, expected);
+
         test.done();
     }
 };

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -18,6 +18,9 @@
  */
 
 if (!Tmx) {
+    var path = require("path");
+    var fs = require("fs");
+
     var Tmx = require("../lib/TMX.js");
     var TranslationUnit = Tmx.TranslationUnit;
     var ResourceString = require("../lib/ResourceString.js");
@@ -1842,7 +1845,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -1854,7 +1857,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 1);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(units[1].string, "This is only a test.");
@@ -1902,7 +1905,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "I would like to see Dr. Smith in the U.S. not someone else. ");
+        test.equal(units[0].string, "I would like to see Dr. Smith in the U.S. not someone else.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -1914,7 +1917,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 1);
 
-        test.equal(variants[0].string, "I would like to see Dr. Smith in the U.S. not someone else. ");
+        test.equal(variants[0].string, "I would like to see Dr. Smith in the U.S. not someone else.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(units[1].string, "Please arrange that.");
@@ -2009,7 +2012,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2021,10 +2024,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2077,7 +2080,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2089,7 +2092,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(variants[1].string, "これはテストです。");
@@ -2195,7 +2198,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2207,7 +2210,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 1);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2261,7 +2264,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2273,10 +2276,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2335,7 +2338,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 4);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2347,10 +2350,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2371,7 +2374,7 @@ module.exports.tmx = {
         test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
-        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].string, "Yet another test.");
         test.equal(units[2].locale, "en-US");
         props = units[2].getProperties();
         test.ok(props);
@@ -2383,10 +2386,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].string, "Yet another test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Jemals noch eine Untersuchung. ");
+        test.equal(variants[1].string, "Jemals noch eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[3].string, "Another test.");
@@ -2439,7 +2442,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2451,7 +2454,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 1);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2505,7 +2508,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 2);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2517,10 +2520,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2579,7 +2582,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 4);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2591,10 +2594,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2615,7 +2618,7 @@ module.exports.tmx = {
         test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
-        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].string, "Yet another test.");
         test.equal(units[2].locale, "en-US");
         props = units[2].getProperties();
         test.ok(props);
@@ -2627,10 +2630,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].string, "Yet another test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Jemals noch eine Untersuchung. ");
+        test.equal(variants[1].string, "Jemals noch eine Untersuchung.");
         test.equal(variants[1].locale, "de-DE");
 
         test.equal(units[3].string, "Another test.");
@@ -2688,7 +2691,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 4);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2700,7 +2703,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 1);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2718,7 +2721,7 @@ module.exports.tmx = {
         test.equal(variants[0].string, "This is only a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].string, "Yet another test.");
         test.equal(units[2].locale, "en-US");
         props = units[2].getProperties();
         test.ok(props);
@@ -2730,7 +2733,7 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].string, "Yet another test.");
         test.equal(variants[0].locale, "en-US");
 
         test.equal(variants[1].string, "さらに別のテスト。");
@@ -2793,7 +2796,7 @@ module.exports.tmx = {
         test.ok(units);
         test.equal(units.length, 4);
 
-        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].string, "This is a test.");
         test.equal(units[0].locale, "en-US");
         var props = units[0].getProperties();
         test.ok(props);
@@ -2805,10 +2808,10 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 2);
 
-        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].string, "This is a test.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Это тест. ");
+        test.equal(variants[1].string, "Это тест.");
         test.equal(variants[1].locale, "ru-RU");
 
         test.equal(units[1].string, "This is only a test.");
@@ -2829,7 +2832,7 @@ module.exports.tmx = {
         test.equal(variants[1].string, "Это всего лишь тест.");
         test.equal(variants[1].locale, "ru-RU");
 
-        test.equal(units[2].string, "These are some tests. ");
+        test.equal(units[2].string, "These are some tests.");
         test.equal(units[2].locale, "en-US");
         props = units[2].getProperties();
         test.ok(props);
@@ -2841,13 +2844,13 @@ module.exports.tmx = {
         test.ok(variants);
         test.equal(variants.length, 3);
 
-        test.equal(variants[0].string, "These are some tests. ");
+        test.equal(variants[0].string, "These are some tests.");
         test.equal(variants[0].locale, "en-US");
 
-        test.equal(variants[1].string, "Это некоторые тестов. ");
+        test.equal(variants[1].string, "Это некоторые тестов.");
         test.equal(variants[1].locale, "ru-RU");
 
-        test.equal(variants[2].string, "Это некоторые теста. ");
+        test.equal(variants[2].string, "Это некоторые теста.");
         test.equal(variants[2].locale, "ru-RU");
 
         test.equal(units[3].string, "These are only some tests.");
@@ -2874,4 +2877,183 @@ module.exports.tmx = {
         test.done();
     },
 
+    testTmxWrite: function(test) {
+        test.expect(4);
+
+        var tmx = new Tmx({
+            path: "./test/output.tmx",
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf. Foobar foo.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "Eins zwei drei. Vier fumpf sechs."
+        });
+
+        tmx.addResource(res);
+
+        var res = new ResourcePlural({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "blah blah",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "eine Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "A b cee. E f g.",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "X y zee. M n o.",
+                "y",
+                "z"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        var base = path.dirname(module.id);
+
+        if (fs.existsSync(path.join(base, "testfiles/test/output.tmx"))) {
+            fs.unlinkSync(path.join(base, "testfiles/test/output.tmx"));
+        }
+
+        test.ok(!fs.existsSync(path.join(base, "testfiles/test/output.tmx")));
+
+        tmx.write(path.join(base, "testfiles"));
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/test/output.tmx")));
+
+        var actual = fs.readFileSync(path.join(base, "testfiles/test/output.tmx"), "utf-8");
+        var expected = 
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <header segtype="sentence" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <body>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Asdf asdf.</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>Eins zwei drei.</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Foobar foo.</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>Vier fumpf sechs.</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>one string</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eine Zeichenfolge</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>other strings</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>mehrere Zeichenfolge</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>A b cee.</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>X y zee.</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>E f g.</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>M n o.</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>b</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>y</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>c</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>z</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    }
 };

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -68,19 +68,19 @@ module.exports.tmx = {
 
         var tmx = new Tmx({
             properties: {
-	            creationtool: "loctool",
-	            "tool-name": "Localization Tool",
-	            creationtoolversion: "1.2.34",
+                creationtool: "loctool",
+                "tool-name": "Localization Tool",
+                creationtoolversion: "1.2.34",
             },
             path: "a/b/c.tmx"
         });
         test.ok(tmx);
         var props = tmx.getProperties();
-        
+
         test.equal(props["creationtool"], "loctool");
         test.equal(props["creationtoolversion"], "1.2.34");
         test.equal(props["tool-name"], "Localization Tool");
-        
+
         test.equal(tmx.getPath(), "a/b/c.tmx");
 
         test.done();
@@ -1357,7 +1357,7 @@ module.exports.tmx = {
 
         test.equal(variants[1].string, "много струн");
         test.equal(variants[1].locale, "ru-RU");
-        
+
         test.equal(variants[2].string, "несколько струны");
         test.equal(variants[2].locale, "ru-RU");
 
@@ -1589,6 +1589,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-context">asdf</prop>\n' +
@@ -1639,6 +1640,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -1736,6 +1738,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -1808,5 +1811,1065 @@ module.exports.tmx = {
         test.equal(actual, expected);
 
         test.done();
-    }
+    },
+
+    testTmxAddResourceSegmentSentenceSource: function(test) {
+        test.expect(23);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "This is a test. This is only a test.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceSourceTricky: function(test) {
+        test.expect(23);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "I would like to see Dr. Smith in the U.S. not someone else. Please arrange that.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "I would like to see Dr. Smith in the U.S. not someone else. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "I would like to see Dr. Smith in the U.S. not someone else. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[1].string, "Please arrange that.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "Please arrange that.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceSourceOnlyOneSentence: function(test) {
+        test.expect(13);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "This is a test.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        test.equal(units[0].string, "This is a test.");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTarget: function(test) {
+        test.expect(27);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "This is a test. This is only a test.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            target: "Dies ist eine Untersuchung. Dies ist nur eine Untersuchung.",
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetJapanese: function(test) {
+        test.expect(27);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "This is a test. This is only a test.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            target: "これはテストです。これは単なるテストです。",
+            targetLocale: "ja-JP"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "これはテストです。");
+        test.equal(variants[1].locale, "ja-JP");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "これは単なるテストです。");
+        test.equal(variants[1].locale, "ja-JP");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetOnlyOneSentence: function(test) {
+        test.expect(15);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "This is a test.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            target: "Dies ist eine Untersuchung.",
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        test.equal(units[0].string, "This is a test.");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceArray: function(test) {
+        test.expect(23);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "This is a test. This is only a test."
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetArray: function(test) {
+        test.expect(27);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "This is a test. This is only a test."
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetArray: [
+                "Dies ist eine Untersuchung. Dies ist nur eine Untersuchung."
+            ],
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetArrayMultiple: function(test) {
+        test.expect(51);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "This is a test. This is only a test.",
+                "Yet another test. Another test."
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetArray: [
+                "Dies ist eine Untersuchung. Dies ist nur eine Untersuchung.",
+                "Jemals noch eine Untersuchung. Noch eine Untersuchung."
+            ],
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 4);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].locale, "en-US");
+        props = units[2].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Jemals noch eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[3].string, "Another test.");
+        test.equal(units[3].locale, "en-US");
+        props = units[3].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Another test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Noch eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentencePlural: function(test) {
+        test.expect(23);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourcePlural({
+            sourcePlurals: {
+                other: "This is a test. This is only a test."
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetPlural: function(test) {
+        test.expect(27);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourcePlural({
+            sourcePlurals: {
+                "other": "This is a test. This is only a test."
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetPlurals: {
+                "other": "Dies ist eine Untersuchung. Dies ist nur eine Untersuchung."
+            },
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetPluralMultiple: function(test) {
+        test.expect(51);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourcePlural({
+            sourcePlurals: {
+                one: "This is a test. This is only a test.",
+                other: "Yet another test. Another test."
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetPlurals: {
+                one: "Dies ist eine Untersuchung. Dies ist nur eine Untersuchung.",
+                other: "Jemals noch eine Untersuchung. Noch eine Untersuchung."
+            },
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 4);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Dies ist nur eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].locale, "en-US");
+        props = units[2].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Jemals noch eine Untersuchung. ");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(units[3].string, "Another test.");
+        test.equal(units[3].locale, "en-US");
+        props = units[3].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Another test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Noch eine Untersuchung.");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetPluralLessCategories: function(test) {
+        test.expect(47);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourcePlural({
+            sourcePlurals: {
+                one: "This is a test. This is only a test.",
+                other: "Yet another test. Another test."
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetPlurals: {
+                other: "さらに別のテスト。別のテスト。"
+            },
+            targetLocale: "ja-JP"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 4);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(units[2].string, "Yet another test. ");
+        test.equal(units[2].locale, "en-US");
+        props = units[2].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Yet another test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "さらに別のテスト。");
+        test.equal(variants[1].locale, "ja-JP");
+
+        test.equal(units[3].string, "Another test.");
+        test.equal(units[3].locale, "en-US");
+        props = units[3].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Another test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "別のテスト。");
+        test.equal(variants[1].locale, "ja-JP");
+
+        test.done();
+    },
+
+    testTmxAddResourceSegmentSentenceTargetPluralMoreCategories: function(test) {
+        test.expect(55);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourcePlural({
+            sourcePlurals: {
+                one: "This is a test. This is only a test.",
+                other: "These are some tests. These are only some tests."
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetPlurals: {
+                one: "Это тест. Это всего лишь тест.",
+                few: "Это некоторые теста. Это только некоторые теста.",
+                other: "Это некоторые тестов. Это только некоторые тестов."
+            },
+            targetLocale: "ru-RU"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 4);
+
+        test.equal(units[0].string, "This is a test. ");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is a test. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Это тест. ");
+        test.equal(variants[1].locale, "ru-RU");
+
+        test.equal(units[1].string, "This is only a test.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "This is only a test.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Это всего лишь тест.");
+        test.equal(variants[1].locale, "ru-RU");
+
+        test.equal(units[2].string, "These are some tests. ");
+        test.equal(units[2].locale, "en-US");
+        props = units[2].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "These are some tests. ");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Это некоторые тестов. ");
+        test.equal(variants[1].locale, "ru-RU");
+
+        test.equal(variants[2].string, "Это некоторые теста. ");
+        test.equal(variants[2].locale, "ru-RU");
+
+        test.equal(units[3].string, "These are only some tests.");
+        test.equal(units[3].locale, "en-US");
+        props = units[3].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "These are only some tests.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Это только некоторые тестов.");
+        test.equal(variants[1].locale, "ru-RU");
+
+        test.equal(variants[2].string, "Это только некоторые теста.");
+        test.equal(variants[2].locale, "ru-RU");
+
+        test.done();
+    },
+
 };

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -42,6 +42,8 @@ function diff(a, b) {
     }
 }
 
+var loctoolVersion = require("../package.json").version;
+
 module.exports.tmx = {
     testTmxConstructor: function(test) {
         test.expect(1);
@@ -1589,7 +1591,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-context">asdf</prop>\n' +
@@ -1640,7 +1642,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -1738,7 +1740,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="2.11.0" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -1,0 +1,1820 @@
+/*
+ * testTMX.js - test the Tmx object.
+ *
+ * Copyright © 2021 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if (!Tmx) {
+    var Tmx = require("../lib/TMX.js");
+    var TranslationUnit = Tmx.TranslationUnit;
+    var ResourceString = require("../lib/ResourceString.js");
+    var ContextResourceString = require("../lib/ContextResourceString.js");
+    var IosLayoutResourceString = require("../lib/IosLayoutResourceString.js");
+    var ResourceArray = require("../lib/ResourceArray.js");
+    var ResourceString = require("../lib/ResourceString.js");
+    var ResourcePlural = require("../lib/ResourcePlural.js");
+    var ResourceFactory = require("../lib/ResourceFactory.js");
+}
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+
+module.exports.tmx = {
+    testTmxConstructor: function(test) {
+        test.expect(1);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        test.done();
+    },
+
+    testTmxConstructorIsEmpty: function(test) {
+        test.expect(2);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        test.equal(tmx.size(), 0);
+
+        test.done();
+    },
+
+    testTmxConstructorFull: function(test) {
+        test.expect(7);
+
+        var tmx = new Tmx({
+            creationtool: "loctool",
+            "tool-name": "Localization Tool",
+            creationtoolversion: "1.2.34",
+            path: "a/b/c.tmx"
+        });
+        test.ok(tmx);
+
+        test.equal(tmx["creationtool"], "loctool");
+        test.equal(tmx["creationtoolversion"], "1.2.34"),
+        test.equal(tmx.path, "a/b/c.tmx");
+
+        test.done();
+    },
+
+    testTmxGetPath: function(test) {
+        test.expect(2);
+
+        var tmx = new Tmx({
+            path: "foo/bar/x.tmx"
+        });
+        test.ok(tmx);
+
+        test.equal(tmx.getPath(), "foo/bar/x.tmx");
+
+        test.done();
+    },
+
+    testTmxSetPath: function(test) {
+        test.expect(3);
+
+        var tmx = new Tmx({
+            path: "foo/bar/x.tmx"
+        });
+        test.ok(tmx);
+
+        test.equal(tmx.getPath(), "foo/bar/x.tmx");
+
+        tmx.setPath("asdf/asdf/y.tmx");
+
+        test.equal(tmx.getPath(), "asdf/asdf/y.tmx");
+
+        test.done();
+    },
+
+    testTmxSetPathInitiallyEmpty: function(test) {
+        test.expect(3);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        test.ok(!tmx.getPath());
+
+        tmx.setPath("asdf/asdf/y.tmx");
+
+        test.equal(tmx.getPath(), "asdf/asdf/y.tmx");
+
+        test.done();
+    },
+
+    testTmxAddResourceString: function(test) {
+        test.expect(11);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringWithTranslation: function(test) {
+        test.expect(11);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceString: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.ok(!units[1].comment);
+        props = units[1].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "baby baby");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceStringWithTranslations: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "vier fumpf sechs"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.ok(!units[1].comment);
+        props = units[1].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "baby baby");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "vier fumpf sechs");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceStringSameSource: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "fr-FR",
+            target: "un deu trois"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        // should add a variant to the previous translation
+        // unit instead of creating a new one
+        test.equal(variants[2].string, "un deu trois");
+        test.equal(variants[2].locale, "fr-FR");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceStringSameSourceDifferentTranslation: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei",
+            context: "a"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "a/b/cfoo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "sieben acht neun",
+            context: "b"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "a");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        // should become a new variant of the source, even
+        // though we already have a german translation
+        test.equal(variants[2].string, "sieben acht neun");
+        test.equal(variants[2].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceStringSameSourceDifferentSourceLocale: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "en-US",
+            target: "vier fumpf sechs"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.ok(!units[1].comment);
+        props = units[1].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "de-DE");
+
+        test.equal(variants[1].string, "vier fumpf sechs");
+        test.equal(variants[1].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddMultipleResourceStringHandleDups: function(test) {
+        test.expect(18);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 1);
+
+        // should not duplicate the unit or the variants
+
+        test.ok(!units[0].comment);
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.ok(!props["x-context"]);
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "Asdf asdf");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eins zwei drei");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceArray: function(test) {
+        test.expect(11);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 3);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "a");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "b");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "c");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceArrayWithTranslations: function(test) {
+        test.expect(26);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "x",
+                "y",
+                "z"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 3);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "a");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "x");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "b");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "y");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "c");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "z");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceArrayMultiple: function(test) {
+        test.expect(32);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: [
+                "m",
+                "n",
+                "o"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "a");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "b");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "c");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "m");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[4].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "n");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[5].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "o");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceArrayMultipleWithTranslations: function(test) {
+        test.expect(44);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "x",
+                "y",
+                "z"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: [
+                "m",
+                "n",
+                "o"
+            ],
+            sourceLocale: "en-US",
+            key: "asdf",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "p",
+                "q",
+                "r"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "a");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "x");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "b");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "y");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "c");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "z");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "m");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "p");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[4].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "n");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "q");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[5].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "o");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "r");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceArrayMultipleWithTranslationsAndOverlappingSources: function(test) {
+        test.expect(44);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "x",
+                "y",
+                "z"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "o"
+            ],
+            sourceLocale: "en-US",
+            key: "asdf",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "p",
+                "q",
+                "r"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "a");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "x");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(variants[2].string, "p");
+        test.equal(variants[2].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "b");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "y");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(variants[2].string, "q");
+        test.equal(variants[2].locale, "de-DE");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "c");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "z");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "o");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "r");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceString: function(test) {
+        test.expect(7);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other string"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 3);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "other string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringWithTranslations: function(test) {
+        test.expect(20);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other string"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "ein Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 3);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "ein Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "other string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "mehrere Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringMultiple: function(test) {
+        test.expect(24);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            sourceStrings: {
+                one: "a string",
+                other: "some strings"
+            },
+            sourceLocale: "en-US",
+            key: "asdf",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "other strings");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "a string");
+        test.equal(variants[0].locale, "en-US");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].string, "some strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringMultipleWithMoreTranslations: function(test) {
+        test.expect(34);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "ein Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            sourceStrings: {
+                one: "a string",
+                other: "many strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "ru-RU",
+            targetStrings: {
+                one: "одна струна",
+                few: "несколько струны",
+                other: "много струн"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "ein Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "other strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "mehrere Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "a string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "одна струна");
+        test.equal(variants[1].locale, "ru-RU");
+
+        variants = units[3].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "many strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "несколько струны");
+        test.equal(variants[1].locale, "ru-RU");
+
+        test.equal(variants[2].string, "много струн");
+        test.equal(variants[2].locale, "ru-RU");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringMultipleWithLessTranslations: function(test) {
+        test.expect(34);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "ein Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "ja-JP",
+            targetStrings: {
+                other: "1つの弦"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "ein Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "other strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "mehrere Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(variants[2].string, "1つの弦");
+        test.equal(variants[2].locale, "ja-JP");
+
+        test.done();
+    },
+
+    testTmxAddResourceStringMultipleWithTranslationsAndOverlappingSources: function(test) {
+        test.expect(28);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "eine Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "some other strings"
+            },
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "1 Zeichenfolge",
+                other: "mehrere andere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 6);
+
+        test.equal(units[0].comment, "this is a comment");
+        var props = units[0].getProps();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        // the "one" string shares some translations and the "other" string doesn't
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 3);
+
+        test.equal(variants[0].string, "one string");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "eine Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.equal(variants[2].string, "1 Zeichenfolge");
+        test.equal(variants[2].locale, "de-DE");
+
+        variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "other strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "mehrere Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        variants = units[2].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "some other strings");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "mehrere andere Zeichenfolge");
+        test.equal(variants[1].locale, "de-DE");
+
+        test.done();
+    },
+
+    testTmxSerializeStringMultipleWithTranslations: function(test) {
+        test.expect(2);
+
+        var x = new Tmx();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        tmx.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <body>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-context">asdf</prop>\n' +
+            '      <prop type="x-flavor">chocolate</prop>\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testTmxSerializeString: function(test) {
+        test.expect(2);
+
+        var x = new Tmx();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "vier fumpf sechs"
+        });
+
+        tmx.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <body>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>baby baby</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>vier fumpf sechs</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testTmxSerializeComplex: function(test) {
+        test.expect(2);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        var res = new ResourceString({
+            sourceStrings: {
+                one: "one string",
+                other: "other strings"
+            },
+            sourceLocale: "en-US",
+            key: "blah blah",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetStrings: {
+                one: "eine Zeichenfolge",
+                other: "mehrere Zeichenfolge"
+            }
+        });
+
+        tmx.addResource(res);
+
+        var res = new ResourceArray({
+            sourceArray: [
+                "a",
+                "b",
+                "c"
+            ],
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            targetLocale: "de-DE",
+            targetArray: [
+                "x",
+                "y",
+                "z"
+            ]
+        });
+
+        tmx.addResource(res);
+
+        var actual = tmx.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <body>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>baby baby</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>vier fumpf sechs</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>one string</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eine Zeichenfolge</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>other strings</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>mehrere Zeichenfolge</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>a</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>x</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>b</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>y</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>c</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>z</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    }
+};


### PR DESCRIPTION
- add regular resources from any source to the tmx file
- tmx file will break down the resources, segment them according to the segmentation style requested, and write out the resulting tmx file format
- can handle strings, plurals, and array resource types
- can handle source-only or source+target resources
- segmentation handled by the `cldr-segmentation` package
- currently output only. Cannot read/parse tmx files.
