### PR TITLE
Update not to trim when making key

### DIFF
--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1652080578623</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -20,15 +20,4 @@
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1652080578623</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 032
+-------
+Published as version 2.17.1
+
+New Features:
+
+Bug Fixes:
+* updated not to trim when making key
+
 Build 031
 -------
 Published as version 2.17.0

--- a/lib/ResourceString.js
+++ b/lib/ResourceString.js
@@ -226,7 +226,7 @@ ResourceString.hashKey = function(project, locale, reskey, datatype, flavor) {
  * @return {String} a hash key
  */
 ResourceString.cleanHashKey = function(project, locale, reskey, datatype, flavor) {
-    var cleaned = reskey && reskey.replace(/\s+/g, " ").trim() || "";
+    var cleaned = reskey && reskey.replace(/\s+/g, " ") || "";
     var key = ["rs", project, locale, cleaned, datatype, flavor].join("_");
     logger.trace("CleanHashkey is " + key);
     return key;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.17.0",
+    "version": "2.17.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -3666,5 +3666,32 @@ module.exports.xliff20 = {
         test.equal(reslist[6].getId(), "settings_22");
 
         test.done();
+    },
+    testXliff20DeserializeKeyCompare: function(test) {
+        test.expect(12);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        var fs = require("fs");
+
+        var str = fs.readFileSync("testfiles/test6.xliff", "utf-8");
+
+        x.deserialize(str);
+
+        var reslist = x.getResources();
+        test.ok(reslist);
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "Do you want to register a new scheduling?﻿");
+        test.equal(reslist[0].getSourceLocale(), "en-KR");
+        test.equal(reslist[0].getTarget(), "新しい予約を設定しますか？");
+        test.equal(reslist[0].getTargetLocale(), "ja-JP");
+        test.equal(reslist[0].getProject(), "app1");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].datatype, "javascript");
+        test.equal(reslist[0].getKey(), "Do you want to register a new scheduling?﻿");
+        test.notEqual(reslist[0].getKey(), "Do you want to register a new scheduling?");
+        test.done();
     }
 };

--- a/test/testfiles/test6.xliff
+++ b/test/testfiles/test6.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Do you want to register a new scheduling?﻿</source>
+          <target>新しい予約を設定しますか？</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>


### PR DESCRIPTION
Updated code not to do a `trim()` when making key.
there is a case including U+FEFF('ZERO WIDTH NO-BREAK SPACE') at the end of the string
and it should be treated different string from the string without it.

The following two sentences are not the same.
please check the string by coping here:https://www.branah.com/unicode-converter

- "Do you want to register a new scheduling?﻿"  (--> includes u+feff)
-  "Do you want to register a new scheduling?"
