### PR TITLE
Add a --project option to the command line

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,9 @@ New Features:
     * you may need plugins to read/write some file types
 
 Bug Fixes:
-
+- the locales to localize to were not set correctly if there are no translation files already.
+  This made it harder to start new projects.
+- Xliff output didn't work if the source locale was something other than "en-US"
 
 Build 020
 -------

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -83,7 +83,7 @@ var CustomProject = function(options, root, settings) {
         this.plugins = (options.plugins || []).concat(settings && settings.plugins || []);
         this.useFileTypes = (options.fileTypes || []).concat(settings && settings.fileTypes || []);
         this.resourceFileTypes = (options.resourceFileTypes || settings && settings.resourceFileTypes) || {};
-        this.defaultLocales = options.locales || (settings && settings.locales) || [];
+        this.defaultLocales = this.settings.locales || (options.settings && options.settings.locales) || [];
     }
 
     if (settings && settings["build.gradle"]) {

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -599,6 +599,7 @@ Project.prototype.close = function(cb) {
                 var modernPath = path.join(dir, base + "-modern.xliff");
                 logger.info("Writing out the modern translation strings to " + modernPath);
                 var modernXliff = new Xliff({
+                    sourceLocale: this.sourceLocale,
                     pathName: modernPath,
                     version: this.settings.xliffVersion,
                     style: this.settings.xliffStyle
@@ -625,6 +626,7 @@ Project.prototype.close = function(cb) {
         if (extracted.size()) {
             logger.info("Writing out the extracted strings to " + extractedPath);
             var extractedXliff = new Xliff({
+                sourceLocale: this.sourceLocale,
                 pathName: extractedPath,
                 allowDups: true,
                 version: this.settings.xliffVersion,

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -27,8 +27,8 @@ var logger = log4js.getLogger("loctool.lib.convert");
 
 function convert(settings) {
     var project = new CustomProject({
-        name: "convert",
-        id: "convert",
+        name: settings.projectName,
+        id: settings.projectName,
         sourceLocale: "en-US",
         fileTypes: [
             "Xliff",

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -27,8 +27,8 @@ var logger = log4js.getLogger("loctool.lib.convert");
 
 function convert(settings) {
     var project = new CustomProject({
-        name: settings.projectName,
-        id: settings.projectName,
+        name: settings.id,
+        id: settings.id,
         sourceLocale: "en-US",
         fileTypes: [
             "Xliff",

--- a/loctool.js
+++ b/loctool.js
@@ -78,8 +78,8 @@ function usage() {
         "  Use the old ruby-based haml localizer instead of the new javascript one.\n" +
         "-p or --pull\n" +
         "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
-        "--project\n" +
-        "  Specify the name of the project to use for output files during a convert command.\n" +
+        "--projectId\n" +
+        "  Specify the default name of the project if not specified otherwise.\n" +
         "--projectType\n" +
         "  The type of project, which affects how source files are read and resource files are written. Default: web \n" +
         "--plugins\n" +
@@ -162,8 +162,7 @@ var settings = {
     projectType: "web",
     exclude: ["**/node_modules", "**/.git", "**/.svn"],
     segmentation: "paragraph",
-    targetLocale: null,
-    projectName: "convert"
+    targetLocale: null
 };
 
 var options = [];
@@ -271,8 +270,6 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--targetLocale") {
         settings.targetLocale = argv[++i];
-    } else if (val === "--project") {
-        settings.projectName = argv[++i];
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
     } else if (val === "--exclude") {
@@ -576,6 +573,9 @@ try {
        break;
 
     case "convert":
+        if (!settings.id) {
+            settings.id = "convert";
+        }
         fileConvert(settings);
         break;
     }

--- a/loctool.js
+++ b/loctool.js
@@ -78,8 +78,10 @@ function usage() {
         "  Use the old ruby-based haml localizer instead of the new javascript one.\n" +
         "-p or --pull\n" +
         "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
+        "--project\n" +
+        "  Specify the name of the project to use for output files during a convert command.\n" +
         "--projectType\n" +
-        "  the type of project, which affects how source files are read and resource files are written. Default: web \n" +
+        "  The type of project, which affects how source files are read and resource files are written. Default: web \n" +
         "--plugins\n" +
         "  plugins to use that handle various file types in your project. The parameter should be a\n" +
         "  comma-separated list of plugin names.\n" +
@@ -160,7 +162,8 @@ var settings = {
     projectType: "web",
     exclude: ["**/node_modules", "**/.git", "**/.svn"],
     segmentation: "paragraph",
-    targetLocale: null
+    targetLocale: null,
+    projectName: "convert"
 };
 
 var options = [];
@@ -268,6 +271,8 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--targetLocale") {
         settings.targetLocale = argv[++i];
+    } else if (val === "--project") {
+        settings.projectName = argv[++i];
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
     } else if (val === "--exclude") {


### PR DESCRIPTION
so that you can specify the project name during a convert action.