### PR TITLE
Fixed a bug where the default excluded directory is not exclude

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,13 @@
 Release Notes for Version 2
 ============================
+Build 026
+-------
+Published as version 2.14.2
+
+New Features:
+
+Bug Fixes:
+* Fixed a bug where the default excluded directory is not exclude
 
 Build 025
 -------

--- a/loctool.js
+++ b/loctool.js
@@ -456,9 +456,10 @@ function walk(dir, project) {
             included = true;
 
             if (project) {
-                if (project.options.excludes) {
+                var excludes = project.options.excludes ? project.options.excludes.concat(project.settings.exclude) : project.settings.exclude;
+                if (excludes) {
                     logger.trace("There are excludes. Relpath is " + relPath);
-                    if (mm.isMatch(relPath, project.options.excludes)) {
+                    if (mm.isMatch(relPath, excludes)) {
                         included = false;
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.14.1",
+    "version": "2.14.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
* Fixed a bug where the default excluded directory is not exclude
  * i.e) `node_modules/` should be excluded even if it's not in the config file