### PR TITLE
Add new debug-font pseudo locale style

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Example project with an object of pseudo locales:
 {
   "pseudoLocale": {
     "pl-PL": "debug",
+    "am-XX": "debug-font,
     "en-CA": "english-canadian",
     "en-GB": "english-british",
     "zh-Hant-TW": "chinese-traditional-tw"
@@ -542,6 +543,8 @@ The following is the list of styles supported:
   like Arabic or Hebrew
 - debug-asian: map the Latin characters to Asian characters
   to test your app's font support for Asian characters
+- debug-font: map the Latin characters to characters that 
+  require a different font.
 - english-british: map US spellings to British English spellings
 - english-canadian: map US spellings to Canadian English spellings
 - english-australian: map US spellings to Australian English spellings

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,13 +1,25 @@
 Release Notes for Version 2
 ============================
 
+Build 039
+-------
+Published as version 2.22.0
+* added new `debug-font` pseudoLocale style. It transform the source strings into strings of characters
+  that require a different font. This allows you to test out whether or not the font works in your UI
+  without having a real translation.  
+  e.g.
+  ```
+  "pseudoLocale": {
+    "am-XX": "debug-font",
+  },
+  ```
+
 Build 038
 -------
 Published as version 2.21.0
 
 New Features:
 * added new `resourceDir` parameter support to util's `formatPath()` which is for modifying the resource root path.
-* added new `debug-font` pseudoLocale style for checking scripts and fonts.
 
 Bug Fixes:
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,6 +7,7 @@ Published as version 2.21.0
 
 New Features:
 * added new `resourceDir` parameter support to util's `formatPath()` which is for modifying the resource root path.
+* added new `debug-font` pseudoLocale style for checking scripts and fonts.
 
 Bug Fixes:
 

--- a/lib/PseudoFactory.js
+++ b/lib/PseudoFactory.js
@@ -2,7 +2,7 @@
  * PseudoFactory.js - class that creates the right type of pseudo localization
  * resource bundle for the given locale
  *
- * Copyright © 2016-2017, 2020 HealthTap, Inc.
+ * Copyright © 2016-2017, 2020 2023 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ var WordBasedPseudo = require("./WordBasedPseudo.js");
 var PseudoHant = require("./PseudoHant.js");
 var RegularPseudo = require("./RegularPseudo.js");
 var Locale = require("ilib/lib/Locale");
-
+var ilib = require("ilib");
 var logger = log4js.getLogger("loctool.lib.PseudoFactory");
 
 // Maps the datatype from known plugins to iLib escape types.
@@ -181,7 +181,16 @@ var PseudoFactory = function(options) {
                 targetLocale: "zxx-Cyrl-XX"
             });
             break;
-
+        case 'debug-font':
+                logger.trace('Debug font pseudo for locale ' + options.targetLocale);
+                ilib.setAsPseudoLocale(options.targetLocale);
+                return new RegularPseudo({
+                    set: options.set,
+                    type: type,
+                    sourceLocale: sourceLocale.getSpec(),
+                    targetLocale: options.targetLocale,
+                });
+            break;
         case 'chinese-traditional-tw':
             logger.trace('Hant pseudo for locale ' + options.targetLocale);
             return new PseudoHant({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.21.0",
+    "version": "2.22.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testPseudoFactory.js
+++ b/test/testPseudoFactory.js
@@ -111,6 +111,19 @@ var project8 = new WebProject({
     locales: ["en-GB", "en-NZ", "es-US"]
 });
 
+var project9 = new WebProject({
+    sourceLocale: "en-US",
+    pseudoLocale: {
+        "as-XX": "debug-font",
+        "kn-XX": "debug-font"
+    },
+    resourceDirs: {
+        "json": "resources"
+    }
+}, "./testfiles", {
+    locales: ["en-GB", "en-US", "ko-KR"]
+});
+
 module.exports.pseudofactory = {
     testPseudoFactoryDefaultBritishEnglish: function(test) {
         test.expect(2);
@@ -364,7 +377,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -379,7 +391,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -394,7 +405,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -424,7 +434,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -439,7 +448,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -454,7 +462,6 @@ module.exports.pseudofactory = {
             type: "text"
         });
 
-        // Jamaica is not in the object
         test.ok(!pseudo);
 
         test.done();
@@ -605,6 +612,32 @@ module.exports.pseudofactory = {
         var pseudo = PseudoFactory({
             project: project3,
             targetLocale: "zxx-XX-ASDF",
+            type: "text"
+        });
+        test.ok(pseudo);
+        test.ok(pseudo instanceof RegularPseudo);
+
+        test.done();
+    },
+    testPseudoFactoryNormalasXXLocale: function(test) {
+        test.expect(2);
+
+        var pseudo = PseudoFactory({
+            project: project9,
+            targetLocale: "as-XX",
+            type: "text"
+        });
+        test.ok(pseudo);
+        test.ok(pseudo instanceof RegularPseudo);
+
+        test.done();
+    },
+    testPseudoFactoryNormalknXXLocale: function(test) {
+        test.expect(2);
+
+        var pseudo = PseudoFactory({
+            project: project9,
+            targetLocale: "kn-XX",
             type: "text"
         });
         test.ok(pseudo);


### PR DESCRIPTION
Added new `debug-font` pseudo Locale style.
This style is for related font checking during the pseudo-localization process. 
locales for the debug font style are going to be am-XX, bn-XX, etc In webOS, the representative font is different on the locale, and the font metadata (that affects width and height) is different for each font.  By adding this pseudo locale style, we can test pseudo localization for more scripts and fonts.

note) The way of choosing font per locale in webOS, it checks `language`. so making a pseudo locale as am-XX is safer and more accurate than zxx-Ethi-XXX

related PRs:
* https://github.com/iLib-js/iLib/pull/430
* https://github.com/iLib-js/ilib-loctool-samples/pull/56

