### PR TITLE
Updated to remove duplicate plugins from the pluginlist and fix ternaty operator bug

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 2
 ============================
 
+Build 035
+-------
+Published as version 2.20.1
+
+New Features:
+
+Bug Fixes:
+* Updated to remove duplicate plugins from the list which can reduce duplication of work.
+
+
 Build 034
 -------
 Published as version 2.20.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,7 +9,7 @@ New Features:
 
 Bug Fixes:
 * Updated to remove duplicate plugins from the list which can reduce duplication of work.
-
+* Fixed ternary operator bug in `getTranslations()` method on the Project class.
 
 Build 034
 -------

--- a/lib/CustomProject.js
+++ b/lib/CustomProject.js
@@ -85,7 +85,7 @@ var CustomProject = function(options, root, settings) {
         this.resourceFileTypes = (options.resourceFileTypes || settings && settings.resourceFileTypes) || {};
         this.defaultLocales = this.settings.locales || (options.settings && options.settings.locales) || [];
     }
-
+    this.plugins = Array.from(new Set(this.plugins));
     if (settings && settings["build.gradle"]) {
         this.flavors = new AndroidFlavors(settings["build.gradle"], this.root);
     }

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -304,7 +304,7 @@ Project.prototype.getTranslations = function(locales) {
     if (!locales) return;
     var resAll = [];
 
-    locales = (!ilib.isArray(locales) ? locales : [locales]);
+    locales = (ilib.isArray(locales) ? locales : [locales]);
     locales.forEach(function(locale){
         this.db.getBy({
             targetLocale: locale

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.20.0",
+    "version": "2.20.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",


### PR DESCRIPTION
* Updated to remove duplicate plugins from the pluginlist which can reduce duplication of work.
* Fixed ternary operator bug in `getTranslations()` method on the Project class.