### PR TITLE
Added new method on the Project calss to get all of the translations.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,6 +7,7 @@ Published as version 2.18.0
 
 New Features:
 * Added the utility function to override language default locale.
+* Added new `getTranslations()` method on the Project calss to get all of the translations.
 
 Bug Fixes:
 

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -284,6 +284,26 @@ Project.prototype.getTranslationSet = function() {
 };
 
 /**
+ * Extract all translations according to a given locale list
+ *
+ * @returns {Array.<Resource>} resources an array of resources
+ */
+Project.prototype.getTranslations = function(locales) {
+    if (!locales) return;
+    var resAll = [];
+
+    locales.forEach(function(locale){
+        this.db.getBy({
+            targetLocale: locale
+        }, function(err, res){
+            resAll = resAll.concat(res)
+        }.bind(this))
+    }.bind(this));
+
+    return resAll;
+};
+
+/**
  * Return the unique id of this project. Often this is the
  * name of the repository in source control.
  *


### PR DESCRIPTION
Added new `getTranslations()` method on the Project calss to get all of the translations.
It will be used for `genearte` mode.
related plugin change : https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/37
sample for check: https://github.com/iLib-js/ilib-loctool-samples/pull/28
