### PR TITLE
Implement a "convert" action in the loctool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ point for your project, and then edit it to customize any settings.
 22:52:56 INFO loctool.loctool: loctool - extract strings from source code.
 
 22:52:56 INFO loctool.loctool: Command: init
-loctool v2.8.2 Copyright (c) 2016-2017, 2019-2020, HealthTap, Inc. and JEDLSoft
+loctool v2.8.2 Copyright (c) 2016-2017, 2019-2021, HealthTap, Inc. and JEDLSoft
 Project Initialize
 Full name of this project: myproject
 Type of this project (web, swift, iosobjc, android, custom) [custom]:
@@ -144,7 +144,9 @@ All paths are relative to the root of the project.
     * xliffsOut - where to place the output xliff files, such as
     the "new" strings files
 * plugins - an array of names of plugins to use that handle various file
-  types in your project
+  types in your project. Make sure you have put these plugins as dependencies
+  in your package.json. See the plugins section below for more information
+  about them.
 
 Both the "includes" and "excludes" arrays may contain enhanced glob
 wildcard expressions using the [minimatch syntax](https://github.com/isaacs/minimatch):
@@ -506,6 +508,41 @@ Then:
 ```
 npm run loc
 ```
+
+Other Actions the Loctool Can Do
+-------
+
+All of the above documentation is focussed on localization, which is the
+main function of the loctool and it is the default action. There are a
+few other things that the loctool can do as well, and these are specified
+on the command line as the 2nd parameter, similar to the way that
+actions are specified to git or npm.
+
+These are the actions which are available:
+
+- localize - localize any projects found in the current directory tree.
+  This is the default action.
+- init - create a new project.json file based on the answers to a few
+  questions. This makes it easy to set up a new project for localization.
+- merge - merge multiple xliff files together into one. There may be some
+  restrictions to this, as xliff v2.0 format files cannot contain translations
+  to multiple languages.
+- split - split a set of xliff files into multiple xliff files where each
+  output file contains one language or project.
+- generate - like the localize action, this generates a set of localized
+  files for the project. However, unlike the localize action, it does not
+  read the source files first to determine which strings are used nor does
+  it generate a new strings file.
+- convert - Converts one resource file format to another. Resource files
+  are files that contain a collection of translations for a product in a
+  particular programming language. Examples include xliff, po, json,
+  strings, or
+  properties files. Additionally, the convert action can transform the
+  input files into translation memory tmx files. Tmx files cannot be
+  input files, only output. Note that conversion of files is not guaranteed
+  to preserve all data. For example, strings files for iOS can contain
+  comments whereas json files cannot. If you convert a strings file into a
+  json file, any comments will be lost.
 
 Copyright and License
 -------

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ point for your project, and then edit it to customize any settings.
 22:52:56 INFO loctool.loctool: loctool - extract strings from source code.
 
 22:52:56 INFO loctool.loctool: Command: init
-loctool v2.8.2 Copyright (c) 2016-2017, 2019-2021, HealthTap, Inc. and JEDLSoft
+loctool v2.12.0 Copyright (c) 2016-2017, 2019-2021, HealthTap, Inc. and JEDLSoft
 Project Initialize
 Full name of this project: myproject
 Type of this project (web, swift, iosobjc, android, custom) [custom]:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,10 +7,12 @@ Published as version 2.12.0
 
 New Features:
 * Added the --xliffStyle flag which specifies customized xliff format
-* Added support for generating a TMX file out of a set of xliff files.
-    * Added a "tmx" action to the command-line: `loctool tmx output.tmx *.xliff`
-    * The TMX files are not segmented. That is, they contain the full strings
-      that appear in the input xliff files
+* Added support for writing TMX files
+    * The TMX files are segmented by paragraph (whole strings) or sentence.
+* Added a "convert" action to the command-line. This converts files from one format to another:
+    * `loctool convert output.tmx input1.xliff input2.xliff ...`
+    * files types are recognized by extension
+    * you may need plugins to read/write some file types
 
 Bug Fixes:
 

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -18,6 +18,7 @@
  */
 
 var path = require("path");
+var ilib = require("ilib");
 
 var AndroidFlavors = require("./AndroidFlavors.js");
 var Project = require("./Project.js");
@@ -25,6 +26,25 @@ var ResourceFactory = require("./ResourceFactory.js");
 var PseudoFactory = require("./PseudoFactory.js");
 var TranslationSet = require("./TranslationSet.js");
 var utils = require("./utils.js");
+var ObjectiveCFileType = require("./ObjectiveCFileType.js");
+var SwiftFileType = require("./SwiftFileType.js");
+var IosStringsFileType = require("./IosStringsFileType.js");
+var JavaScriptFileType = require("./JavaScriptFileType.js");
+var JavaScriptResourceFileType = require("./JavaScriptResourceFileType.js");
+var HTMLFileType = require("./HTMLFileType.js");
+var HTMLTemplateFileType = require("./HTMLTemplateFileType.js");
+var HamlFileType = require("./HamlFileType.js");
+var OldHamlFileType = require("./OldHamlFileType.js");
+var RubyFileType = require("./RubyFileType.js");
+var YamlFileType = require("./YamlFileType.js");
+var JsxFileType = require("./JsxFileType.js");
+var YamlResourceFileType = require("./YamlResourceFileType.js");
+var JsxFileType = require("./JsxFileType.js");
+var MarkdownFileType = require("./MarkdownFileType.js");
+var AndroidLayoutFileType = require("./AndroidLayoutFileType.js");
+var AndroidResourceFileType = require("./AndroidResourceFileType.js");
+var JavaFileType = require("./JavaFileType.js");
+var XliffFileType = require("./XliffFileType.js");
 
 var log4js = require("log4js");
 
@@ -54,10 +74,17 @@ var logger = log4js.getLogger("loctool.lib.CustomProject");
  */
 var CustomProject = function(options, root, settings) {
     this.parent.prototype.constructor.call(this, options, root, settings);
+    this.plugins = [];
+    this.useFileTypes = [];
+    this.resourceFileTypes = {};
+    this.defaultLocales = [];
 
-    this.plugins = (options && (options.plugins || options.settings && options.settings.plugins)) || [];
-    this.resourceFileTypes = (options && (options.resourceFileTypes || options.settings && options.settings.resourceFileTypes)) || {};
-    this.defaultLocales = this.settings.locales || (options && options.settings && options.settings.locales) || [];
+    if (options) {
+        this.plugins = (options.plugins || []).concat(settings && settings.plugins || []);
+        this.useFileTypes = (options.fileTypes || []).concat(settings && settings.fileTypes || []);
+        this.resourceFileTypes = (options.resourceFileTypes || settings && settings.resourceFileTypes) || {};
+        this.defaultLocales = options.locales || (settings && settings.locales) || [];
+    }
 
     if (settings && settings["build.gradle"]) {
         this.flavors = new AndroidFlavors(settings["build.gradle"], this.root);
@@ -132,6 +159,26 @@ CustomProject.prototype.getAPI = function() {
     };
 };
 
+var builtinFileTypes = {
+    "HTML": HTMLFileType,
+    "HTMLTemplate": HTMLTemplateFileType,
+    "JavaScript": JavaScriptFileType,
+    "JavaScriptResource": JavaScriptResourceFileType,
+    "Jsx": JsxFileType,
+    "Yaml": YamlFileType,
+    "Ruby": RubyFileType,
+    "YamlResource": YamlResourceFileType,
+    "Haml": HamlFileType,
+    "Markdown": MarkdownFileType,
+    "Java": JavaFileType,
+    "AndroidLayout": AndroidLayoutFileType,
+    "AndroidResource": AndroidLayoutFileType,
+    "ObjectiveCFile": ObjectiveCFileType,
+    "Swift": SwiftFileType,
+    "IosStrings": IosStringsFileType,
+    "Xliff": XliffFileType
+};
+
 CustomProject.prototype.defineFileTypes = function() {
     this.fileTypes = [];
     this.resourceFileMap = {};
@@ -151,6 +198,14 @@ CustomProject.prototype.defineFileTypes = function() {
             this.resourceFileMap[filetype] = this.loadPlugin(this.resourceFileTypes[filetype], this.getAPI());
         }
     }.bind(this));
+
+    if (this.useFileTypes && ilib.isArray(this.useFileTypes) && this.useFileTypes.length > 0) {
+        this.useFileTypes.forEach(function(type) {
+            if (builtinFileTypes[type]) {
+                this.fileTypes.push(new builtinFileTypes[type](this));
+            }
+        }.bind(this));
+    }
 };
 
 /**

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -101,7 +101,7 @@ LocalRepository.prototype.init = function(cb) {
             var ts = xliff.getTranslationSet();
             this.ts.addSet(ts);
         } else {
-            logger.warn("Could not open xliff file: " + this.pathName);
+            logger.debug("Could not open xliff file: " + this.pathName);
         }
     }
     cb();

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -362,11 +362,7 @@ Project.prototype.getFileTypes = function(pathName) {
  * This method is not used during localization. If the
  * caller only needs source files to be read in or wants to
  * perform localization, the caller should use the
- * extract() method instead. Once all of the files are
- * read in, this method calls the callback.
- *
- * @param {Function} cb callback function to call when the
- * extraction is done
+ * extract() method instead.
  */
 Project.prototype.read = function() {
     var pathName;

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -206,8 +206,6 @@ Project.prototype.init = function(cb) {
                     return locale !== "en" && locale !== this.sourceLocale;
                 }.bind(this));
 
