### PR TITLE
Add --onlyTranslated flag for "convert" action

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,15 +1,25 @@
 Release Notes for Version 2
 ============================
+
+Build 027
+-------
+Published as version 2.15.0
+
+New Features:
+* Added the --onlyTranslated flag which causes the convert action
+  to only convert translated resources into the target file.
+  Source-only resources will be skipped. By default, all resources
+  are converted.
+
 Build 026
 -------
 Published as version 2.14.2
 
 New Features:
-* Added the --noxliffDups flag which is not allows duplicated strings in extracted xliff file
+* Added the --noxliffDups flag which does not allow duplicated strings in extracted xliff file
 
 Bug Fixes:
 * Fixed a bug where the default excluded directory is not exclude
-
 
 Build 025
 -------

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -74,6 +74,45 @@ function convert(settings) {
         }
 
         set.getAll().forEach(function(resource) {
+            var source, target;
+            
+            // try to make sure every target-only resource has a source string
+            switch (resource.getType()) {
+                case "string":
+                    source = resource.getSource();
+                    target = resource.getTarget();
+                    if (target && !source) {
+                        hash = resource.cleanHashKeyForTranslation(resource.getSourceLocale());
+                        var sourceResource = set.get(hash);
+                        if (sourceResource) {
+                            resource.setSource(sourceResource.getTarget() || sourceResource.getSource());
+                        }
+                    }
+                    break;
+                case "plural":
+                    source = resource.getSourceStrings();
+                    target = resource.getTargetStrings();
+                    if (target && !source) {
+                        hash = resource.cleanHashKeyForTranslation(resource.getSourceLocale());
+                        var sourceResource = set.get(hash);
+                        if (sourceResource) {
+                            resource.setSourceStrings(sourceResource.getTargetStrings() || sourceResource.getSourceStrings());
+                        }
+                    }
+                    break;
+                case "array":
+                    source = resource.getSourceArray();
+                    target = resource.getTargetArray();
+                    if (target && !source) {
+                        hash = resource.cleanHashKeyForTranslation(resource.getSourceLocale());
+                        var sourceResource = set.get(hash);
+                        if (sourceResource) {
+                            resource.setSourceArray(sourceResource.getTargetArray() || sourceResource.getSourceArray());
+                        }
+                    }
+                    break;
+            }
+
             resource.setProject(project);
             resource.setSourceLocale(settings.localeMap[resource.getSourceLocale()] || resource.getSourceLocale());
             resource.setTargetLocale(settings.localeMap[resource.getTargetLocale()] || resource.getTargetLocale());

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -75,7 +75,7 @@ function convert(settings) {
 
         set.getAll().forEach(function(resource) {
             var source, target;
-            
+
             // try to make sure every target-only resource has a source string
             switch (resource.getType()) {
                 case "string":

--- a/loctool.js
+++ b/loctool.js
@@ -81,6 +81,9 @@ function usage() {
         "  not to do pseudo-localization.\n" +
         "-o or --oldhaml\n" +
         "  Use the old ruby-based haml localizer instead of the new javascript one.\n" +
+        "--onlyTranslated\n" +
+        "  During the convert action, only convert fully translated resources to the target\n" +
+        "  file. Source-only resources will skipped. (Default: convert all resources.)\n" +
         "-p or --pull\n" +
         "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
         "--projectId\n" +
@@ -172,7 +175,8 @@ var settings = {
     segmentation: "paragraph",
     sourceLocale: "en-US",
     targetLocale: null,
-    localeMap: {}
+    localeMap: {},
+    onlyTranslated: false
 };
 
 var options = [];
@@ -295,6 +299,8 @@ for (var i = 0; i < argv.length; i++) {
         settings.targetLocale = argv[++i];
     } else if (val === "--localizeOnly") {
         settings.localizeOnly = true;
+    } else if (val === "--onlyTranslated") {
+        settings.onlyTranslated = true;
     } else if (val === "--exclude") {
         if (i+1 < argv.length && argv[i+1]) {
             var excludeList = argv[++i].split(",");
@@ -303,8 +309,7 @@ for (var i = 0; i < argv.length; i++) {
                 return temp.indexOf(item) === index;
             })
         }
-    }
-     else {
+    } else {
         options.push(val);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.14.2",
+    "version": "2.15.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
When the --onlyTranslated flag is given, the "convert" action only does conversions for resources that have both a source and a target string. Strings that are source-only or target-only are skipped.