### PR TITLE
Add ability of plugins to get the loctool logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,9 @@ json schemas.
 
 * `ilib-loctool-po` - extract strings from po files and produce translated po files
 
+* `ilib-loctool-xml` - extract strings from XML files and produce translated XML files. This
+specifies which strings to extract using a schema file. Different XML files can use different schemas.
+
 Configuring a Custom Project Type
 -----------------------------------------------
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,18 @@
 Release Notes for Version 2
 ============================
 
+Build 029
+-------
+Published as version 2.16.0
+
+New Features:
+* added the ability for the plugins to get their own logger instance from
+  the loctool so that the plugin output comes with the regular output
+  from the loctool itself. This way, plugins do not need a separate
+  logging system of their own.
+
+Bug Fixes:
+
 Build 028
 -------
 Published as version 2.15.1

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -1,7 +1,7 @@
 /*
  * CustomProject.js - a customizable project
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,16 @@ CustomProject.prototype.getAPI = function() {
         },
         getResourceFileType: function(type) {
             return this.resourceFileMap[type];
-        }.bind(this)
+        }.bind(this),
+        /**
+         * Return the loctool's log4js logger so that the plugin can put its output into
+         * the regular loctool's stream.
+         * @param {string} category the logger category to return
+         * @returns {Logger} a logger instance
+         */
+        getLogger: function(category) {
+            return log4js.getLogger(category);
+        }
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.15.1",
+    "version": "2.16.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
This way, they can add their logging out to the regular loctool log4js output instead of handling logging completely on their own.