### PR TITLE
Add --localeInherit flag to define custom locale inheritance

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,14 @@
 Release Notes for Version 2
 ============================
 
+Build 033
+-------
+Published as version 2.19.0
+
+New Features:
+* Added the --localeInherit flag which could define custom locale inheritance.
+
+
 Build 032
 -------
 Published as version 2.18.0

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -666,7 +666,7 @@ Project.prototype.getOutputLocale = function(locale) {
  * @returns {String|undefined} inheritance locale. it returns undefind if it follows current default.
  */
  Project.prototype.getLocaleInherit = function(locale) {
-    if (!locale) return undefined;
+    if (typeof (locale) !== "string") return undefined;
     return (this.localeInherit && this.localeInherit[locale] ? this.localeInherit[locale]: undefined);
 };
 

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -133,6 +133,7 @@ var Project = function(options, root, settings) {
         });
     }
     this.localeMap = JSUtils.merge((this.settings && this.settings.localeMap) || {}, (options.settings && options.settings.localeMap) || {});
+    this.localeInherit = JSUtils.merge((this.settings && this.settings.localeInherit) || {}, (options.settings && options.settings.localeInherit) || {});
 
     this.root = root;  // where localizable files live
     this.target = smartJoin(this.root, this.settings.targetDir || '.'); // where localized stuff is written
@@ -292,6 +293,7 @@ Project.prototype.getTranslations = function(locales) {
     if (!locales) return;
     var resAll = [];
 
+    locales = (!ilib.isArray(locales) ? locales : [locales]);
     locales.forEach(function(locale){
         this.db.getBy({
             targetLocale: locale
@@ -653,6 +655,19 @@ Project.prototype.getExtracted = function(cb) {
  */
 Project.prototype.getOutputLocale = function(locale) {
     return (this.localeMap && this.localeMap[locale]) || locale;
+};
+
+/**
+ * If this project specifies a locale inheritance information either from the project.json
+ * file or on the command-line, then the locale will be mapped. If the
+ * given locale does not exist in the mapping, it will be returned undefined.
+ *
+ * @param {String} locale the locale to check
+ * @returns {String|undefined} inheritance locale. it returns undefind if it follows current default.
+ */
+ Project.prototype.getLocaleInherit = function(locale) {
+    if (!locale) return undefined;
+    return (this.localeInherit && this.localeInherit[locale] ? this.localeInherit[locale]: undefined);
 };
 
 /**

--- a/loctool.js
+++ b/loctool.js
@@ -74,6 +74,11 @@ function usage() {
         "  is a comma-separated list of mappings where each mapping is a BCP-47 specifier\n" +
         "  of the source locale, a colon, and the BCP-47 specifier of the target locale.\n" +
         "  eg. 'da:da-DK,no:nb-NO,en:en-GB'\n" +
+        "--localeInherit\n" +
+        "  Map input locales to follow different locale inherit than the default. The format of the parameter\n" +
+        "  is a comma-separated list of mappings where each mapping is a BCP-47 specifier\n" +
+        "  of the source locale, a colon, and the BCP-47 specifier of the target locale.\n" +
+        "  eg. 'en-AU:en-GB' (en-AU inherits from en-GB )\n" +
         "--localizeOnly\n" +
         "  Generate a localization resource only. Do not create any other files at all after running loctool. \n" +
         "-n or --pseudo\n" +
@@ -194,6 +199,7 @@ var settings = {
     sourceLocale: "en-US",
     targetLocale: null,
     localeMap: {},
+    localeInherit: {},
     onlyTranslated: false
 };
 
@@ -218,6 +224,16 @@ for (var i = 0; i < argv.length; i++) {
                 var parts = mapping.split(":");
                 if (parts && parts.length > 1) {
                     settings.localeMap[parts[0]] = parts[1];
+                }
+            });
+        }
+    } else if (val.toLowerCase() === "--localeinherit") {
+        if (i < argv.length && argv[i+1]) {
+            var inheritList = argv[++i].split(",");
+            inheritList.forEach(function(list) {
+                var parts = list.split(":");
+                if (parts && parts.length > 1) {
+                    settings.localeInherit[parts[0]] = parts[1];
                 }
             });
         }

--- a/loctool.js
+++ b/loctool.js
@@ -75,10 +75,12 @@ function usage() {
         "  of the source locale, a colon, and the BCP-47 specifier of the target locale.\n" +
         "  eg. 'da:da-DK,no:nb-NO,en:en-GB'\n" +
         "--localeInherit\n" +
-        "  Map input locales to follow different locale inherit than the default. The format of the parameter\n" +
-        "  is a comma-separated list of mappings where each mapping is a BCP-47 specifier\n" +
-        "  of the source locale, a colon, and the BCP-47 specifier of the target locale.\n" +
-        "  eg. 'en-AU:en-GB' (en-AU inherits from en-GB )\n" +
+        "  Map locales to follow different locale inheritance rules than the default. By default, a locale inherits\n" +
+        "  translations from the locale with the language only, and then from the root (en-US -> en -> root). With this\n" +
+        "  option, you can specify that a locale inherits from a different locale first.\n" +
+        "  The value of the parameter is a comma-separated list of mappings where each mapping is a BCP-47\n" +
+        "  specifier of the source locale, a colon, and the BCP-47 specifier of the target locale.\n" +
+        "  eg. 'en-AU:en-GB' (en-AU inherits translations from en-GB)\n" +
         "--localizeOnly\n" +
         "  Generate a localization resource only. Do not create any other files at all after running loctool. \n" +
         "-n or --pseudo\n" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.18.0",
+    "version": "2.19.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -508,4 +508,13 @@ module.exports.project = {
 
         test.done();
     },
+    testGetOutputLocaleInheritEmpty2: function(test) {
+        test.expect(2);
+
+        var project = ProjectFactory('./testfiles', {});
+        test.equals(project.getLocaleInherit("ko-KR"), undefined);
+        test.equals(project.getLocaleInherit(), undefined);
+
+        test.done();
+    },
 };

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -480,4 +480,32 @@ module.exports.project = {
 
         test.done();
     },
+    testGetOutputLocaleInherit: function(test) {
+        test.expect(2);
+
+        var project = ProjectFactory('./testfiles', {
+            localeInherit: {
+                "en-AU": "en-GB",
+                "en-CN": "en-GB"
+            }
+        });
+        test.ok(project.getLocaleInherit("en-AU"), "en-GB");
+        test.ok(project.getLocaleInherit("en-CN"), "en-GB");
+
+        test.done();
+    },
+    testGetOutputLocaleInheritEmpty: function(test) {
+        test.expect(2);
+
+        var project = ProjectFactory('./testfiles', {
+            localeInherit: {
+                "en-AU": "en-GB",
+                "en-CN": "en-GB"
+            }
+        });
+        test.equals(project.getLocaleInherit("ko-KR"), undefined);
+        test.equals(project.getLocaleInherit(), undefined);
+
+        test.done();
+    },
 };


### PR DESCRIPTION
* Add `--localeInherit` flag to define custom locale inheritance
  *  i.e) --localeInherit en-AU:en-GB (which means en-AU locale inherits from en-GB)
  * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/29
  * related change: https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/39