### PR TITLE
Added support for different plurals in different target locales

### DIFF
--- a/db/pluralCategories.json
+++ b/db/pluralCategories.json
@@ -1,0 +1,903 @@
+{
+    "af": [
+        "one",
+        "other"
+    ],
+    "ak": [
+        "one",
+        "other"
+    ],
+    "am": [
+        "one",
+        "other"
+    ],
+    "an": [
+        "one",
+        "other"
+    ],
+    "ar": [
+        "zero",
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "ars": [
+        "zero",
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "as": [
+        "one",
+        "other"
+    ],
+    "asa": [
+        "one",
+        "other"
+    ],
+    "ast": [
+        "one",
+        "other"
+    ],
+    "az": [
+        "one",
+        "other"
+    ],
+    "be": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "bem": [
+        "one",
+        "other"
+    ],
+    "bez": [
+        "one",
+        "other"
+    ],
+    "bg": [
+        "one",
+        "other"
+    ],
+    "bho": [
+        "one",
+        "other"
+    ],
+    "bm": [
+        "other"
+    ],
+    "bn": [
+        "one",
+        "other"
+    ],
+    "bo": [
+        "other"
+    ],
+    "br": [
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "brx": [
+        "one",
+        "other"
+    ],
+    "bs": [
+        "one",
+        "few",
+        "other"
+    ],
+    "ca": [
+        "one",
+        "other"
+    ],
+    "ce": [
+        "one",
+        "other"
+    ],
+    "ceb": [
+        "one",
+        "other"
+    ],
+    "cgg": [
+        "one",
+        "other"
+    ],
+    "chr": [
+        "one",
+        "other"
+    ],
+    "ckb": [
+        "one",
+        "other"
+    ],
+    "cs": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "cy": [
+        "zero",
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "da": [
+        "one",
+        "other"
+    ],
+    "de": [
+        "one",
+        "other"
+    ],
+    "doi": [
+        "one",
+        "other"
+    ],
+    "dsb": [
+        "one",
+        "two",
+        "few",
+        "other"
+    ],
+    "dv": [
+        "one",
+        "other"
+    ],
+    "dz": [
+        "other"
+    ],
+    "ee": [
+        "one",
+        "other"
+    ],
+    "el": [
+        "one",
+        "other"
+    ],
+    "en": [
+        "one",
+        "other"
+    ],
+    "eo": [
+        "one",
+        "other"
+    ],
+    "es": [
+        "one",
+        "other"
+    ],
+    "et": [
+        "one",
+        "other"
+    ],
+    "eu": [
+        "one",
+        "other"
+    ],
+    "fa": [
+        "one",
+        "other"
+    ],
+    "ff": [
+        "one",
+        "other"
+    ],
+    "fi": [
+        "one",
+        "other"
+    ],
+    "fil": [
+        "one",
+        "other"
+    ],
+    "fo": [
+        "one",
+        "other"
+    ],
+    "fr": [
+        "one",
+        "many",
+        "other"
+    ],
+    "fur": [
+        "one",
+        "other"
+    ],
+    "fy": [
+        "one",
+        "other"
+    ],
+    "ga": [
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "gd": [
+        "one",
+        "two",
+        "few",
+        "other"
+    ],
+    "gl": [
+        "one",
+        "other"
+    ],
+    "gsw": [
+        "one",
+        "other"
+    ],
+    "gu": [
+        "one",
+        "other"
+    ],
+    "guw": [
+        "one",
+        "other"
+    ],
+    "gv": [
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "ha": [
+        "one",
+        "other"
+    ],
+    "haw": [
+        "one",
+        "other"
+    ],
+    "he": [
+        "one",
+        "two",
+        "many",
+        "other"
+    ],
+    "hi": [
+        "one",
+        "other"
+    ],
+    "hr": [
+        "one",
+        "few",
+        "other"
+    ],
+    "hsb": [
+        "one",
+        "two",
+        "few",
+        "other"
+    ],
+    "hu": [
+        "one",
+        "other"
+    ],
+    "hy": [
+        "one",
+        "other"
+    ],
+    "ia": [
+        "one",
+        "other"
+    ],
+    "id": [
+        "other"
+    ],
+    "ig": [
+        "other"
+    ],
+    "ii": [
+        "other"
+    ],
+    "in": [
+        "other"
+    ],
+    "io": [
+        "one",
+        "other"
+    ],
+    "is": [
+        "one",
+        "other"
+    ],
+    "it": [
+        "one",
+        "other"
+    ],
+    "iu": [
+        "one",
+        "two",
+        "other"
+    ],
+    "iw": [
+        "one",
+        "two",
+        "many",
+        "other"
+    ],
+    "ja": [
+        "other"
+    ],
+    "jbo": [
+        "other"
+    ],
+    "jgo": [
+        "one",
+        "other"
+    ],
+    "ji": [
+        "one",
+        "other"
+    ],
+    "jmc": [
+        "one",
+        "other"
+    ],
+    "jv": [
+        "other"
+    ],
+    "jw": [
+        "other"
+    ],
+    "ka": [
+        "one",
+        "other"
+    ],
+    "kab": [
+        "one",
+        "other"
+    ],
+    "kaj": [
+        "one",
+        "other"
+    ],
+    "kcg": [
+        "one",
+        "other"
+    ],
+    "kde": [
+        "other"
+    ],
+    "kea": [
+        "other"
+    ],
+    "kk": [
+        "one",
+        "other"
+    ],
+    "kkj": [
+        "one",
+        "other"
+    ],
+    "kl": [
+        "one",
+        "other"
+    ],
+    "km": [
+        "other"
+    ],
+    "kn": [
+        "one",
+        "other"
+    ],
+    "ko": [
+        "other"
+    ],
+    "ks": [
+        "one",
+        "other"
+    ],
+    "ksb": [
+        "one",
+        "other"
+    ],
+    "ksh": [
+        "zero",
+        "one",
+        "other"
+    ],
+    "ku": [
+        "one",
+        "other"
+    ],
+    "kw": [
+        "zero",
+        "one",
+        "two",
+        "few",
+        "many",
+        "other"
+    ],
+    "ky": [
+        "one",
+        "other"
+    ],
+    "lag": [
+        "zero",
+        "one",
+        "other"
+    ],
+    "lb": [
+        "one",
+        "other"
+    ],
+    "lg": [
+        "one",
+        "other"
+    ],
+    "lij": [
+        "one",
+        "other"
+    ],
+    "lkt": [
+        "other"
+    ],
+    "ln": [
+        "one",
+        "other"
+    ],
+    "lo": [
+        "other"
+    ],
+    "lt": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "lv": [
+        "zero",
+        "one",
+        "other"
+    ],
+    "mas": [
+        "one",
+        "other"
+    ],
+    "mg": [
+        "one",
+        "other"
+    ],
+    "mgo": [
+        "one",
+        "other"
+    ],
+    "mk": [
+        "one",
+        "other"
+    ],
+    "ml": [
+        "one",
+        "other"
+    ],
+    "mn": [
+        "one",
+        "other"
+    ],
+    "mo": [
+        "one",
+        "few",
+        "other"
+    ],
+    "mr": [
+        "one",
+        "other"
+    ],
+    "ms": [
+        "other"
+    ],
+    "mt": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "my": [
+        "other"
+    ],
+    "nah": [
+        "one",
+        "other"
+    ],
+    "naq": [
+        "one",
+        "two",
+        "other"
+    ],
+    "nb": [
+        "one",
+        "other"
+    ],
+    "nd": [
+        "one",
+        "other"
+    ],
+    "ne": [
+        "one",
+        "other"
+    ],
+    "nl": [
+        "one",
+        "other"
+    ],
+    "nn": [
+        "one",
+        "other"
+    ],
+    "nnh": [
+        "one",
+        "other"
+    ],
+    "no": [
+        "one",
+        "other"
+    ],
+    "nqo": [
+        "other"
+    ],
+    "nr": [
+        "one",
+        "other"
+    ],
+    "nso": [
+        "one",
+        "other"
+    ],
+    "ny": [
+        "one",
+        "other"
+    ],
+    "nyn": [
+        "one",
+        "other"
+    ],
+    "om": [
+        "one",
+        "other"
+    ],
+    "or": [
+        "one",
+        "other"
+    ],
+    "os": [
+        "one",
+        "other"
+    ],
+    "osa": [
+        "other"
+    ],
+    "pa": [
+        "one",
+        "other"
+    ],
+    "pap": [
+        "one",
+        "other"
+    ],
+    "pcm": [
+        "one",
+        "other"
+    ],
+    "pl": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "prg": [
+        "zero",
+        "one",
+        "other"
+    ],
+    "ps": [
+        "one",
+        "other"
+    ],
+    "pt": [
+        "one",
+        "other"
+    ],
+    "pt-PT": [
+        "one",
+        "other"
+    ],
+    "rm": [
+        "one",
+        "other"
+    ],
+    "ro": [
+        "one",
+        "few",
+        "other"
+    ],
+    "rof": [
+        "one",
+        "other"
+    ],
+    "root": [
+        "other"
+    ],
+    "ru": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "rwk": [
+        "one",
+        "other"
+    ],
+    "sah": [
+        "other"
+    ],
+    "saq": [
+        "one",
+        "other"
+    ],
+    "sat": [
+        "one",
+        "two",
+        "other"
+    ],
+    "sc": [
+        "one",
+        "other"
+    ],
+    "scn": [
+        "one",
+        "other"
+    ],
+    "sd": [
+        "one",
+        "other"
+    ],
+    "sdh": [
+        "one",
+        "other"
+    ],
+    "se": [
+        "one",
+        "two",
+        "other"
+    ],
+    "seh": [
+        "one",
+        "other"
+    ],
+    "ses": [
+        "other"
+    ],
+    "sg": [
+        "other"
+    ],
+    "sh": [
+        "one",
+        "few",
+        "other"
+    ],
+    "shi": [
+        "one",
+        "few",
+        "other"
+    ],
+    "si": [
+        "one",
+        "other"
+    ],
+    "sk": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "sl": [
+        "one",
+        "two",
+        "few",
+        "other"
+    ],
+    "sma": [
+        "one",
+        "two",
+        "other"
+    ],
+    "smi": [
+        "one",
+        "two",
+        "other"
+    ],
+    "smj": [
+        "one",
+        "two",
+        "other"
+    ],
+    "smn": [
+        "one",
+        "two",
+        "other"
+    ],
+    "sms": [
+        "one",
+        "two",
+        "other"
+    ],
+    "sn": [
+        "one",
+        "other"
+    ],
+    "so": [
+        "one",
+        "other"
+    ],
+    "sq": [
+        "one",
+        "other"
+    ],
+    "sr": [
+        "one",
+        "few",
+        "other"
+    ],
+    "ss": [
+        "one",
+        "other"
+    ],
+    "ssy": [
+        "one",
+        "other"
+    ],
+    "st": [
+        "one",
+        "other"
+    ],
+    "su": [
+        "other"
+    ],
+    "sv": [
+        "one",
+        "other"
+    ],
+    "sw": [
+        "one",
+        "other"
+    ],
+    "syr": [
+        "one",
+        "other"
+    ],
+    "ta": [
+        "one",
+        "other"
+    ],
+    "te": [
+        "one",
+        "other"
+    ],
+    "teo": [
+        "one",
+        "other"
+    ],
+    "th": [
+        "other"
+    ],
+    "ti": [
+        "one",
+        "other"
+    ],
+    "tig": [
+        "one",
+        "other"
+    ],
+    "tk": [
+        "one",
+        "other"
+    ],
+    "tl": [
+        "one",
+        "other"
+    ],
+    "tn": [
+        "one",
+        "other"
+    ],
+    "to": [
+        "other"
+    ],
+    "tr": [
+        "one",
+        "other"
+    ],
+    "ts": [
+        "one",
+        "other"
+    ],
+    "tzm": [
+        "one",
+        "other"
+    ],
+    "ug": [
+        "one",
+        "other"
+    ],
+    "uk": [
+        "one",
+        "few",
+        "many",
+        "other"
+    ],
+    "ur": [
+        "one",
+        "other"
+    ],
+    "uz": [
+        "one",
+        "other"
+    ],
+    "ve": [
+        "one",
+        "other"
+    ],
+    "vi": [
+        "other"
+    ],
+    "vo": [
+        "one",
+        "other"
+    ],
+    "vun": [
+        "one",
+        "other"
+    ],
+    "wa": [
+        "one",
+        "other"
+    ],
+    "wae": [
+        "one",
+        "other"
+    ],
+    "wo": [
+        "other"
+    ],
+    "xh": [
+        "one",
+        "other"
+    ],
+    "xog": [
+        "one",
+        "other"
+    ],
+    "yi": [
+        "one",
+        "other"
+    ],
+    "yo": [
+        "other"
+    ],
+    "yue": [
+        "other"
+    ],
+    "zh": [
+        "other"
+    ],
+    "zu": [
+        "one",
+        "other"
+    ]
+}

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,7 +3,14 @@ Release Notes for Version 2
 
 Build 024
 -------
-Published as version 2.13.2
+Published as version 2.14.0
+
+New Features:
+* Changed the new strings xliff files to contain the correct plural categories
+  for the target language. If the target locale has more or less strings than
+  the source locale, that will come out in that xliff file.
+    * This way, translators just need to translate each string and
+      not worry about adding/subtracting categories for the language
 
 Bug Fixes:
 * Fixed some bugs in pseudo locale translation when called from a plugin

--- a/generate/genPluralCategories.js
+++ b/generate/genPluralCategories.js
@@ -1,0 +1,42 @@
+/*
+ * genPluralCategories.js - generate the list of plural categories
+ * per locale
+ *
+ * Copyright © 2021, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+console.log("Generating pluralCategories.json ...");
+var fs = require("fs");
+
+var plurals = require("cldr-core/supplemental/plurals.json").supplemental["plurals-type-cardinal"];
+
+var categories = {};
+
+var languages = Object.keys(plurals);
+languages.sort();
+
+for (var i = 0; i < languages.length; i++ ) {
+    var language = languages[i];
+    var rules = Object.keys(plurals[language]);
+    categories[language] = rules.map(function(rule) {
+        // pluralRule-count-X -> X
+        return rule.substring(17);
+    });
+}
+
+fs.writeFileSync("./db/pluralCategories.json", JSON.stringify(categories, undefined, 4), "utf-8");
+
+console.log("Done.");

--- a/lib/AndroidResourceFile.js
+++ b/lib/AndroidResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * AndroidResourceFile.js - represents an Android strings.xml resource file
  *
- * Copyright © 2016-2017, 2019-2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2021 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,7 +276,7 @@ AndroidResourceFile.prototype.extract = function() {
         var p = path.join(this.project.root, this.pathName);
         logger.trace("Attempting to read and parse file " + p);
         try {
-            var xml = fs.readFileSync(this.pathName, "utf8");
+            var xml = fs.readFileSync(p, "utf8");
 
             if (xml) {
                 this.parse(xml);

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -32,6 +32,7 @@ var PseudoFactory = require("./PseudoFactory.js");
 var GenerateMode = require("./GenerateMode.js");
 var Xliff = require("./Xliff.js");
 var utils = require("./utils.js");
+var pluralCategories = require("../db/pluralCategories.json");
 var log4js = require("log4js");
 
 var logger = log4js.getLogger("loctool.lib.Project");
@@ -686,6 +687,17 @@ Project.prototype.close = function(cb) {
                         });
 
                         resources.forEach(function(res) {
+                            if (res.getType() === "plural") {
+                                // adjust the plural categories for the target language
+                                var l = new Locale(locale);
+                                var categories = pluralCategories[l.getLanguage()];
+                                var sourcePlurals = res.getSourcePlurals();
+                                var targetPlurals = {};
+                                categories.forEach(function(category) {
+                                    targetPlurals[category] = (category === "one") ? sourcePlurals.one : sourcePlurals.other;
+                                });
+                                res.setTargetPlurals(targetPlurals);
+                            }
                             newXliff.addResource(res);
                         });
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
         "node": ">=6.0.0"
     },
     "scripts": {
-        "test": "cd test; LANG=en-US node testSuite.js",
-        "clean": "ant clean"
+        "clean": "ant clean",
+        "dist": "npm run generate ; npm pack",
+        "generate": "node generate/genPluralCategories.js",
+        "test": "cd test; LANG=en-US node testSuite.js"
     },
     "dependencies": {
         "@babel/core": "^7.10.5",
@@ -93,6 +95,7 @@
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
+        "cldr-core": "^39.0.0",
         "ilib-loctool-mock": "file:test/ilib-loctool-mock/ilib-loctool-mock-1.0.0.tgz",
         "ilib-loctool-mock-resource": "file:test/ilib-loctool-mock-resource/ilib-loctool-mock-resource-1.0.0.tgz",
         "nodeunit": "^0.11.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.13.2",
+    "version": "2.14.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testAndroidResourceFile.js
+++ b/test/testAndroidResourceFile.js
@@ -351,7 +351,7 @@ module.exports.androidresourcefile = {
         var arf = new AndroidResourceFile({
             project: p,
             type: arft,
-            pathName: "./testfiles/java/res/values/strings.xml"
+            pathName: "./java/res/values/strings.xml"
         });
         test.ok(arf);
 
@@ -379,7 +379,7 @@ module.exports.androidresourcefile = {
         var arf = new AndroidResourceFile({
             project: p,
             type: arft,
-            pathName: "./testfiles/java/res/values/plurals.xml"
+            pathName: "./java/res/values/plurals.xml"
         });
         test.ok(arf);
 
@@ -409,7 +409,7 @@ module.exports.androidresourcefile = {
         var arf = new AndroidResourceFile({
             project: p,
             type: arft,
-            pathName: "./testfiles/java/res/values/arrays.xml"
+            pathName: "./java/res/values/arrays.xml"
         });
         test.ok(arf);
 

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -234,6 +234,118 @@ module.exports.project = {
         test.done();
     },
 
+    testProjectGeneratesCorrectPluralCategoriesInNewStringsXliffs20: function(test){
+        test.expect(9);
+        // set up first
+        rmrf("./testfiles/project2/loctest-new-es-US.xliff");
+        rmrf("./testfiles/project2/loctest-new-ja-JP.xliff");
+        rmrf("./testfiles/project2/loctest-new-ru-RU.xliff");
+
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-es-US.xliff"));
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-ja-JP.xliff"));
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-ru-RU.xliff"));
+
+        // adds Japanese and Russian to the list of locales to generate
+        var project = ProjectFactory('./testfiles/project2', {
+            xliffVersion: 2
+        });
+        project.addPath("res/values/strings.xml");
+        project.init(function() {
+            project.extract(function() {
+                project.generatePseudo();
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            var filename = "./testfiles/project2/loctest-new-es-US.xliff";
+                            test.ok(fs.existsSync(filename));
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                                '  <file original="res/values/strings.xml" l:project="loctest">\n' +
+                                '    <group id="group_1" name="x-android-resource">\n' +
+                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friend commented</source>\n' +
+                                '          <target state="new">%d friend commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friends commented</source>\n' +
+                                '          <target state="new">%d friends commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '    </group>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            diff(actual, expected);
+                            test.equal(actual, expected);
+
+                            filename = "./testfiles/project2/loctest-new-ja-JP.xliff";
+                            test.ok(fs.existsSync(filename));
+                            actual = fs.readFileSync(filename, "utf8");
+                            expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="2.0" srcLang="en-US" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">\n' +
+                                '  <file original="res/values/strings.xml" l:project="loctest">\n' +
+                                '    <group id="group_1" name="x-android-resource">\n' +
+                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friends commented</source>\n' +
+                                '          <target state="new">%d friends commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '    </group>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            diff(actual, expected);
+                            test.equal(actual, expected);
+
+                            filename = "./testfiles/project2/loctest-new-ru-RU.xliff";
+                            test.ok(fs.existsSync(filename));
+                            actual = fs.readFileSync(filename, "utf8");
+                            expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="2.0" srcLang="en-US" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">\n' +
+                                '  <file original="res/values/strings.xml" l:project="loctest">\n' +
+                                '    <group id="group_1" name="x-android-resource">\n' +
+                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friend commented</source>\n' +
+                                '          <target state="new">%d friend commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friends commented</source>\n' +
+                                '          <target state="new">%d friends commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="3" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friends commented</source>\n' +
+                                '          <target state="new">%d friends commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <segment>\n' +
+                                '          <source>%d friends commented</source>\n' +
+                                '          <target state="new">%d friends commented</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '    </group>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            test.equal(actual, expected);
+                        });
+                    });
+                });
+            });
+        });
+        test.done();
+    },
+
     testProjectIsResourcePathYes: function(test){
         test.expect(1);
 

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -1,7 +1,7 @@
 /*
  * testProject.js - test Project class
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,19 @@ if (!Project) {
 function rmrf(path) {
     if (fs.existsSync(path)) {
         fs.unlinkSync(path);
+    }
+}
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
     }
 }
 
@@ -125,6 +138,102 @@ module.exports.project = {
         test.done();
     },
     
+    testProjectGeneratesCorrectPluralCategoriesInNewStringsXliffs: function(test){
+        test.expect(9);
+        // set up first
+        rmrf("./testfiles/project2/loctest-new-es-US.xliff");
+        rmrf("./testfiles/project2/loctest-new-ja-JP.xliff");
+        rmrf("./testfiles/project2/loctest-new-ru-RU.xliff");
+
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-es-US.xliff"));
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-ja-JP.xliff"));
+        test.ok(!fs.existsSync("./testfiles/project2/loctest-new-ru-RU.xliff"));
+
+        // adds Japanese and Russian to the list of locales to generate
+        var project = ProjectFactory('./testfiles/project2', {});
+        project.addPath("res/values/strings.xml");
+        project.init(function() {
+            project.extract(function() {
+                project.generatePseudo();
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            var filename = "./testfiles/project2/loctest-new-es-US.xliff";
+                            test.ok(fs.existsSync(filename));
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="res/values/strings.xml" source-language="en-US" target-language="es-US" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                                '        <source>%d friend commented</source>\n' +
+                                '        <target state="new">%d friend commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '        <source>%d friends commented</source>\n' +
+                                '        <target state="new">%d friends commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            diff(actual, expected);
+                            test.equal(actual, expected);
+
+                            filename = "./testfiles/project2/loctest-new-ja-JP.xliff";
+                            test.ok(fs.existsSync(filename));
+                            actual = fs.readFileSync(filename, "utf8");
+                            expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="res/values/strings.xml" source-language="en-US" target-language="ja-JP" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '        <source>%d friends commented</source>\n' +
+                                '        <target state="new">%d friends commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            diff(actual, expected);
+                            test.equal(actual, expected);
+
+                            filename = "./testfiles/project2/loctest-new-ru-RU.xliff";
+                            test.ok(fs.existsSync(filename));
+                            actual = fs.readFileSync(filename, "utf8");
+                            expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="res/values/strings.xml" source-language="en-US" target-language="ru-RU" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                                '        <source>%d friend commented</source>\n' +
+                                '        <target state="new">%d friend commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="few">\n' +
+                                '        <source>%d friends commented</source>\n' +
+                                '        <target state="new">%d friends commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
+                                '        <source>%d friends commented</source>\n' +
+                                '        <target state="new">%d friends commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '        <source>%d friends commented</source>\n' +
+                                '        <target state="new">%d friends commented</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            test.equal(actual, expected);
+                        });
+                    });
+                });
+            });
+        });
+        test.done();
+    },
+
     testProjectIsResourcePathYes: function(test){
         test.expect(1);
 

--- a/test/testfiles/project2/project.json
+++ b/test/testfiles/project2/project.json
@@ -1,0 +1,16 @@
+{
+    "name": "Loctool Test",
+    "id": "loctest",
+    "projectType": "android",
+    "pseudoLocale": "ps-DO",
+    "resourceDirs": {
+        "java": "."
+    },
+    "excludes": [
+    ],
+    "includes": [
+    ],
+    "settings": {
+        "locales": ["en-GB", "es-US", "ja-JP", "ru-RU"]
+    }
+}

--- a/test/testfiles/project2/res/values/strings.xml
+++ b/test/testfiles/project2/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string name="app_id" i18n="Do not translate">151779581544891</string>
+  <plurals name="foobar">
+    <item quantity="one">
+     %d friend commented
+    </item>
+    <item quantity="other">
+      %d friends commented
+    </item>
+  </plurals>
+</resources>


### PR DESCRIPTION
- retrieve lists of plurals per language from cldr
- fixed extraction bug in Android resource file
- before adding resources to a new strings file, make sure each
  plural contains the right target plural strings for the
  target locale