-                logger.info("Localize project " + this.options.id + " to locales " + JSON.stringify(locales));
-
                 this.locales = locales;
 
                 cb();
@@ -339,10 +337,69 @@ Project.prototype.getPseudoLocale = function() {
     return this.pseudoLocale;
 };
 
+/**
+ * Return a list of file types that can handle a file
+ * with the given path. Sometimes there is more than
+ * one file type that can handle a path. For example,
+ * HTML file contain both Javascript and HTML strings
+ * in them, so files with a ".html" extension can be
+ * handled by both the javascript file type and the
+ * HTML file type. Sometimes there are none and the
+ * loctool with the current configuration does not
+ * know how to handle that type of file.
+ *
+ * @param {String} pathName path to the file to handle
+ * @returns {Array.<FileType>} an array of file type
+ * instances that can handle the given path
+ */
+Project.prototype.getFileTypes = function(pathName) {
+    return this.extensionMap[path.extname(pathName)];
+};
 
 /**
- * Extract all strings for all file types and when that is
- * done, call the callback function.
+ * Read all the files and extract all strings. All files in
+ * the queue are read in, including translated resource files.
+ * This method is not used during localization. If the
+ * caller only needs source files to be read in or wants to
+ * perform localization, the caller should use the
+ * extract() method instead. Once all of the files are
+ * read in, this method calls the callback.
+ *
+ * @param {Function} cb callback function to call when the
+ * extraction is done
+ */
+Project.prototype.read = function() {
+    var pathName;
+
+    while (!this.paths.isEmpty()) {
+        pathName = this.paths.dequeue();
+
+        try {
+            var types = this.extensionMap[path.extname(pathName)];
+
+            if (types) {
+                types.forEach(function(type) {
+                    // If the path name is explicitly given in the includes list, then we handle it regardless of whether
+                    // or not the type thinks it should be handled.
+                    logger.debug("    " + pathName);
+                    var file = type.newFile(pathName);
+                    file.extract();
+                    type.addSet(file.getTranslationSet());
+                }.bind(this));
+            }
+        } catch (e) {
+            logger.error("Error while extracting from file " + pathName + ". Skipping...");
+            logger.error(e);
+        }
+    }
+
+    this.paths = undefined; // signal to the GC that we are done with this
+};
+
+/**
+ * Extract all strings from source files for all file types and when that is
+ * done, call the callback function. Files which are already-translated
+ * resource files are skipped.
  *
  * @param {Function} cb callback function to call when the
  * extraction is done
@@ -501,6 +558,19 @@ Project.prototype.generateMode = function(cb) {
         genMode.init();
     }
     cb();
+};
+
+/**
+ * Return a translation set with all of the strings that have
+ * been extracted so far.
+ * @returns {TranslationSet} a set of all strings extracted so far
+ */
+Project.prototype.getExtracted = function(cb) {
+    var extracted = new TranslationSet();
+    this.fileTypes.forEach(function(type) {
+        extracted.addSet(type.getExtracted());
+    });
+    return extracted;
 };
 
 /**

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -394,7 +394,7 @@ Tmx.prototype.addResource = function(res) {
                     locale: res.getSourceLocale(),
                     string: segment
                 }));
-                if (addTarget) {
+                if (addTarget && res.getTarget() && translationSegments[i]) {
                     tu.addVariant(new TranslationVariant({
                         locale: res.getTargetLocale(),
                         string: translationSegments[i]
@@ -413,7 +413,7 @@ Tmx.prototype.addResource = function(res) {
             var srcArr = res.getSourceArray().map(function(element) {
                 return this.segmentString(element, res.getSourceLocale());
             }.bind(this));
-            var tarArr = addTarget && res.getTargetArray().map(function(element) {
+            var tarArr = addTarget && res.getTargetArray() && res.getTargetArray().map(function(element) {
                 return this.segmentString(element, res.getTargetLocale());
             }.bind(this));
             srcArr.forEach(function(element, i) {
@@ -427,7 +427,7 @@ Tmx.prototype.addResource = function(res) {
                         locale: res.getSourceLocale(),
                         string: string
                     }));
-                    if (addTarget) {
+                    if (addTarget && tarArr[i] && j < tarArr[i].length) {
                         tu.addVariant(new TranslationVariant({
                             locale: res.getTargetLocale(),
                             string: tarArr[i][j]
@@ -450,7 +450,7 @@ Tmx.prototype.addResource = function(res) {
             srcPlurals = utils.objectMap(srcPlurals, function(string) {
                 return this.segmentString(string, res.getSourceLocale());
             }.bind(this));
-            tarPlurals = utils.objectMap(tarPlurals, function(string) {
+            tarPlurals = tarPlurals && utils.objectMap(tarPlurals, function(string) {
                 return this.segmentString(string, res.getTargetLocale());
             }.bind(this));
 
@@ -471,7 +471,7 @@ Tmx.prototype.addResource = function(res) {
                     // categories than the source language. So, we have
                     // to check if the target category exists first before
                     // we attempt to add a variant for it.
-                    if (addTarget && tarPlurals[category]) {
+                    if (addTarget && tarPlurals && tarPlurals[category]) {
                         tu.addVariant(new TranslationVariant({
                             locale: res.getTargetLocale(),
                             string: tarPlurals[category][i]
@@ -493,7 +493,7 @@ Tmx.prototype.addResource = function(res) {
             // the source language, we have to check for those extra
             // categories and add a variant for each of them to the
             // translation unit for the "other" category
-            if (addTarget) {
+            if (addTarget && tarPlurals) {
                 for (var category in tarPlurals) {
                     if (!srcPlurals[category]) {
                         tarPlurals[category].forEach(function(string, i) {

--- a/lib/XliffFile.js
+++ b/lib/XliffFile.js
@@ -46,6 +46,10 @@ var XliffFile = function(props) {
         this.locale = props.locale;
         this.context = props.context || undefined;
     }
+
+    this.locale = this.locale || (this.project && this.project.sourceLocale) || "en-US";
+
+    this.set = new TranslationSet(this.locale);
 };
 
 /**
@@ -55,15 +59,15 @@ var XliffFile = function(props) {
 XliffFile.prototype.extract = function() {
     if (this.pathName && fs.existsSync(this.pathName)) {
         logger.trace("XliffFile: loading strings in " + this.pathName);
-        this.xliff = new Xliff({
+        var xliff = new Xliff({
             path: this.pathName,
             sourceLocale: this.project.sourceLocale,
             project: this.project
         });
 
-        this.xliff.deserialize(fs.readFileSync(this.pathName, "utf-8"));
+        xliff.deserialize(fs.readFileSync(this.pathName, "utf-8"));
 
-        this.set = this.xliff.getTranslationSet();
+        this.set = xliff.getTranslationSet();
         logger.trace("After loading, there are " + this.set.size() + " resources.");
 
         // mark this set as not dirty after we read it from disk
@@ -156,7 +160,17 @@ XliffFile.prototype.write = function() {
         var d = path.dirname(p);
         utils.makeDirs(d);
 
-        fs.writeFileSync(p, this.xliff.serialize(), "utf-8");
+        var xliff = new Xliff({
+            path: this.pathName,
+            sourceLocale: this.project.sourceLocale,
+            project: this.project,
+            version: this.project.settings.xliffVersion,
+            style: this.project.settings.xliffStyle
+        });
+
+        xliff.addSet(this.set);
+
+        fs.writeFileSync(p, xliff.serialize(), "utf-8");
 
         logger.debug("Wrote string translations to file " + this.pathName);
     } else {

--- a/lib/XliffFileType.js
+++ b/lib/XliffFileType.js
@@ -1,7 +1,7 @@
 /*
  * XliffFileType.js - Represents a collection of Xliff files
  *
- * Copyright © 2016-2017, 2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2020-2021 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ XliffFileType.prototype = new FileType();
 XliffFileType.prototype.parent = FileType;
 XliffFileType.prototype.constructor = XliffFileType;
 
+var alreadyLoc = new RegExp(/([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z](-[A-Z]+)?)?)\.html?$/);
+
 /**
  * Return true if the given path is a Haml file and is handled
  * by the current file type.
@@ -48,9 +50,14 @@ XliffFileType.prototype.constructor = XliffFileType;
  */
 XliffFileType.prototype.handles = function(pathName) {
     logger.debug("XliffFileType handles " + pathName + "?");
-    // var ret = extensionRE.test(pathName);
-    ret = (path.normalize(pathName) === "en-US.xliff");
 
+    logger.debug(ret ? "Yes" : "No");
+    var ret = ((pathName.length > 4) && (pathName.substring(pathName.length - 4) === ".xlf")) ||
+        ((pathName.length > 6) && (pathName.substring(pathName.length - 6) === ".xliff"));
+    if (ret) {
+        var match = alreadyLoc.exec(pathName);
+        ret = (match && match.length) ? match[1] === this.project.sourceLocale : true;
+    }
     logger.debug(ret ? "Yes" : "No");
     return ret;
 };
