### PR TITLE
Fix locale recognition for xliff files that have a locale that uses with numeric region codes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,10 @@ New Features:
 Bug fixes:
 * Removed unused mysql dependencies to avoid mysql2 security
   vulnerabilities
+* Fixed a bug where xliff files in the xliffs dir which had a locale
+  that used numeric region codes were not being recognized and
+  therefore never read. This meant that no localization could happen
+  to locales with numeric region codes. (example locale spec: "es-419")
 
 
 Build 042

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -48,7 +48,8 @@ var LocalRepository = function (options) {
     this.ts = new TranslationSet(this.sourceLocale);
 };
 
-var xliffFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]))?\.xliff$/;
+var xliffFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?\.xliff$/;
+var numericRegionCode = /^[0-9][0-9][0-9]$/;
 
 /**
  * Initialize this repository and read in all of the strings.
@@ -76,7 +77,7 @@ LocalRepository.prototype.init = function(cb) {
                        match.length < 2 ||
                        (match.length >= 3 && match[2] && !utils.iso639[match[2]]) ||
                        (match.length >= 5 && match[4] && !utils.iso15924[match[4]]) ||
-                       (match.length >= 7 && match[6] && !utils.iso3166[match[6]])) {
+                       (match.length >= 7 && match[6] && !utils.iso3166[match[6]] && !numericRegionCode.test(match[6]))) {
                         return false;
                     }
                     return true;

--- a/lib/LocalRepository.js
+++ b/lib/LocalRepository.js
@@ -48,7 +48,13 @@ var LocalRepository = function (options) {
     this.ts = new TranslationSet(this.sourceLocale);
 };
 
+// Recognize file names that use the BCP-47 locale specs of the form language-Script-REGION where:
+// - language is the 2 letter lower-case ISO 639 code for the language
+// - Script the 4 letter ISO 15924 code for the script with only the first letter capitalized. This part is optional.
+// - REGION is the 2 letter upper-case ISO 3166 code for the region, OR the 3-digit UN.49 region code. This part is also optional.
 var xliffFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?\.xliff$/;
+
+// recognize the UN.49 3-digit region codes
 var numericRegionCode = /^[0-9][0-9][0-9]$/;
 
 /**

--- a/test/LocalRepository.test.js
+++ b/test/LocalRepository.test.js
@@ -92,7 +92,7 @@ describe("localrepository", function() {
     });
 
     test("LocalRepositoryConstructorWithXliffsDir", function() {
-        expect.assertions(24);
+        expect.assertions(31);
 
         var repo = new LocalRepository({
             sourceLocale: "en-US",
@@ -106,7 +106,7 @@ describe("localrepository", function() {
                 reskey: "foobar"
             }, function(err, resources) {
                 expect(resources).toBeTruthy();
-                expect(resources.length).toBe(3);
+                expect(resources.length).toBe(4);
 
                 resources.sort(function(left, right) {
                     var leftLocale = left.getTargetLocale();
@@ -126,17 +126,26 @@ describe("localrepository", function() {
                 expect(resources[1].getProject()).toBe("webapp");
                 expect(resources[1].getSourceLocale()).toBe("en-US");
                 expect(resources[1].getSource()).toBe("Asdf asdf");
-                expect(resources[1].getTargetLocale()).toBe("fr-FR");
-                expect(resources[1].getTarget()).toBe("La asdf");
+                expect(resources[1].getTargetLocale()).toBe("es-419");
+                expect(resources[1].getTarget()).toBe("El asdf");
                 expect(resources[1].getComment()).toBe("foobar is where it's at!");
 
                 expect(resources[2].getKey()).toBe("foobar");
                 expect(resources[2].getProject()).toBe("webapp");
                 expect(resources[2].getSourceLocale()).toBe("en-US");
                 expect(resources[2].getSource()).toBe("Asdf asdf");
-                expect(resources[2].getTargetLocale()).toBe("nl-NL");
-                expect(resources[2].getTarget()).toBe("Het asdf");
+                expect(resources[2].getTargetLocale()).toBe("fr-FR");
+                expect(resources[2].getTarget()).toBe("La asdf");
                 expect(resources[2].getComment()).toBe("foobar is where it's at!");
+
+                expect(resources[3].getKey()).toBe("foobar");
+                expect(resources[3].getProject()).toBe("webapp");
+                expect(resources[3].getSourceLocale()).toBe("en-US");
+                expect(resources[3].getSource()).toBe("Asdf asdf");
+                expect(resources[3].getTargetLocale()).toBe("nl-NL");
+                expect(resources[3].getTarget()).toBe("Het asdf");
+                expect(resources[3].getComment()).toBe("foobar is where it's at!");
+
 
                 repo.close(function() {
                 });

--- a/test/testfiles/xliffs/es-419.xliff
+++ b/test/testfiles/xliffs/es-419.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/j.java" source-language="en-US" target-language="es-419" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>El asdf</target>
+        <note annotates="source">foobar is where it&apos;s at!</note>
+      </trans-unit>
+      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">
+        <source>baby baby</source>
+        <target>bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with us</note>
+      </trans-unit>
+      <trans-unit id="3" resname="ohhuzzah" restype="string" datatype="plaintext">
+        <source x-key="oh">baby baby</source>
+        <target>Los bebes</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+      <trans-unit id="4">
+        <source x-key="asdfasdf">Hello</source>
+        <target>Buenas dias</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
- if you have an xliffs dir with the file `es-419.xliff` in it, the "419" part would not be recognized as a valid region code. Therefore, it would not read the file and its translations and the loctool would never localize to that locale.
- affects any locale that uses numeric region codes and all the strings for that locale come out in the "new strings" file, even though the translations are right there