### PR TITLE
Escape less than characters in xml attributes

### DIFF
--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -457,7 +457,8 @@ function escapeAttr(str) {
         replace(/\n/g, "\\n").
         replace(/&/g, "&amp;").
         replace(/"/g, "&quot;").
-        replace(/'/g, "&apos;");
+        replace(/'/g, "&apos;").
+        replace(/</g, "&lt;");
 }
 
 /**
@@ -469,6 +470,7 @@ function unescapeAttr(str) {
     if (!str) return;
     return str.
         replace(/\\n/g, "\n").
+        replace(/&lt;/g, '<').
         replace(/&quot;/g, '"').
         replace(/&apos;/g, "'").
         replace(/&amp;/g, "&");


### PR DESCRIPTION
Mojito cannot read xml with less than characters in attribute values, so these need to be escaped when writing the xliff files and then unescaped when reading them.