### PR TITLE
Add --noxliffDups flag not to allow duplicated strings in xliff

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -5,9 +5,11 @@ Build 026
 Published as version 2.14.2
 
 New Features:
+* Added the --noxliffDups flag which is not allows duplicated strings in extracted xliff file
 
 Bug Fixes:
 * Fixed a bug where the default excluded directory is not exclude
+
 
 Build 025
 -------

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -695,7 +695,7 @@ Project.prototype.close = function(cb) {
             var extractedXliff = new Xliff({
                 sourceLocale: this.sourceLocale,
                 pathName: extractedPath,
-                allowDups: true,
+                allowDups: this.settings.allowDups,
                 version: this.settings.xliffVersion,
                 style: this.settings.xliffStyle
             });

--- a/loctool.js
+++ b/loctool.js
@@ -124,6 +124,8 @@ function usage() {
         "  Specify the dir where the generation output should go. (Default is resources/) \n" +
         "--xliffStyle\n" +
         "  Specify the Xliff format style. Style can be 'standard' or 'custom'. (Default is 'standard') \n" +
+        "--noxliffDups\n" +
+        "  Do not allow duplicated strings in extracted xliff file. (Default is 'true') \n" +
         "command\n" +
         "  a command to execute. This is one of:\n" +
         "    init  [project-name] - initialize the current directory as a loctool project\n" +
@@ -163,6 +165,7 @@ var settings = {
     xliffsDir: ".",
     xliffVersion: 1.2,
     xliffStyle: "standard",
+    allowDups: true,
     localizeOnly: false,
     projectType: "web",
     exclude: ["**/node_modules", "**/.git", "**/.svn"],
@@ -280,7 +283,10 @@ for (var i = 0; i < argv.length; i++) {
         if (candidate.indexOf(argv[i+1]) !== -1) {
             settings.xliffStyle = argv[++i];
         }
-    } else if (val === "--segmentation") {
+    } else if (val === "--noxliffDups") {
+        settings.allowDups = false;
+    }
+    else if (val === "--segmentation") {
         var candidate = ["paragraph", "sentence"];
         if (candidate.indexOf(argv[++i]) !== -1) {
             settings.segmentation = argv[i];


### PR DESCRIPTION
Added `-noxliffDups` flag which gives an option to set allowDups as false. Currently, it always set `true`  It generates many duplicate strings in xliff 2.0 which doesn't need it