### PR TITLE
Update SourceContextResourceString to save paramContext

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,12 @@
 Release Notes for Version 2
 ============================
 
+Build 040
+-------
+Published as version 2.23.0
+* Added new `paramContext` value for SourceContextResourceString.
+  * It is the first parameter of `qsTranslate()`. It is going to be used for generating ts translation resource.
+
 Build 039
 -------
 Published as version 2.22.0

--- a/lib/SourceContextResourceString.js
+++ b/lib/SourceContextResourceString.js
@@ -1,7 +1,7 @@
 /*
  * SourceContextResourceString.js - represents an string in a qml file
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020, 2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ var logger = log4js.getLogger("loctool.lib.SourceSourceContextResourceString");
  */
 var SourceContextResourceString = function(props) {
     ResourceString.prototype.constructor.call(this, props);
+    this.paramContext = props.paramContext;
 };
 
 SourceContextResourceString.prototype = new ResourceString();
@@ -131,6 +132,15 @@ SourceContextResourceString.prototype.cleanHashKey = function() {
  */
 SourceContextResourceString.prototype.cleanHashKeyForTranslation = function(locale) {
     return SourceContextResourceString.cleanHashKey(this.project, this.context, locale, this.reskey, this.datatype, this.flavor, this.sourcehash);
+};
+
+/**
+ * Return the a parameter's context
+ *
+ * @return {String} a contex parameter value
+ */
+ SourceContextResourceString.prototype.getParamContext = function() {
+    return this.paramContext;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.22.0",
+    "version": "2.23.0",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1092,7 +1092,6 @@ module.exports.resourcestring = {
 
         test.done();
     },
-
     testIosLayoutResourceStringStaticHashKey: function(test) {
         test.expect(1);
 
@@ -1376,5 +1375,37 @@ module.exports.resourcestring = {
 
         test.done();
     },
+    testSourceContextResourceStringSourceParamContext: function(test) {
+        test.expect(2);
 
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml",
+            paramContext: "abc"
+        });
+        test.ok(rs);
+        test.equal(rs.getParamContext(), "abc");
+        test.done();
+    },
+    testSourceContextResourceStringSourceParamContextEmpty: function(test) {
+        test.expect(2);
+
+        var rs = new SourceContextResourceString({
+            project: "qmlqpp",
+            context: "foobar",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            pathName: "a/b/c.qml",
+            datatype: "x-qml"
+        });
+        test.ok(rs);
+        test.equal(rs.getParamContext(), undefined);
+        test.done();
+    }
 };


### PR DESCRIPTION
* Added new `paramContext` value for SourceContextResourceString.
   * It is the first parameter of `qsTranslate()`. It is going to be used for generating ts translation resource.

To explain in detail)
   `SourceContextResourceString` is used for qml file type localization.
    webos-qml plugin treats the file name as the context so far, but we've missed the case that there are methods that can 
    transfer the context as a parameter.
   e.g) qsTranslate (https://doc.qt.io/qt-6/qml-qtqml-qt.html#qsTranslate-method) 
   if that context value exists,  it has to be used when generating output regarding the context name.
   If there is no context value like qsTR, the context would be still the file name.
