### PR TITLE
Avoid putting resources with missing or empty sources into the xliff files

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,21 @@ Release Notes for Version 2
 
 Build 038
 -------
+Published as version 2.21.1
+
+New Features:
+
+Bug Fixes:
+* Fixed a bug in the ResourceArray constructor where an undefined element
+  in the array would get stored as the string "undefined" in the resource array
+  instead of the undefined value. This caused all manner of bad things, including
+  translations units in the extracted and new xliff files that had a bad or
+  missing source tag and therefore no source string to translate. Now, undefined
+  elements do not show up in the output xliff files because there is nothing
+  to translate. They stay undefined in localized files.
+
+Build 038
+-------
 Published as version 2.21.0
 
 New Features:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,13 +8,13 @@ Published as version 2.21.1
 New Features:
 
 Bug Fixes:
-* Fixed a bug in the ResourceArray constructor where an undefined element
-  in the array would get stored as the string "undefined" in the resource array
-  instead of the undefined value. This caused all manner of bad things, including
-  translations units in the extracted and new xliff files that had a bad or
-  missing source tag and therefore no source string to translate. Now, undefined
-  elements do not show up in the output xliff files because there is nothing
-  to translate. They stay undefined in localized files.
+* Fixed bug where resources with no source would sometimes appear in the
+  extracted and new xliff files.
+    * in the ResourceArray constructor: an undefined element
+      in the array would get stored as the string "undefined" in the resource array
+      instead of the actual value undefined. This messed a lot of things up
+    * in projects, filter out any resources, from any plugin, where the
+      source is not defined. This goes for strings, arrays, or plurals.
 
 Build 038
 -------

