### PR TITLE
Fix various bugs

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,8 @@ Bug Fixes:
 * Fixed a bug where it was not loading plugins correctly on Windows.
   Switched from using process.env.PWD which does not work on Windows to
   process.cwd() which should work everywhere.
+* Fixed exception when you put an unknown substitution parameter into
+  an output path template. Now gives a warning instead.
 
 Build 024
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -13,6 +13,9 @@ Bug Fixes:
   process.cwd() which should work everywhere.
 * Fixed exception when you put an unknown substitution parameter into
   an output path template. Now gives a warning instead.
+* Fixed a bug where the [basename] in a output file name template was
+  not calculated properly if the extension was not ".json". Now you can
+  use any extension.
 
 Build 024
 -------

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,17 @@
 Release Notes for Version 2
 ============================
 
+Build 025
+-------
+Published as version 2.14.1
+
+New Features:
+
+Bug Fixes:
+* Fixed a bug where it was not loading plugins correctly on Windows.
+  Switched from using process.env.PWD which does not work on Windows to
+  process.cwd() which should work everywhere.
+
 Build 024
 -------
 Published as version 2.14.0

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -116,8 +116,8 @@ CustomProject.prototype._attemptLoad = function (name, API) {
 CustomProject.prototype.loadPlugin = function(plugin, API) {
     var ret = this._attemptLoad(plugin, API) ||
         this._attemptLoad("ilib-loctool-" + plugin, API) ||
-        this._attemptLoad(path.join(process.env.PWD, "node_modules", plugin), API) ||
-        this._attemptLoad(path.join(process.env.PWD, "node_modules", "ilib-loctool-" + plugin), API) ||
+        this._attemptLoad(path.join(process.cwd(), "node_modules", plugin), API) ||
+        this._attemptLoad(path.join(process.cwd(), "node_modules", "ilib-loctool-" + plugin), API) ||
         this._attemptLoad(path.join("..", "plugins", plugin + ".js"), API) ||
         this._attemptLoad(path.join("..", "plugins", "ilib-loctool-" + plugin + ".js"), API);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1924,6 +1924,7 @@ module.exports.formatPath = function (template, parameters) {
     var locale = parameters.locale || "en";
     var output = "";
     var l = new Locale(locale);
+    var base;
 
     for (var i = 0; i < template.length; i++) {
         if ( template[i] !== '[' ) {
@@ -1942,11 +1943,12 @@ module.exports.formatPath = function (template, parameters) {
                     output += path.basename(pathname);
                     break;
                 case 'extension':
-                    var base = path.basename(pathname);
+                    base = path.basename(pathname);
                     output += base.substring(base.lastIndexOf('.')+1);
                     break;
                 case 'basename':
-                    output += path.basename(pathname, ".json");
+                    base = path.basename(pathname);
+                    output += base.substring(0, base.lastIndexOf('.'));
                     break;
                 default:
                 case 'locale':
@@ -2040,6 +2042,7 @@ module.exports.getLocaleFromPath = function(template, pathname) {
     var regex = "";
     var matchGroups = {};
     var totalBrackets = 0;
+    var base;
 
     if (!template) {
         template = defaultMappings["**/*.json"].template;
@@ -2059,11 +2062,12 @@ module.exports.getLocaleFromPath = function(template, pathname) {
                     regex += path.basename(pathname);
                     break;
                 case 'extension':
-                    var base = path.basename(pathname);
+                    base = path.basename(pathname);
                     regex += base.substring(base.lastIndexOf('.')+1);
                     break;
                 case 'basename':
-                    regex += path.basename(pathname, ".json");
+                    base = path.basename(pathname);
+                    regex += base.substring(0, base.lastIndexOf('.'));
                     break;
                 default:
                     if (!matchExprs[keyword]) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2066,6 +2066,10 @@ module.exports.getLocaleFromPath = function(template, pathname) {
                     regex += path.basename(pathname, ".json");
                     break;
                 default:
+                    if (!matchExprs[keyword]) {
+                        logger.warning("Warning: template contains unknown substitution parameter " + keyword);
+                        return "";
+                    }
                     regex += matchExprs[keyword].regex;
                     for (var prop in matchExprs[keyword].groups) {
                         matchGroups[prop] = totalBrackets + matchExprs[keyword].groups[prop];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -225,6 +225,17 @@ module.exports.utils = {
         test.done();
     },
 
+    testGetLocalizedPathBasenameAlternateExtension: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[localeDir]/tr-[basename].j', {
+            sourcepath: "x/y/strings.md",
+            locale: "de-DE"
+        }), "de/DE/tr-strings.j");
+
+        test.done();
+    },
+
     testGetLocalizedPathFilename: function(test) {
         test.expect(1);
 
@@ -314,6 +325,30 @@ module.exports.utils = {
         test.expect(1);
 
         test.equals(utils.getLocaleFromPath('[dir]/[basename].json', "x/y/strings.json"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasenameAlternateExtension: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[basename].md', "x/y/strings.md"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasenameWithLocale: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[locale]/[basename].json', "x/y/zh-Hans-CN/strings.json"), "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasenameWithLocaleAlternateExtension: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[locale]/[basename].md', "x/y/de-DE/strings.md"), "de-DE");
 
         test.done();
     },


### PR DESCRIPTION
* Fixed a bug where it was not loading plugins correctly on Windows.
  Switched from using process.env.PWD which does not work on Windows to
  process.cwd() which should work everywhere.
* Fixed exception when you put an unknown substitution parameter into
  an output path template. Now gives a warning instead.
* Fixed a bug where the [basename] in a output file name template was
  not calculated properly if the extension was not ".json". Now you can
  use any extension.
