### PR TITLE
Fix crash related to plugins that don't implement generatePseudo method

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,7 +1,7 @@
 Release Notes for Version 2
 ============================
 
-Build 023
+Build 024
 -------
 Published as version 2.13.2
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,16 @@ Release Notes for Version 2
 
 Build 023
 -------
+Published as version 2.13.2
+
+Bug Fixes:
+
+* Loctool crashed if some plugins don't implement the generatePseudo method
+  in the FileType class. Now it tests for the existence of the method before
+  attempting to call it.
+
+Build 023
+-------
 Published as version 2.13.1
 
 Bug Fixes:

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -1,7 +1,7 @@
 /*
  * Project.js - represents an project
  *
- * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2021 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -493,7 +493,9 @@ Project.prototype.generatePseudo = function() {
     for (var i = 0; i < this.fileTypes.length; i++) {
         var pseudos = this.fileTypes[i].pseudos;
         for (var locale in pseudos) {
-            this.fileTypes[i].generatePseudo(locale, pseudos[locale]);
+            if (typeof(this.fileTypes[i].generatePseudo) === 'function') {
+                this.fileTypes[i].generatePseudo(locale, pseudos[locale]);
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.13.1",
+    "version": "2.13.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
Test if the function exists first before trying to call it.