### PR TITLE
added new `resourceDir` parameter support to util's `formatPath()` 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 Release Notes for Version 2
 ============================
 
+Build 038
+-------
+Published as version 2.20.4
+
+New Features:
+
+Bug Fixes:
+* added new `resourceDir` parameter support to util's `formatPath()` which is for modifing the resource root path.
+
 Build 037
 -------
 Published as version 2.20.3

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Published as version 2.20.4
 New Features:
 
 Bug Fixes:
-* added new `resourceDir` parameter support to util's `formatPath()` which is for modifing the resource root path.
+* added new `resourceDir` parameter support to util's `formatPath()` which is for modifying the resource root path.
 
 Build 037
 -------

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1894,6 +1894,8 @@ module.exports.nodeMajorVersion = function() {
  * - [dir] the original directory where the source file
  *   came from. This is given as a directory that is relative
  *   to the root of the project. eg. "foo/bar/strings.json" -> "foo/bar"
+ * - [resourceDir] the root of the resource directory.
+ *   e.g "foo/bar/resources/strings.json" -> "resources"
  * - [filename] the file name of the source file.
  *   eg. "foo/bar/strings.json" -> "strings.json"
  * - [basename] the basename of the source file without any extension
@@ -1933,6 +1935,7 @@ module.exports.formatPath = function (template, parameters) {
     var output = "";
     var l = new Locale(locale);
     var base;
+    var resDir = parameters.resourceDir || ".";
 
     for (var i = 0; i < template.length; i++) {
         if ( template[i] !== '[' ) {
@@ -1946,6 +1949,9 @@ module.exports.formatPath = function (template, parameters) {
             switch (keyword) {
                 case 'dir':
                     output += path.dirname(pathname);
+                    break;
+                case 'resourceDir':
+                    output += resDir;
                     break;
                 case 'filename':
                     output += path.basename(pathname);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.20.3",
+    "version": "2.20.4",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -368,6 +368,41 @@ module.exports.utils = {
         test.done();
     },
 
+    testGetresourceDirPath: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[resourceDir]/[localeDir]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "ko",
+            resourceDir: "res"
+        }), "x/y/res/ko/strings.json");
+
+        test.done();
+    },
+
+    testGetresourceDirPath2: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[resourceDir]/[localeDir]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "fr-CA",
+            resourceDir: "resources"
+        }), "x/y/resources/fr/CA/strings.json");
+
+        test.done();
+    },
+
+    testGetresourceDirPath3: function(test) {
+        test.expect(1);
+
+        test.equals(utils.formatPath('[dir]/[resourceDir]/[localeDir]/strings.json', {
+            sourcepath: "x/y/strings.json",
+            locale: "es"
+        }), "x/y/es/strings.json");
+
+        test.done();
+    },
+
     testGetLocaleFromPathDir: function(test) {
         test.expect(1);
 


### PR DESCRIPTION
added new `resourceDir` parameter support to util's `formatPath()` which is for modifying the resource root path.