### PR TITLE
Bug fixes to pass in the targetLocale to new file instances

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,8 +4,11 @@ Release Notes for Version 2
 Build 023
 -------
 Published as version 2.13.1
+
 Bug Fixes:
 * Fixed the part where the argument number was increased incorrectly
+* Make sure to pass in the target locale as specified on the command line when converting files
+* Corrected misspelled function name in ResourcePlural
 
 Build 022
 -------

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -69,7 +69,7 @@ var Project = function(options, root, settings) {
             return;
         }
         this.sourceLocale = options.sourceLocale;
-        this.targetLocale = options.targetLocale || settings.targetLocale;
+        this.targetLocale = options.targetLocale || (settings && settings.targetLocale);
         this.pseudoLocale = options.pseudoLocale;
         if (options.excludes && ilib.isArray(options.excludes)) {
             logger.trace("normalizing excludes");

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -69,6 +69,7 @@ var Project = function(options, root, settings) {
             return;
         }
         this.sourceLocale = options.sourceLocale;
+        this.targetLocale = options.targetLocale || settings.targetLocale;
         this.pseudoLocale = options.pseudoLocale;
         if (options.excludes && ilib.isArray(options.excludes)) {
             logger.trace("normalizing excludes");
@@ -379,7 +380,10 @@ Project.prototype.read = function() {
                     // If the path name is explicitly given in the includes list, then we handle it regardless of whether
                     // or not the type thinks it should be handled.
                     logger.debug("    " + pathName);
-                    var file = type.newFile(pathName);
+                    var file = type.newFile(pathName, {
+                        sourceLocale: this.sourceLocale,
+                        targetLocale: this.targetLocale
+                    });
                     file.extract();
                     type.addSet(file.getTranslationSet());
                 }.bind(this));
@@ -425,7 +429,10 @@ Project.prototype.extract = function(cb) {
                         logger.trace("Checking if " + types[i].name() + " handles " + pathName);
                         if (types[i].handles(pathName)) {
                             logger.debug("    " + pathName);
-                            var file = types[i].newFile(pathName);
+                            var file = types[i].newFile(pathName, {
+                                sourceLocale: this.sourceLocale,
+                                targetLocale: this.targetLocale
+                            });
                             this.files.enqueue(file);
                             file.extract();
 

--- a/lib/ResourcePlural.js
+++ b/lib/ResourcePlural.js
@@ -427,7 +427,7 @@ ResourcePlural.prototype.cleanHashKey = function() {
  * @param {String} locale a locale spec of the desired translation
  * @return {String} a unique hash key for this resource
  */
-ResourcePlural.prototype.cleanhashKeyForTranslation = function(locale) {
+ResourcePlural.prototype.cleanHashKeyForTranslation = function(locale) {
     var cleaned = this.reskey && this.reskey.replace(/\s+/g, " ").trim() || "";
     return ResourcePlural.hashKey(this.project, this.context, locale, cleaned);
 };


### PR DESCRIPTION
- pass in the source and target locale from the command-line when creating a new file instance. This overrides the locales that may be extracted from the pathname for those file types where the path contains the locale name in it somewhere.
- also includes a fix to the spelling of a ResourcePlural function name that was not used much (so we didn't notice it before), but when I tried to use it from a plugin, I discovered it