### PR TITLE
Added the setBaseLocale() utility function to override language default locale.

### DIFF
--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1663744601182</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -20,15 +20,4 @@
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1663744601182</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 032
+-------
+Published as version 2.18.0
+
+New Features:
+* Added the utility function to override language default locale.
+
+Bug Fixes:
+
 Build 031
 -------
 Published as version 2.17.0

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2077,7 +2077,7 @@ var matchExprs = {
  * @param {String} language
  */
    module.exports.setBaseLocale = function(locale, lang) {
-    if (!locale) return;
+    if (!locale || !lang) return;
     overrideBaseLocale[lang] = locale;
  }
 
@@ -2099,6 +2099,9 @@ var matchExprs = {
     return langLocaleMinimal;
  }
 
+  /**
+ * Reset the list of overrideBaseLocale
+ */
  module.exports.clearOverrideBaseLocale = function() {
     overrideBaseLocale = {};
  }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2062,12 +2062,23 @@ var matchExprs = {
  */
  module.exports.isBaseLocale = function(locale) {
     if (!locale) return false;
-
     var lo = new Locale(locale);
     var localeMinimal = new LocaleMatcher({locale: lo}).getLikelyLocaleMinimal().getSpec();
-    var langLocaleMinimal = new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
+    var langLocaleMinimal = ((typeof overrideBaseLocale[lo.language]) !== 'undefined') ?
+                            overrideBaseLocale[lo.language] : new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
 
     return (localeMinimal === langLocaleMinimal);
+ }
+
+ var overrideBaseLocale = {};
+
+ /**
+ * @param {String} locale
+ * @param {String} language
+ */
+   module.exports.setBaseLocale = function(locale, lang) {
+    if (!locale) return;
+    overrideBaseLocale[lang] = locale;
  }
 
  /**
@@ -2079,9 +2090,17 @@ var matchExprs = {
     if (!locale) return;
 
     var lo = new Locale(locale);
-    var langLocaleMinimal = new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
-
+    var langLocaleMinimal;
+    if (typeof overrideBaseLocale[lo.language] !== 'undefined') {
+        langLocaleMinimal = overrideBaseLocale[lo.language];
+    } else {
+        langLocaleMinimal = new LocaleMatcher({locale: lo.language}).getLikelyLocaleMinimal().getSpec();
+    }
     return langLocaleMinimal;
+ }
+
+ module.exports.clearOverrideBaseLocale = function() {
+    overrideBaseLocale = {};
  }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2055,8 +2055,9 @@ var matchExprs = {
     }
 };
 
+var overrideBaseLocale = {};
+
 /**
- *
  * @param {String} locale
  * @return {boolean} true if the locale is matched language default locale.
  */
@@ -2070,19 +2071,19 @@ var matchExprs = {
     return (localeMinimal === langLocaleMinimal);
  }
 
- var overrideBaseLocale = {};
-
  /**
- * @param {String} locale
- * @param {String} language
+ * @param {Object} localeMapData localeMap data object
  */
-   module.exports.setBaseLocale = function(locale, lang) {
-    if (!locale || !lang) return;
-    overrideBaseLocale[lang] = locale;
+   module.exports.setBaseLocale = function(localeMapData) {
+    if (!localeMapData) return;
+    var lang;
+    for (var locale in localeMapData) {
+        lang = localeMapData[locale];
+        overrideBaseLocale[lang] = locale;
+    }
  }
 
  /**
- *
  * @param {String} locale
  * @return {String} return language default locale.
  */
@@ -2099,12 +2100,12 @@ var matchExprs = {
     return langLocaleMinimal;
  }
 
-  /**
+ /**
  * Reset the list of overrideBaseLocale
  */
- module.exports.clearOverrideBaseLocale = function() {
-    overrideBaseLocale = {};
- }
+    module.exports.clearOverrideBaseLocale = function() {
+        overrideBaseLocale = {};
+    }
 
 /**
  * Return a locale encoded in the path using template to parse that path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.17.0",
+    "version": "2.18.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -596,4 +596,17 @@ module.exports.utils = {
 
         test.done();
     },
+    testsetBaseLocale: function(test) {
+        test.expect(6);
+        utils.setBaseLocale("es-CO", "es");
+        test.equals(utils.isBaseLocale("es-ES"), false);
+        test.equals(utils.isBaseLocale("es-CO"), true);
+        test.equals(utils.getBaseLocale("es-ES"), "es-CO");
+        utils.clearOverrideBaseLocale();
+
+        test.equals(utils.isBaseLocale("es-ES"), true);
+        test.equals(utils.isBaseLocale("es-CO"), false);
+        test.equals(utils.getBaseLocale("es-ES"), "es-ES");
+        test.done();
+    },
 }

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -602,6 +602,7 @@ module.exports.utils = {
         test.equals(utils.isBaseLocale("es-ES"), false);
         test.equals(utils.isBaseLocale("es-CO"), true);
         test.equals(utils.getBaseLocale("es-ES"), "es-CO");
+
         utils.clearOverrideBaseLocale();
 
         test.equals(utils.isBaseLocale("es-ES"), true);

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -597,17 +597,28 @@ module.exports.utils = {
         test.done();
     },
     testsetBaseLocale: function(test) {
-        test.expect(6);
-        utils.setBaseLocale("es-CO", "es");
+        test.expect(12);
+        var localeMap = {
+            "es-CO": "es",
+            "fr-CA": "fr"
+        };
+
+        utils.setBaseLocale(localeMap);
         test.equals(utils.isBaseLocale("es-ES"), false);
         test.equals(utils.isBaseLocale("es-CO"), true);
+        test.equals(utils.isBaseLocale("fr-FR"), false);
+        test.equals(utils.isBaseLocale("fr-CA"), true);
         test.equals(utils.getBaseLocale("es-ES"), "es-CO");
+        test.equals(utils.getBaseLocale("fr-FR"), "fr-CA");
 
         utils.clearOverrideBaseLocale();
 
         test.equals(utils.isBaseLocale("es-ES"), true);
         test.equals(utils.isBaseLocale("es-CO"), false);
-        test.equals(utils.getBaseLocale("es-ES"), "es-ES");
+        test.equals(utils.isBaseLocale("fr-FR"), true);
+        test.equals(utils.isBaseLocale("fr-CA"), false);
+        test.equals(utils.getBaseLocale("es-CO"), "es-ES");
+        test.equals(utils.getBaseLocale("fr-FR"), "fr-FR");
         test.done();
     },
 }


### PR DESCRIPTION
* Added the `setBaseLocale()` utility function to override language default locale.
  * related PR : https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/36
  * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/25
