### PR TITLE
Added the isBaseLocale utility function 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,7 @@ New Features:
   to use. Translation units in the later xliff directories override those found in
   the earlier ones. Xliff dirs found on the command-line override ones found in
   the project.json file.
+* Added the utility function to check whether the current locale matches the language default locale.
 
 Bug Fixes:
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2070,6 +2070,20 @@ var matchExprs = {
     return (localeMinimal === langLocaleMinimal);
  }
 
+ /**
+ *
+ * @param {String} locale
+ * @return {String} return language default locale.
+ */
+  module.exports.getBaseLocale = function(locale) {
+    if (!locale) return;
+
+    var lo = new Locale(locale);
+    var langLocaleMinimal = new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
+
+    return langLocaleMinimal;
+ }
+
 /**
  * Return a locale encoded in the path using template to parse that path.
  * See {#formatPath} for the full description of the syntax of the template.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 /*
  * utils.js - various utilities
  *
- * Copyright © 2016-2020, HealthTap, Inc.
+ * Copyright © 2016-2020, 2022 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,10 @@
 var fs = require("fs");
 var path = require("path");
 var ilib = require("ilib");
-var Locale = require("ilib/lib/Locale");
+var Locale = require("ilib/lib/Locale.js");
 var isAlnum = require("ilib/lib/isAlnum.js");
 var isIdeo = require("ilib/lib/isIdeo.js");
+var LocaleMatcher = require("ilib/lib/LocaleMatcher.js");
 
 //load the data for these
 isAlnum._init();
@@ -2053,6 +2054,21 @@ var matchExprs = {
         }
     }
 };
+
+/**
+ *
+ * @param {String} locale
+ * @return {boolean} true if the locale is matched language default locale.
+ */
+ module.exports.isBaseLocale = function(locale) {
+    if (!locale) return false;
+
+    var lo = new Locale(locale);
+    var localeMinimal = new LocaleMatcher({locale: lo}).getLikelyLocaleMinimal().getSpec();
+    var langLocaleMinimal = new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
+
+    return (localeMinimal === langLocaleMinimal);
+ }
 
 /**
  * Return a locale encoded in the path using template to parse that path.

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,7 +1,7 @@
 /*
  * testUtils.js - test the utils object.
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2022 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -579,5 +579,13 @@ module.exports.utils = {
         test.ok(!utils.cleanString({'obj': 'foo'}));
 
         test.done();
-    }
+    },
+    testisBaseLocale: function(test) {
+        test.expect(3);
+        test.equals(utils.isBaseLocale("ko-KR"), true);
+        test.equals(utils.isBaseLocale("fr-CA"), false);
+        test.equals(utils.isBaseLocale(), false);
+
+        test.done();
+    },
 }

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -588,4 +588,12 @@ module.exports.utils = {
 
         test.done();
     },
+    testgetBaseLocale: function(test) {
+        test.expect(3);
+        test.equals(utils.getBaseLocale("ko-KR"), "ko-KR");
+        test.equals(utils.getBaseLocale("fr-CA"), "fr-FR");
+        test.equals(utils.getBaseLocale(), undefined);
+
+        test.done();
+    },
 }


### PR DESCRIPTION
Added the utility function `isBaseLocale` to check whether the current locale match the language default locale.

It is needed for webos plugins when generating resource directory.
I think it's better to share it by providing it to the util rather than having each one in the plugin itseslf.