### PR TITLE
Add comments for mojito to read

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 2
 ============================
 
+Build 031
+-------
+Published as version 2.17.0
+
+New Features:
+* Added xliff comments on translation units for [mojito](https://mojito.global) to
+  read so that it can recognize plural resources
 
 Build 030
 -------

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -474,6 +474,25 @@ function unescapeAttr(str) {
         replace(/&amp;/g, "&");
 }
 
+function generatePluralComment(res, sourcePlurals, form) {
+    var json = {};
+
+    if (res.comment) {
+        try {
+            // see if its json already. If so, we'll add to it
+            json = JSON.parse(res.comment);
+        } catch (e) {
+            // not json, so just return it as is
+            return res.comment;
+        }
+    }
+
+    json.pluralForm = form;
+    json.pluralFormOther = res.getKey();
+
+    return JSON.stringify(json);
+}
+
 /**
  * Convert a resource into one or more translation units.
  *
@@ -560,7 +579,6 @@ Xliff.prototype._convertResource = function(res) {
                 id: res.getId(),
                 translated: true,
                 context: res.context,
-                comment: res.comment,
                 resType: res.resType,
                 datatype: res.datatype,
                 flavor: res.getFlavor ? res.getFlavor() : undefined
@@ -574,6 +592,7 @@ Xliff.prototype._convertResource = function(res) {
                     var newtu = tu.clone();
                     newtu.source = sp[p];
                     newtu.quantity = p;
+                    newtu.comment = generatePluralComment(res, sp, p);
                     units.push(newtu);
                 }
             } else {
@@ -582,6 +601,7 @@ Xliff.prototype._convertResource = function(res) {
                     newtu.source = sp[p] || sp.other;
                     newtu.target = tp[p];
                     newtu.quantity = p;
+                    newtu.comment = generatePluralComment(res, sp, p);
                     units.push(newtu);
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.16.3",
+    "version": "2.17.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -169,14 +169,17 @@ module.exports.project = {
                                 '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
                                 '        <source>%d friend commented</source>\n' +
                                 '        <target state="new">%d friend commented</target>\n' +
+                                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '      <trans-unit id="3" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '    </body>\n' +
                                 '  </file>\n' +
@@ -195,6 +198,7 @@ module.exports.project = {
                                 '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '    </body>\n' +
                                 '  </file>\n' +
@@ -213,18 +217,22 @@ module.exports.project = {
                                 '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
                                 '        <source>%d friend commented</source>\n' +
                                 '        <target state="new">%d friend commented</target>\n' +
+                                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="few">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '      <trans-unit id="3" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
+                                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
                                 '    </body>\n' +
                                 '  </file>\n' +
@@ -269,18 +277,27 @@ module.exports.project = {
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
                                 '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friend commented</source>\n' +
                                 '          <target state="new">%d friend commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
                                 '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
                                 '      <unit id="3" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
@@ -301,6 +318,9 @@ module.exports.project = {
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
                                 '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
@@ -321,24 +341,36 @@ module.exports.project = {
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
                                 '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friend commented</source>\n' +
                                 '          <target state="new">%d friend commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
                                 '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
                                 '      <unit id="3" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
                                 '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '        <notes>\n' +
+                                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                                '        </notes>\n' +
                                 '        <segment>\n' +
                                 '          <source>%d friends commented</source>\n' +
                                 '          <target state="new">%d friends commented</target>\n' +
@@ -347,6 +379,7 @@ module.exports.project = {
                                 '    </group>\n' +
                                 '  </file>\n' +
                                 '</xliff>';
+                            diff(actual, expected);
                             test.equal(actual, expected);
                         });
                     });

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -667,12 +667,15 @@ module.exports.xliff = {
             '    <body>\n' +
             '      <trans-unit id="2" resname="huzzah" restype="plural" datatype="x-android-resource" extype="zero">\n' +
             '        <source>0</source>\n' +
+            '        <note>{"pluralForm":"zero","pluralFormOther":"huzzah"}</note>\n' +
             '      </trans-unit>\n' +
             '      <trans-unit id="3" resname="huzzah" restype="plural" datatype="x-android-resource" extype="one">\n' +
             '        <source>1</source>\n' +
+            '        <note>{"pluralForm":"one","pluralFormOther":"huzzah"}</note>\n' +
             '      </trans-unit>\n' +
             '      <trans-unit id="4" resname="huzzah" restype="plural" datatype="x-android-resource" extype="few">\n' +
             '        <source>few</source>\n' +
+            '        <note>{"pluralForm":"few","pluralFormOther":"huzzah"}</note>\n' +
             '      </trans-unit>\n' +
             '    </body>\n' +
             '  </file>\n' +
@@ -1024,10 +1027,12 @@ module.exports.xliff = {
                 '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
                 '        <source>There is 1 object.</source>\n' +
                 '        <target state="new">Da gibts 1 Objekt.</target>\n' +
+                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                 '      </trans-unit>\n' +
                 '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
                 '        <source>There are {n} objects.</source>\n' +
                 '        <target state="new">Da gibts {n} Objekten.</target>\n' +
+                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                 '      </trans-unit>\n' +
                 '    </body>\n' +
                 '  </file>\n' +
@@ -1077,14 +1082,17 @@ module.exports.xliff = {
                 '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
                 '        <source>There is 1 object.</source>\n' +
                 '        <target state="new">Имеется {n} объект.</target>\n' +
+                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                 '      </trans-unit>\n' +
                 '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="few">\n' +
                 '        <source>There are {n} objects.</source>\n' +
                 '        <target state="new">Есть {n} объекта.</target>\n' +
+                '        <note>{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
                 '      </trans-unit>\n' +
                 '      <trans-unit id="3" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
                 '        <source>There are {n} objects.</source>\n' +
                 '        <target state="new">Всего {n} объектов.</target>\n' +
+                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                 '      </trans-unit>\n' +
                 '    </body>\n' +
                 '  </file>\n' +

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -876,16 +876,25 @@ module.exports.xliff20 = {
             '  <file original="foo/bar/j.java" l:project="webapp">\n' +
             '    <group id="group_2" name="x-android-resource">\n' +
             '      <unit id="2" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="zero">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"zero","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
             '        <segment>\n' +
             '          <source>0</source>\n' +
             '        </segment>\n' +
             '      </unit>\n' +
             '      <unit id="3" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
             '        <segment>\n' +
             '          <source>1</source>\n' +
             '        </segment>\n' +
             '      </unit>\n' +
             '      <unit id="4" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
             '        <segment>\n' +
             '          <source>few</source>\n' +
             '        </segment>\n' +
@@ -1247,12 +1256,18 @@ module.exports.xliff20 = {
                 '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
                 '    <group id="group_1" name="ruby">\n' +
                 '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
                 '        <segment>\n' +
                 '          <source>There is 1 object.</source>\n' +
                 '          <target state="new">Da gibts 1 Objekt.</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
                 '        <segment>\n' +
                 '          <source>There are {n} objects.</source>\n' +
                 '          <target state="new">Da gibts {n} Objekten.</target>\n' +
@@ -1304,18 +1319,27 @@ module.exports.xliff20 = {
                 '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
                 '    <group id="group_1" name="ruby">\n' +
                 '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
                 '        <segment>\n' +
                 '          <source>There is 1 object.</source>\n' +
                 '          <target state="new">Имеется {n} объект.</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="few">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
                 '        <segment>\n' +
                 '          <source>There are {n} objects.</source>\n' +
                 '          <target state="new">Есть {n} объекта.</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '      <unit id="3" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
                 '        <segment>\n' +
                 '          <source>There are {n} objects.</source>\n' +
                 '          <target state="new">Всего {n} объектов.</target>\n' +


### PR DESCRIPTION
- comments on each plural translation unit allow mojito to tell that the units are related plural strings
- only add comments where the comments are already in json format or where there were no comments to begin with