### PR TITLE
Avoid outputting translation units with no translations

### DIFF
--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -181,6 +181,11 @@ TranslationUnit.prototype.addProperties = function(properties) {
  * @returns {Object} a json object which encodes this unit.
  */
 TranslationUnit.prototype.serialize = function() {
+    if (!this.variants || this.variants.length < 2) {
+        // nothing in this translation unit, so don't serialize it
+        return undefined;
+    }
+
     var retval = {
         _attributes: {
             srclang: this.locale
@@ -579,7 +584,12 @@ Tmx.prototype.serialize = function() {
 
     // now finally add each of the units to the json
 
-    json.tmx.body.tu = this.tu.map(function(unit) {
+    json.tmx.body.tu = this.tu.filter(function(unit) {
+        // TUs have to have at least 2 variants (a source + a target) to make it useful.
+        // Otherwise, just don't output the variant at all.
+        var variants = unit.getVariants();
+        return variants.length > 1;
+    }).map(function(unit) {
         return unit.serialize();
     });
 

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -1571,7 +1571,9 @@ module.exports.tmx = {
             context: "asdf",
             flavor: "chocolate",
             comment: "this is a comment",
-            project: "webapp"
+            project: "webapp",
+            target: "foobar auf deutsch",
+            targetLocale: "de-DE"
         });
 
         tmx.addResource(res);
@@ -1586,7 +1588,9 @@ module.exports.tmx = {
             context: "asdf",
             flavor: "chocolate",
             comment: "this is a comment",
-            project: "webapp"
+            project: "webapp",
+            target: "foobar en francais",
+            targetLocale: "fr-FR"
         });
 
         tmx.addResource(res);
@@ -1602,6 +1606,12 @@ module.exports.tmx = {
             '      <prop type="x-project">webapp</prop>\n' +
             '      <tuv xml:lang="en-US">\n' +
             '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>foobar auf deutsch</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="fr-FR">\n' +
+            '        <seg>foobar en francais</seg>\n' +
             '      </tuv>\n' +
             '    </tu>\n' +
             '  </body>\n' +
@@ -3125,4 +3135,77 @@ module.exports.tmx = {
         test.done();
     },
 
+    testTmxSerializeStringDontSerializeUnitsWithNoTranslations: function(test) {
+        test.expect(2);
+
+        var tmx = new Tmx();
+        test.ok(tmx);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "eins zwei drei"
+        });
+
+        tmx.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE",
+            target: "vier fumpf sechs"
+        });
+
+        tmx.addResource(res);
+
+        // source-only resource should not appear in the serialized output
+        res = new ResourceString({
+            source: "oh yeah!",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE"
+        });
+
+        tmx.addResource(res);
+
+        var actual = tmx.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<tmx version="1.4">\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <body>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>Asdf asdf</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>eins zwei drei</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '    <tu srclang="en-US">\n' +
+            '      <prop type="x-project">webapp</prop>\n' +
+            '      <tuv xml:lang="en-US">\n' +
+            '        <seg>baby baby</seg>\n' +
+            '      </tuv>\n' +
+            '      <tuv xml:lang="de-DE">\n' +
+            '        <seg>vier fumpf sechs</seg>\n' +
+            '      </tuv>\n' +
+            '    </tu>\n' +
+            '  </body>\n' +
+            '</tmx>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    }
 };


### PR DESCRIPTION
If there are no "variants" of a source string, then don't bother outputting the translation unit to the tmx file. The string is not useful in a translation memory if it doesn't have translations.