### PR TITLE
Handle zero-length sources properly

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,8 @@ New Features:
 Bug Fixes:
 * upgraded dependencies
     * plural categories are now based on CLDR 40
+* fixed a bug where a resource with an zero-length source string caused the
+  xliff writer to throw exceptions
 
 Build 029
 -------

--- a/lib/ResourceString.js
+++ b/lib/ResourceString.js
@@ -42,7 +42,7 @@ var ResourceString = function(props) {
     Resource.prototype.constructor.call(this, props);
 
     if (props) {
-        this.source = props.source || props.text;
+        this.source = typeof(props.source) === 'string' ? props.source : props.text;
         this.target = props.target;
     }
 


### PR DESCRIPTION
- fixed a bug where a resource with an zero-length source string caused the xliff writer to throw exceptions. When the source string in props.source was zero-length, the line would set the resource's source to be undefined because props.text was undefined. (Props.text is a legacy property that should be removed at some point.) Instead, it should only try props.text if props.source is not a string.