### PR TITLE
Does not throw error if there is no path template

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,9 @@ New Features:
 Bug Fixes:
 * Updated to remove duplicate plugins from the list which can reduce duplication of work.
 * Fixed ternary operator bug in `getTranslations()` method on the Project class.
+* Fixed a bug where attempting to glean the locale from a path using an undefined template
+  would cause an error. Instead, it should just return the empty string to indicate that
+  no locale was found.
 
 Build 034
 -------

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2120,8 +2120,9 @@ module.exports.getLocaleFromPath = function(template, pathname) {
     var totalBrackets = 0;
     var base;
 
-    if (!template) {
-        template = defaultMappings["**/*.json"].template;
+    if (!template || !pathname) {
+        // missing template or pathname? We cannot find the locale without them!
+        return "";
     }
 
     for (var i = 0; i < template.length; i++) {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -560,6 +560,22 @@ module.exports.utils = {
         test.done();
     },
 
+    testGetLocaleFromPathNoTemplate: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath(undefined, "x/y/strings_zh-hans-cn.json"), "");
+
+        test.done();
+    },
+
+    testGetLocaleFromPathNoPath: function(test) {
+        test.expect(1);
+
+        test.equals(utils.getLocaleFromPath('[dir]/strings_[localeLower].json', undefined), "");
+
+        test.done();
+    },
+
     testUtilsCleanString: function(test) {
         test.expect(1);
 


### PR DESCRIPTION
* Fixed a bug where attempting to glean the locale from a path using an undefined template would cause an error. Instead, it should just return the empty string to indicate that no locale was found.