--- a/lib/AndroidResourceFileType.js
+++ b/lib/AndroidResourceFileType.js
@@ -174,7 +174,7 @@ AndroidResourceFileType.prototype.write = function(translations, locales) {
 
                         var translatedItems = r.getTargetArray();
                         for (var i = 0; i < items.length; i++) {
-                            if (!translatedItems[i]) {
+                            if (items[i] && !translatedItems[i]) {
                                 translatedItems[i] = items[i]; // use the English as backup
                                 fullyTranslated = false;
                                 newItems.push(items[i]);

--- a/lib/Project.js
+++ b/lib/Project.js
@@ -708,6 +708,9 @@ Project.prototype.close = function(cb) {
             logger.trace("Collecting extracted strings from " + this.fileTypes[i].name());
             extracted.addAll(this.fileTypes[i].getExtracted().getBy({
                 sourceLocale: this.sourceLocale
+            }).filter(function(res) {
+                // no source means nothing to translate, so don't need those resources
+                return res.source || res.sourceArray || res.sourceStrings;
             }));
 
             if (this.fileTypes[i].modern && this.fileTypes[i].modern.size() > 0) {
@@ -761,7 +764,8 @@ Project.prototype.close = function(cb) {
                 if (!this.isSourceLocale(locale) && !PseudoFactory.isPseudoLocale(locale, this)) {
                     var newPath = path.join(dir, base + "-new-" + locale + ".xliff");
                     var resources = newres.getAll().filter(function(res) {
-                        return res.getTargetLocale() === locale && !res.dnt;
+                        return res.getTargetLocale() === locale && !res.dnt &&
+                            (res.source || res.sourceArray || res.sourceStrings);
                     });
 
                     if (resources && resources.length) {

--- a/lib/ResourceArray.js
+++ b/lib/ResourceArray.js
@@ -62,13 +62,13 @@ var ResourceArray = function(props) {
         if (props.sourceArray && props.sourceArray.length) {
             // make a deep copy of the array
             this.sourceArray = props.sourceArray.map(function(item) {
-                 return new String(item).toString();
+                 return item ? new String(item).toString() : item;
             });
         }
         if (props.targetArray && props.targetArray.length) {
             // make a deep copy of the array
             this.targetArray = props.targetArray.map(function(item) {
-                 return new String(item).toString();
+                 return item ? new String(item).toString() : item;
             });
         }
         if (props.subtype) {

--- a/lib/Xliff.js
+++ b/lib/Xliff.js
@@ -561,7 +561,7 @@ Xliff.prototype._convertResource = function(res) {
 
                     newtu.ordinal = j;
                     units.push(newtu);
-                } else if (tarr[j]) {
+                } else if (tarr && tarr[j]) {
                     logger.warn("Translated array  " + res.getKey() + " has no source string at index " + j + ". Cannot translate. Resource is: " + JSON.stringify(res, undefined, 4));
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.21.0",
+    "version": "2.21.1",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testProject.js
+++ b/test/testProject.js
@@ -166,17 +166,29 @@ module.exports.project = {
                                 '<xliff version="1.2">\n' +
                                 '  <file original="res/values/strings.xml" source-language="en-US" target-language="es-US" product-name="loctest">\n' +
                                 '    <body>\n' +
-                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                                '      <trans-unit id="1" resname="noSource" restype="array" datatype="x-android-resource" extype="0">\n' +
+                                '        <source>a</source>\n' +
+                                '        <target state="new">a</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="2" resname="noSource" restype="array" datatype="x-android-resource" extype="1">\n' +
+                                '        <source>b</source>\n' +
+                                '        <target state="new">b</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="3" resname="noSource" restype="array" datatype="x-android-resource" extype="3">\n' +
+                                '        <source>c</source>\n' +
+                                '        <target state="new">c</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
                                 '        <source>%d friend commented</source>\n' +
                                 '        <target state="new">%d friend commented</target>\n' +
                                 '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
-                                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
+                                '      <trans-unit id="5" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
-                                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '      <trans-unit id="6" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
@@ -195,7 +207,19 @@ module.exports.project = {
                                 '<xliff version="1.2">\n' +
                                 '  <file original="res/values/strings.xml" source-language="en-US" target-language="ja-JP" product-name="loctest">\n' +
                                 '    <body>\n' +
-                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '      <trans-unit id="1" resname="noSource" restype="array" datatype="x-android-resource" extype="0">\n' +
+                                '        <source>a</source>\n' +
+                                '        <target state="new">a</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="2" resname="noSource" restype="array" datatype="x-android-resource" extype="1">\n' +
+                                '        <source>b</source>\n' +
+                                '        <target state="new">b</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="3" resname="noSource" restype="array" datatype="x-android-resource" extype="3">\n' +
+                                '        <source>c</source>\n' +
+                                '        <target state="new">c</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
@@ -214,22 +238,34 @@ module.exports.project = {
                                 '<xliff version="1.2">\n' +
                                 '  <file original="res/values/strings.xml" source-language="en-US" target-language="ru-RU" product-name="loctest">\n' +
                                 '    <body>\n' +
-                                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                                '      <trans-unit id="1" resname="noSource" restype="array" datatype="x-android-resource" extype="0">\n' +
+                                '        <source>a</source>\n' +
+                                '        <target state="new">a</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="2" resname="noSource" restype="array" datatype="x-android-resource" extype="1">\n' +
+                                '        <source>b</source>\n' +
+                                '        <target state="new">b</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="3" resname="noSource" restype="array" datatype="x-android-resource" extype="3">\n' +
+                                '        <source>c</source>\n' +
+                                '        <target state="new">c</target>\n' +
+                                '      </trans-unit>\n' +
+                                '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
                                 '        <source>%d friend commented</source>\n' +
                                 '        <target state="new">%d friend commented</target>\n' +
                                 '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
-                                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="few">\n' +
+                                '      <trans-unit id="5" resname="foobar" restype="plural" datatype="x-android-resource" extype="few">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
-                                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
+                                '      <trans-unit id="6" resname="foobar" restype="plural" datatype="x-android-resource" extype="many">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '      </trans-unit>\n' +
-                                '      <trans-unit id="4" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                                '      <trans-unit id="7" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
                                 '        <source>%d friends commented</source>\n' +
                                 '        <target state="new">%d friends commented</target>\n' +
                                 '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
@@ -276,7 +312,25 @@ module.exports.project = {
                                 '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
-                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '      <unit id="1" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                                '        <segment>\n' +
+                                '          <source>a</source>\n' +
+                                '          <target state="new">a</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="2" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                                '        <segment>\n' +
+                                '          <source>b</source>\n' +
+                                '          <target state="new">b</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="3" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
+                                '        <segment>\n' +
+                                '          <source>c</source>\n' +
+                                '          <target state="new">c</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -285,7 +339,7 @@ module.exports.project = {
                                 '          <target state="new">%d friend commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
-                                '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
+                                '      <unit id="5" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -294,7 +348,7 @@ module.exports.project = {
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
-                                '      <unit id="3" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '      <unit id="6" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -317,7 +371,25 @@ module.exports.project = {
                                 '<xliff version="2.0" srcLang="en-US" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">\n' +
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
-                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '      <unit id="1" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                                '        <segment>\n' +
+                                '          <source>a</source>\n' +
+                                '          <target state="new">a</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="2" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                                '        <segment>\n' +
+                                '          <source>b</source>\n' +
+                                '          <target state="new">b</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="3" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
+                                '        <segment>\n' +
+                                '          <source>c</source>\n' +
+                                '          <target state="new">c</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -340,7 +412,25 @@ module.exports.project = {
                                 '<xliff version="2.0" srcLang="en-US" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">\n' +
                                 '  <file original="res/values/strings.xml" l:project="loctest">\n' +
                                 '    <group id="group_1" name="x-android-resource">\n' +
-                                '      <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                                '      <unit id="1" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                                '        <segment>\n' +
+                                '          <source>a</source>\n' +
+                                '          <target state="new">a</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="2" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                                '        <segment>\n' +
+                                '          <source>b</source>\n' +
+                                '          <target state="new">b</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="3" name="noSource" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
+                                '        <segment>\n' +
+                                '          <source>c</source>\n' +
+                                '          <target state="new">c</target>\n' +
+                                '        </segment>\n' +
+                                '      </unit>\n' +
+                                '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -349,7 +439,7 @@ module.exports.project = {
                                 '          <target state="new">%d friend commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
-                                '      <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
+                                '      <unit id="5" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -358,7 +448,7 @@ module.exports.project = {
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
-                                '      <unit id="3" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
+                                '      <unit id="6" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="many">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"many","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +
@@ -367,7 +457,7 @@ module.exports.project = {
                                 '          <target state="new">%d friends commented</target>\n' +
                                 '        </segment>\n' +
                                 '      </unit>\n' +
-                                '      <unit id="4" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                                '      <unit id="7" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
                                 '        <notes>\n' +
                                 '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
                                 '        </notes>\n' +

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -103,6 +103,38 @@ module.exports.resourcearray = {
         test.done();
     },
 
+    testResourceArrayConstructorMissingElements: function(test) {
+        test.expect(1);
+
+        var ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", undefined, "This is not"],
+            sourceLocale: "en-US",
+            targetArray: ["Dies ist einen Test.", "Dies ist auch einen Test.", undefined, "Dies ist nicht."],
+            targetLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        test.done();
+    },
+
+    testResourceArrayConstructorEmptyElements: function(test) {
+        test.expect(1);
+
+        var ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", "", "This is not"],
+            sourceLocale: "en-US",
+            targetArray: ["Dies ist einen Test.", "Dies ist auch einen Test.", "", "Dies ist nicht."],
+            targetLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        test.done();
+    },
+
     testResourceArrayConstructorFullRightContents: function(test) {
         test.expect(7);
 
@@ -163,6 +195,38 @@ module.exports.resourcearray = {
         test.ok(ra);
 
         test.equal(ra.size(), 3);
+
+        test.done();
+    },
+
+    testResourceArrayConstructorRightSizeMissingElements: function(test) {
+        test.expect(2);
+
+        var ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", undefined, "This is not"],
+            sourceLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        test.equal(ra.size(), 4);
+
+        test.done();
+    },
+
+    testResourceArrayConstructorRightSizeEmptyElements: function(test) {
+        test.expect(2);
+
+        var ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", "", "This is not"],
+            sourceLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        test.equal(ra.size(), 4);
 
         test.done();
     },
@@ -275,6 +339,42 @@ module.exports.resourcearray = {
         test.done();
     },
 
+    testResourceArrayGetSourceMissingElements: function(test) {
+        test.expect(5);
+
+        var ra = new ResourceArray({
+            key: "foo",
+            sourceArray: ["This is a test", "This is also a test", undefined, "This is not"],
+            pathName: "a/b/c.txt",
+            sourceLocale: "de-DE"
+        });
+        test.ok(ra);
+        test.equal(ra.getSource(0), "This is a test");
+        test.equal(ra.getSource(1), "This is also a test");
+        test.ok(!ra.getSource(2));
+        test.equal(ra.getSource(3), "This is not");
+
+        test.done();
+    },
+
+    testResourceArrayGetSourceEmptyElements: function(test) {
+        test.expect(5);
+
+        var ra = new ResourceArray({
+            key: "foo",
+            sourceArray: ["This is a test", "This is also a test", "", "This is not"],
+            pathName: "a/b/c.txt",
+            sourceLocale: "de-DE"
+        });
+        test.ok(ra);
+        test.equal(ra.getSource(0), "This is a test");
+        test.equal(ra.getSource(1), "This is also a test");
+        test.equal(ra.getSource(2), "");
+        test.equal(ra.getSource(3), "This is not");
+
+        test.done();
+    },
+
     testResourceArrayGetTarget: function(test) {
         test.expect(4);
 
@@ -290,6 +390,46 @@ module.exports.resourcearray = {
         test.equal(ra.getTarget(0), "Dies ist einen Test.");
         test.equal(ra.getTarget(1), "Dies ist auch einen Test.");
         test.equal(ra.getTarget(2), "Dies ist nicht.");
+
+        test.done();
+    },
+
+    testResourceArrayGetTargetMissingElements: function(test) {
+        test.expect(5);
+
+        var ra = new ResourceArray({
+            key: "foo",
+            sourceArray: ["This is a test", "This is also a test", undefined, "This is not"],
+            pathName: "a/b/c.txt",
+            sourceLocale: "en-US",
+            targetArray: ["Dies ist einen Test.", "Dies ist auch einen Test.", undefined, "Dies ist nicht."],
+            targetLocale: "de-DE"
+        });
+        test.ok(ra);
+        test.equal(ra.getTarget(0), "Dies ist einen Test.");
+        test.equal(ra.getTarget(1), "Dies ist auch einen Test.");
+        test.ok(!ra.getTarget(2));
+        test.equal(ra.getTarget(3), "Dies ist nicht.");
+
+        test.done();
+    },
+
+    testResourceArrayGetTargetEmptyElements: function(test) {
+        test.expect(5);
+
+        var ra = new ResourceArray({
+            key: "foo",
+            sourceArray: ["This is a test", "This is also a test", "", "This is not"],
+            pathName: "a/b/c.txt",
+            sourceLocale: "en-US",
+            targetArray: ["Dies ist einen Test.", "Dies ist auch einen Test.", "", "Dies ist nicht."],
+            targetLocale: "de-DE"
+        });
+        test.ok(ra);
+        test.equal(ra.getTarget(0), "Dies ist einen Test.");
+        test.equal(ra.getTarget(1), "Dies ist auch einen Test.");
+        test.equal(ra.getTarget(2), "");
+        test.equal(ra.getTarget(3), "Dies ist nicht.");
 
         test.done();
     },
@@ -425,6 +565,40 @@ module.exports.resourcearray = {
             test.equal(strings[0], "Ťĥíš íš à ţëšţ6543210");
             test.equal(strings[1], "Ťĥíš íš àľšõ à ţëšţ9876543210");
             test.equal(strings[2], "Ťĥíš íš ñõţ543210");
+
+            test.done();
+        });
+    },
+
+    testResourceArrayGeneratePseudoRightStringMissingOrEmptyElements: function(test) {
+        test.expect(10);
+
+        var ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", undefined, "", "This is not"],
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        var rb = new RegularPseudo({
+            type: "c"
+        });
+
+        rb.init(function() {
+            var ra2 = ra.generatePseudo("de-DE", rb);
+
+            test.ok(ra2);
+            test.ok(ra2.getTargetLocale(), "de-DE");
+
+            var strings = ra2.getTargetArray();
+
+            test.ok(strings);
+            test.equal(strings.length, 5);
+            test.equal(strings[0], "Ťĥíš íš à ţëšţ6543210");
+            test.equal(strings[1], "Ťĥíš íš àľšõ à ţëšţ9876543210");
+            test.ok(!strings[2]);
+            test.equal(strings[3], "");
+            test.equal(strings[4], "Ťĥíš íš ñõţ543210");
 
             test.done();
         });

--- a/test/testXliff.js
+++ b/test/testXliff.js
@@ -745,6 +745,124 @@ module.exports.xliff = {
         test.done();
     },
 
+    testXliffSerializeWithSourceOnlyAndArrayWithMissingElement: function(test) {
+        test.expect(2);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: ["one", "two", undefined, "three"],
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
+            '        <source>one</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
+            '        <source>two</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
+            '        <source>three</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithSourceOnlyAndArrayWithEmptyElement: function(test) {
+        test.expect(2);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: ["one", "two", "", "three"],
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
+            '        <source>one</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
+            '        <source>two</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
+            '        <source>three</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
     testXliffSerializeWithExplicitIds: function(test) {
         test.expect(2);
 

--- a/test/testfiles/project2/res/values/strings.xml
+++ b/test/testfiles/project2/res/values/strings.xml
@@ -9,4 +9,10 @@
       %d friends commented
     </item>
   </plurals>
+  <string-array name="noSource">
+    <item>a</item>
+    <item>b</item>
+    <item></item>
+    <item>c</item>
+  </string-array>
 </resources>


### PR DESCRIPTION
- empty sources means nothing to localize, which is pointless and confusing for the translators
- for strings, do not put resources that have no source or a zero-length source into the extracted or new xliff files
- for arrays, allow elements of the arrays to have empty or zero-length strings in them, but do not put those into the extracted or new xliff files
    - make sure localization and pseudo localization still work with arrays that have empty elements