### PR TITLE
Fix a bug with getting locale from path

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,17 @@ Release Notes for Version 2
 
 Build 029
 -------
+Published as version 2.16.1
+
+New Features:
+
+Bug Fixes:
+* Fixed a bug in the utility functions for detecting locales in file names.
+  If you had a mapping with a template of "[dir]/[basename]_[locale].[extension]",
+  then the locale was not detected properly.
+
+Build 029
+-------
 Published as version 2.16.0
 
 New Features:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1990,6 +1990,10 @@ var matchExprs = {
         regex: ".*?",
         brackets: 0,
     },
+    "basename": {
+        regex: ".*?",
+        brackets: 0,
+    },
     "locale": {
         regex: "([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?",
         brackets: 5,
@@ -2082,10 +2086,6 @@ module.exports.getLocaleFromPath = function(template, pathname) {
                 case 'extension':
                     base = path.basename(pathname);
                     regex += base.substring(base.lastIndexOf('.')+1);
-                    break;
-                case 'basename':
-                    base = path.basename(pathname);
-                    regex += base.substring(0, base.lastIndexOf('.'));
                     break;
                 default:
                     if (!matchExprs[keyword]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -392,7 +392,7 @@ module.exports.utils = {
         test.done();
     },
 
-    testGetLocaleFromPathBasenameWithLocale: function(test) {
+    testGetLocaleFromPathBasenameWithLocaleDir: function(test) {
         test.expect(1);
 
         test.equals(utils.getLocaleFromPath('[dir]/[locale]/[basename].json', "x/y/zh-Hans-CN/strings.json"), "zh-Hans-CN");
@@ -404,6 +404,22 @@ module.exports.utils = {
         test.expect(1);
 
         test.equals(utils.getLocaleFromPath('[dir]/[locale]/[basename].md', "x/y/de-DE/strings.md"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasenameAndLocaleTogether1: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[basename]_[locale].[extension]', "x/y/strings_de-DE.json"), "de-DE");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathBasenameAndLocaleTogether2: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/[basename]_[localeUnder].[extension]', "x/y/strings_de_DE.json"), "de-DE");
 
         test.done();
     },


### PR DESCRIPTION
If you have "[basename]_[locale]" in your template and you try to
get the locale from the path, it did not work because it would
capture everything in the basename and the locale came out
empty. Now it works properly of course.