### PR TITLE
Added guard code not to work if the object is empty 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 2
 ============================
 
+Build 022
+-------
+Published as version 2.12.1
+Bug Fixes:
+- Added guard code not to work if the object is empty when setting target locale for conversions
+
+
 Build 021
 -------
 Published as version 2.12.0

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -189,7 +189,7 @@ CustomProject.prototype.defineFileTypes = function() {
             var resFileType = plugin.getResourceFileType();
             if (resFileType) {
                 this.resourceFileMap[plugin.type] = new resFileType(this, this.getAPI());
-                if (this.settings.targetLocale) {
+                if (this.settings.targetLocale && Object.keys(this.settings.targetLocale).length > 0) {
                     this.resourceFileMap[plugin.type].setLocale(this.settings.targetLocale);
                 }
             }

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -189,7 +189,7 @@ CustomProject.prototype.defineFileTypes = function() {
             var resFileType = plugin.getResourceFileType();
             if (resFileType) {
                 this.resourceFileMap[plugin.type] = new resFileType(this, this.getAPI());
-                if (this.settings.targetLocale && Object.keys(this.settings.targetLocale).length > 0) {
+                if (this.settings.mode === "convert" && this.settings.targetLocale) {
                     this.resourceFileMap[plugin.type].setLocale(this.settings.targetLocale);
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
Added guard code not to work if the object is empty when setting target locale for conversions.

During a normal localization process, it occurs an error due to that line. 
this.settings.targetLocale is `{}` at the moment. 
because of https://github.com/iLib-js/loctool/blob/development/lib/Project.js#L84 line. 's merging work.