@@ -68,57 +75,16 @@ XliffFileType.prototype.name = function() {
  * are no aggregated strings.
  */
 XliffFileType.prototype.write = function() {
-    logger.trace("Writing xliff files");
-    if (this.file) {
-        var res, file, resources = this.newres.getAll();
-
-        logger.trace("There are " + resources.length + " resources to add.");
-
-        for (var i = 0; i < resources.length; i++) {
-            res = resources[i];
-            this.file.addResource(res);
-            logger.trace("Added " + res.reskey + " to " + this.file.pathName);
-        }
-
-        resources = this.pseudo.getAll();
-
-        for (var i = 0; i < resources.length; i++) {
-            res = resources[i];
-            this.file.addResource(res);
-            logger.trace("Added " + res.reskey + " to " + this.file.pathName);
-        }
-
-        logger.info("Now writing out the ios xliff files");
-
-        // first write out the xliff file to disk, then import it to xcode
-        this.file.write();
-
-        if (this.file.getTranslationSet().isDirty()) {
-            logger.info("executing xcodebuild on the " + this.project.options.id + " project to import those translations. This may take a while...");
-
-            var args = ["-importLocalizations", "-localizationPath", "./en.xliff", "-project", "feelgood.xcodeproj"];
-            var procStatus = spawnSync('xcodebuild', args);
-            procStatus.stdout && logger.info(procStatus.stdout.toString("utf-8"));
-            if (procStatus.status !== 0) {
-                logger.warn("Execution failed: ");
-            }
-            procStatus.stderr && logger.info(procStatus.stderr.toString("utf-8"));
-
-            logger.info("xcodebuild done");
-        }
-    }
+    // xliffs are localized individually, so we don't have to
+    // write out the resources
 };
 
 XliffFileType.prototype.newFile = function(pathName) {
-    if (!this.file) {
-        this.file = new XliffFile({
-            project: this.project,
-            pathName: pathName,
-            sourceLocale: this.project.sourceLocale
-        });
-    }
-
-    return this.file;
+    return new XliffFile({
+        project: this.project,
+        pathName: pathName,
+        sourceLocale: this.project.sourceLocale
+    });
 };
 
 /**

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1,0 +1,83 @@
+/*
+ * convert.js - convert between file types
+ *
+ * Copyright © 2021 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var path = require("path");
+var log4js = require("log4js");
+
+var CustomProject = require("./CustomProject.js");
+var TMX = require("./TMX.js");
+
+var logger = log4js.getLogger("loctool.lib.convert");
+
+function convert(settings) {
+    var project = new CustomProject({
+        name: "convert",
+        id: "convert",
+        sourceLocale: "en-US",
+        fileTypes: [
+            "Xliff",
+            "JavaScriptResource",
+            "YamlResource",
+            "AndroidResource",
+            "IosStrings",
+        ]
+    }, ".", settings);
+    
+    settings.infiles.forEach(function(file) {
+        project.addPath(file);
+    });
+
+    project.init(function() {
+        logger.info("Reading from input files " + settings.infiles);
+        project.read();
+        var set = project.getExtracted();
+        var file, extension = path.extname(settings.outfile);
+        if (extension === ".tmx") {
+            // special case for tmx files, as there is not FileType for it
+            file = new TMX({
+                path: settings.outfile,
+                sourceLocale: project.sourceLocale,
+                segmentation: settings.segmentation
+            });
+        } else {
+            var ft = project.getFileTypes(settings.outfile);
+            if (ft && ft.length) {
+                // try the first one with a write method
+                var type = ft.find(function(type) {
+                    return typeof(type.write) === 'function';
+                });
+                file = type.newFile(settings.outfile);
+            }
+        }
+
+        if (!file) {
+            logger.error("No File Type available to handle output file " + settings.outfile);
+            return;
+        }
+
+        set.getAll().forEach(function(resource) {
+            file.addResource(resource);
+        });
+
+        logger.info("Writing to output file " + settings.outfile);
+        file.write();
+    });
+}
+
+module.exports = convert;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -38,7 +38,7 @@ function convert(settings) {
             "IosStrings",
         ]
     }, ".", settings);
-    
+
     settings.infiles.forEach(function(file) {
         project.addPath(file);
     });

--- a/loctool.js
+++ b/loctool.js
@@ -32,6 +32,7 @@ var GenerateModeProcess = require("./lib/GenerateModeProcess.js");
 
 var XliffMerge = require("./lib/XliffMerge.js");
 var XliffSplit = require("./lib/XliffSplit.js");
+var fileConvert = require("./lib/convert.js");
 
 // var Git = require("simple-git");
 
@@ -54,6 +55,8 @@ function usage() {
         "Extract localizable strings from the source code.\n\n" +
         "-2\n" +
         "  Use xliff 2.0 format files instead of the default xliff 1.2\n" +
+        "--exclude\n" +
+        "  exclude a comma-separated list of directories while searching for project.json config files \n" +
         "-f or --filetype\n" +
         "  Restrict operation to only the given list of file types. This allows you to\n" +
         "  run only the parts of the loctool that are needed at the moment.\n" +
@@ -66,6 +69,8 @@ function usage() {
         "  Restrict operation to only the given locales. Locales should be given as\n" +
         "  a comma-separated list of BCP-47 locale specs. By default, this tool\n" +
         "  will operate with all locales that are available in the translations.\n" +
+        "--localizeOnly\n" +
+        "  Generate a localization resource only. Do not create any other files at all after running loctool. \n" +
         "-n or --pseudo\n" +
         "  Do pseudo-localize missing strings and generate the pseudo-locale. (Default is\n" +
         "  not to do pseudo-localization.\n" +
@@ -73,58 +78,61 @@ function usage() {
         "  Use the old ruby-based haml localizer instead of the new javascript one.\n" +
         "-p or --pull\n" +
         "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
+        "--projectType\n" +
+        "  the type of project, which affects how source files are read and resource files are written. Default: web \n" +
+        "--plugins\n" +
+        "  plugins to use that handle various file types in your project. The parameter should be a\n" +
+        "  comma-separated list of plugin names.\n" +
         "-q or --quiet\n" +
         "  Quiet mode. Only print banners and any errors/warnings.\n" +
+        "--resourceDirs\n" +
+        "  Specify the dir where the generation output should go. \n" +
+        "--resourceFileNames\n" +
+        "  Specify the resource filename used during resource file generation.\n" +
+        "--resourceFileTypes\n" +
+        "  Specifies the file type of the resource to be created. \n" +
+        "--root dir\n" +
+        "  directory containing the git projects with the source code.\n" +
+        "  Default: current dir.\n" +
         "-s or --silent\n" +
         "  Silent mode. Don't ever print anything on the stdout. Instead, just exit with\n" +
         "  the appropriate exit code.\n" +
+        "--segmentation\n" +
+        "  Style of segmentation to use when writing out TMX files. Style can be 'sentence'\n" +
+        "  or 'paragraph'. (Default is 'paragraph') \n" +
+        "--sourceLocale\n" +
+        "   Default locale of source string. (Default is en-US) \n" +
         "-t or --target\n" +
         "  Write all output to the given target dir instead of in the source dir.\n" +
         "-v or --version\n" +
         "  Print the current loctool version and exit\n" +
         "-x or --xliffs\n" +
         "  Specify the dir where the xliffs files live. Default: \".\"\n" +
-        "--projectType\n" +
-        "  the type of project, which affects how source files are read and resource files are written. Default: web \n" +
-        "--sourceLocale\n" +
-        "   Default locale of source string. (Default is en-US) \n" +
-        "--plugins\n" +
-        "  plugins to use that handle various file types in your project. \n" +
-        "--resourceFileTypes\n" +
-        "  Specifies the file type of the resource to be created. \n" +
-        "--resourceFileNames\n" +
-        "  Specify the resource filename used during resource file generation.\n" +
-        "--resourceDirs\n" +
-        "  Specify the dir where the generation output should go. \n" +
-        "--localizeOnly\n" +
-        "  Generate a localization resource only. Do not create any other files at all after running loctool. \n" +
-        "--xliffResRoot\n" +
-        "  Specify the dir where the generation output should go. (Default is resources/) \n" +
         "--xliffResName\n" +
         "  Specify the resource filename used during resource file generation. (Default is strings.json) \n" +
-        "--exclude\n" +
-        "  exclude a comma-separated list of directories while searching for project.json config files \n" +
+        "--xliffResRoot\n" +
+        "  Specify the dir where the generation output should go. (Default is resources/) \n" +
         "--xliffStyle\n" +
-        "  Specify the Xliff format style. It can have standard or custom. (Default is standard) \n" +
+        "  Specify the Xliff format style. Style can be 'standard' or 'custom'. (Default is 'standard') \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    init  [project-name] - initialize the current directory as a loctool project\n" +
         "             and write out a project.json file.\n" +
         "    localize [root-dir-name] - extract strings and generate localized resource\n" +
         "             files. This is the default command. Default root dir name is '.'\n" +
-        "    report - generate a loc report, but don't generate localized resource files.\n" +
+//        "    report - generate a loc report, but don't generate localized resource files.\n" +
         "    export [filename] - export all the new strings to an xliff or a set of xliff\n" +
-        "             files. Default: a set of files named new-<locale>.xliff\n" +
+        "             files. Default: a set of files named new-<locale>.xliff [not implemented yet]\n" +
         "    import filename ... - import all the translated strings in the given\n" +
-        "             xliff files.\n" +
+        "             xliff files. [not implemented yet]\n" +
         "    split (language|project) filename ... - split the given xliff files by\n" +
         "             language or project.\n" +
         "    merge outfile filename ... - merge the given xliff files to the named\n" +
         "             outfile.\n" +
-        "    generate ... - generate resources without scanning sources. \n " +
-        "root dir\n" +
-        "  directory containing the git projects with the source code. \n" +
-        "  Default: current dir.\n");
+        "    generate ... - generate resources without scanning sources.\n" +
+        "    convert outfile filename ... - convert input files to the output file format.\n" +
+        "             All files must be resource file types such as xliff, po, or xliff.\n"
+        );
     process.exit(0);
 }
 
@@ -147,7 +155,8 @@ var settings = {
     xliffStyle: "standard",
     localizeOnly: false,
     projectType: "web",
-    exclude: ["**/node_modules", "**/.git", "**/.svn"]
+    exclude: ["**/node_modules", "**/.git", "**/.svn"],
+    segmentation: "paragraph"
 };
 
 var options = [];
