### PR TITLE
Add new methods to Project and LocalRepository class

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,14 @@
 Release Notes for Version 2
 ============================
 
+Build 034
+-------
+Published as version 2.20.0
+
+New Features:
+* Added a new `getRepository()` method on the Project class to get the local repository.
+* Added a new `getTranslationSet()` method on the LocalRepository class to get all of the translations.
+
 Build 033
 -------
 Published as version 2.19.0

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -1,7 +1,7 @@
 /*
  * CustomProject.js - a customizable project
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright © 2019-2022, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ var AndroidLayoutFileType = require("./AndroidLayoutFileType.js");
 var AndroidResourceFileType = require("./AndroidResourceFileType.js");
 var JavaFileType = require("./JavaFileType.js");
 var XliffFileType = require("./XliffFileType.js");
-
+var Xliff = require("./Xliff.js");
 var log4js = require("log4js");
 
 var logger = log4js.getLogger("loctool.lib.CustomProject");
@@ -135,6 +135,9 @@ CustomProject.prototype.getAPI = function() {
         utils: utils,
         isPseudoLocale: function(locale) {
             return PseudoFactory.isPseudoLocale(locale, this);
+        },
+        newXliff: function(options) {
+            return new Xliff(options);
         },
         getPseudoBundle: function(locale, filetype, project) {
             var type = "text";

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -1,7 +1,7 @@
 /*
  * LocalRepository.js - a collection of resource strings backed by a local set of files
  *
- * Copyright © 2016-2017, 2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2020, 2022 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -227,6 +227,16 @@ LocalRepository.prototype.getLocales = function(project, context, cb) {
 };
 
 /**
+ * Return the translation set for local repository
+ *
+ * @returns {TranslationSet} the translation set
+ *
+ */
+ LocalRepository.prototype.getTranslationSet = function() {
+    return this.ts;
+};
+
+/**
  * Call the callback with true if the DB already contains the
  * given resource.
  *

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -1,7 +1,7 @@
 /*
  * Project.js - represents an project
  *
- * Copyright © 2016-2017, 2019-2021 HealthTap, Inc.
+ * Copyright © 2016-2017, 2019-2022 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,6 +283,17 @@ Project.prototype.getFileType = function(name) {
 Project.prototype.getTranslationSet = function() {
     return this.translations;
 };
+
+
+/**
+ * Return the LocalRepository for this project.
+ *
+ * @returns {LocalRepository} the localrepository of this project
+ */
+ Project.prototype.getRepository = function() {
+    return this.db;
+};
+
 
 /**
  * Extract all translations according to a given locale list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.19.0",
+    "version": "2.20.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION

* Added a new `getRepository()` method on the Project class to get the local repository.
* Added a new `getTranslationSet()` method on the LocalRepository class to get all of the translations.
* these two methods is for support common xliff data file for webos plugins
   * related PR: https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/40
   * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/32
