### PR TITLE
fixed a bug where not correctly filtering pseudo locale

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,13 @@
 Release Notes for Version 2
 ============================
 
+Build 033
+-------
+Published as version 2.18.1
+
+Bug Fixes:
+* Fixed a bug where not correctly filtering pseudo locale.
+
 Build 032
 -------
 Published as version 2.18.0

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -220,7 +220,9 @@ var PseudoFactory = function(options) {
 PseudoFactory.isPseudoLocale = function (locale, project) {
     var l = new Locale(locale);
     var novariant = new Locale(l.getLanguage(), l.getRegion(), undefined, l.getScript()).getSpec();
-    var ps = (project && project.settings && project.settings.pseudoLocales) || PseudoFactory.defaultPseudoLocales;
+    var ps = (project && ((project.settings && project.settings.pseudoLocales) ||
+             (project && project.pseudoLocales) || (project && project.pseudoLocale)) ||
+             PseudoFactory.defaultPseudoLocales);
     return (l.getSpec() in ps) || (novariant in ps);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.18.0",
+    "version": "2.18.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
fixed a bug where not correctly filtering pseudo locale
 It needs to check `project.pseudoLocales` or `project.pseudoLocale` too when determining if it's pseudo locale or not.
fyi. https://github.com/iLib-js/loctool/blob/development/lib/Project.js#L87