@@ -248,6 +257,11 @@ for (var i = 0; i < argv.length; i++) {
         if (candidate.indexOf(argv[++i]) !== -1) {
             settings.xliffStyle = argv[++i];
         }
+    } else if (val === "--segmentation") {
+        var candidate = ["paragraph", "sentence"];
+        if (candidate.indexOf(argv[++i]) !== -1) {
+            settings.segmentation = argv[++i];
+        }
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
     } else if (val === "--exclude") {
@@ -267,6 +281,7 @@ for (var i = 0; i < argv.length; i++) {
 var command = options.length > 2 ? options[2] : "localize";
 settings.mode = command;
 switch (command) {
+default:
 case "localize":
     if (options.length > 3) {
         settings.rootDir = options[3];
@@ -309,9 +324,18 @@ case "merge":
     settings.outfile = options[3]
     settings.infiles = options.slice(4);
     break;
+
+case "convert":
+    if (options.length < 5) {
+        console.log("Error: must specify an output file name and at least one input file.");
+        usage();
+    }
+    settings.outfile = options[3]
+    settings.infiles = options.slice(4);
+    break;
 }
 
-logger.info("loctool - extract strings from source code.\n");
+logger.info("loctool - extract strings from source code and localize them.\n");
 logger.info("Command: " + command);
 
 if (command === "localize") {
@@ -539,8 +563,11 @@ try {
         var project = ProjectFactory.newProject(settings, settings);
         GenerateModeProcess(project);
        break;
-    }
 
+    case "convert":
+        fileConvert(settings);
+        break;
+    }
 } catch (e) {
     logger.error("caught exception: " + e);
     logger.error(e.stack);

--- a/loctool.js
+++ b/loctool.js
@@ -260,7 +260,7 @@ for (var i = 0; i < argv.length; i++) {
     } else if (val === "--segmentation") {
         var candidate = ["paragraph", "sentence"];
         if (candidate.indexOf(argv[++i]) !== -1) {
-            settings.segmentation = argv[++i];
+            settings.segmentation = argv[i];
         }
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;

--- a/log4js.json
+++ b/log4js.json
@@ -33,6 +33,10 @@
             "appenders": [ "default" ],
             "level": "info"
         },
+        "loctool.lib.convert": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
         "loctool.lib.ContextResourceString": {
             "appenders": [ "default" ],
             "level": "info"
@@ -186,6 +190,10 @@
             "level": "info"
         },
         "loctool.lib.SwiftProject": {
+            "appenders": [ "default" ],
+            "level": "info"
+        },
+        "loctool.lib.Tmx": {
             "appenders": [ "default" ],
             "level": "info"
         },

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -2959,7 +2959,7 @@ module.exports.tmx = {
         test.ok(fs.existsSync(path.join(base, "testfiles/test/output.tmx")));
 
         var actual = fs.readFileSync(path.join(base, "testfiles/test/output.tmx"), "utf-8");
-        var expected = 
+        var expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
             '  <header segtype="sentence" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
@@ -3055,5 +3055,74 @@ module.exports.tmx = {
         test.equal(actual, expected);
 
         test.done();
-    }
+    },
+
+    testTmxAddResourceSegmentSentenceTargetSpecial: function(test) {
+        test.expect(27);
+
+        var tmx = new Tmx({
+            segmentation: "sentence"
+        });
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "The SignRequest subdomain cannot be changed. If you need a different domain you can create a new team.",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            flavor: "chocolate",
+            comment: "this is a comment",
+            project: "webapp",
+            target: "SignRequest domänen kan inte ändras. Om du behöver en annan domän kan du skapa en nya arbetsgrupp.",
+            targetLocale: "sv"
+        });
+
+        tmx.addResource(res);
+
+        var units = tmx.getTranslationUnits();
+        test.ok(units);
+        test.equal(units.length, 2);
+
+        test.equal(units[0].string, "The SignRequest subdomain cannot be changed.");
+        test.equal(units[0].locale, "en-US");
+        var props = units[0].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[0].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "The SignRequest subdomain cannot be changed.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "SignRequest domänen kan inte ändras.");
+        test.equal(variants[1].locale, "sv");
+
+        test.equal(units[1].string, "If you need a different domain you can create a new team.");
+        test.equal(units[1].locale, "en-US");
+        props = units[1].getProperties();
+        test.ok(props);
+        test.equal(props["x-project"], "webapp");
+        test.equal(props["x-context"], "asdf");
+        test.equal(props["x-flavor"], "chocolate");
+
+        var variants = units[1].getVariants();
+        test.ok(variants);
+        test.equal(variants.length, 2);
+
+        test.equal(variants[0].string, "If you need a different domain you can create a new team.");
+        test.equal(variants[0].locale, "en-US");
+
+        test.equal(variants[1].string, "Om du behöver en annan domän kan du skapa en nya arbetsgrupp.");
+        test.equal(variants[1].locale, "sv");
+
+        test.done();
+    },
+
 };


### PR DESCRIPTION
* Converts one resource file format to another. Resource files are files that contain a collection of translations for a product in a particular programming language. Examples include xliff, po, json, strings, or properties files.
* Additionally, the convert action can transform the input files into translation memory tmx files. Tmx files cannot be input files, only output. 
* Note that conversion of files is not guaranteed to preserve all data. For example, strings files for iOS can contain comments whereas json files cannot. If you convert a strings file into a json file, any comments will be lost.

Command-line usage:

`loctool convert output-file input-file [input-file ...]`

