### PR TITLE
TMX file output was missing the srclang attribute in the header

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,8 @@ New Features:
 
 Bug Fixes:
 * added more explicit logging output in order to be able to debug problems
+* fixed a problem where tmx file output was not adding the srclang attribute
+  to the header of the tmx file
 
 Build 036
 -------

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -1,7 +1,7 @@
 /*
  * TMX.js - model an tmx file
  *
- * Copyright © 2021 Box, Inc.
+ * Copyright © 2021, 2023 Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,12 +241,14 @@ var Tmx = function Tmx(options) {
     this.version = 1.4;
     this.properties = {};
     this.sourceLocale = "en-US";
+    this.adminLocale = this.sourceLocale;
     this.segmentation = "paragraph";
 
     if (options) {
         this.properties = options.properties || this.properties;
         this.path = options.path;
         this.sourceLocale = options.sourceLocale || this.sourceLocale;
+        this.adminLocale = options.adminLocale || this.adminLocale;
         if (typeof(options.version) !== 'undefined') {
             this.version = Number.parseFloat(options.version);
         }
@@ -555,7 +557,7 @@ Tmx.prototype.serialize = function() {
                     creationtool: this.properties.creationtool || "loctool",
                     creationtoolversion: this.properties.creationtoolversion || getVersion(),
                     srclang: this.sourceLocale,
-                    adminlang: "en-US",
+                    adminlang: this.adminLocale,
                     datatype: "unknown"
                 }
             },

--- a/lib/TMX.js
+++ b/lib/TMX.js
@@ -554,8 +554,8 @@ Tmx.prototype.serialize = function() {
                     segtype: this.segmentation,
                     creationtool: this.properties.creationtool || "loctool",
                     creationtoolversion: this.properties.creationtoolversion || getVersion(),
+                    srclang: this.sourceLocale,
                     adminlang: "en-US",
-                    srclang: this.locale,
                     datatype: "unknown"
                 }
             },

--- a/test/testTMX.js
+++ b/test/testTMX.js
@@ -1598,7 +1598,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" srclang="en-US" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-context">asdf</prop>\n' +
@@ -1655,7 +1655,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" srclang="en-US" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -1753,7 +1753,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" srclang="en-US" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -2972,7 +2972,7 @@ module.exports.tmx = {
         var expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="sentence" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="sentence" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" srclang="en-US" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +
@@ -3180,7 +3180,7 @@ module.exports.tmx = {
         var actual = tmx.serialize();
         var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<tmx version="1.4">\n' +
-            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" adminlang="en-US" datatype="unknown"/>\n' +
+            '  <header segtype="paragraph" creationtool="loctool" creationtoolversion="' + loctoolVersion + '" srclang="en-US" adminlang="en-US" datatype="unknown"/>\n' +
             '  <body>\n' +
             '    <tu srclang="en-US">\n' +
             '      <prop type="x-project">webapp</prop>\n' +


### PR DESCRIPTION
- this caused the ilib-tmx library to read the file incorrectly and put all of the translation variants into the same translation unit
- fixed this to output the right header attributes, and will fix the ilib-tmx separately to be more tolerant of a missing srclang