### PR TITLE
Fix a bug in Utils.formatPath

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes for Version 2
 ============================
 
+Build 046
+-------
+Published as version 2.25.2
+
+New Features:
+
+Bug fixes:
+* fixed a bug in Utils.formatPath where it did not format the correct
+  basename of a file if the file name did not have an extension on it
+
 Build 045
 -------
 Published as version 2.25.1

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1964,7 +1964,7 @@ module.exports.formatPath = function (template, parameters, project, filetype) {
                     break;
                 case 'extension':
                     base = path.basename(pathname);
-                    lastDot = base.indexOf('.');
+                    lastDot = base.lastIndexOf('.');
                     output += lastDot > -1 ? base.substring(lastDot+1) : "";
                     break;
                 case 'basename':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 /*
  * utils.js - various utilities
  *
- * Copyright © 2016-2020, 2022-2023 HealthTap, Inc.
+ * Copyright © 2016-2020, 2022-2024 HealthTap, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1939,6 +1939,7 @@ module.exports.formatPath = function (template, parameters, project, filetype) {
     var output = "";
     var l = new Locale(locale);
     var base;
+    var lastDot;
     var pj = project;
     var resDir = parameters.resourceDir || ((typeof project !== 'undefined' && typeof filetype !=='undefined') ? pj.project.getResourceDirs(filetype.type)[0] : ".");
 
@@ -1963,11 +1964,13 @@ module.exports.formatPath = function (template, parameters, project, filetype) {
                     break;
                 case 'extension':
                     base = path.basename(pathname);
-                    output += base.indexOf('.') > -1 ? base.substring(base.lastIndexOf('.')+1) : "";
+                    lastDot = base.indexOf('.');
+                    output += lastDot > -1 ? base.substring(lastDot+1) : "";
                     break;
                 case 'basename':
                     base = path.basename(pathname);
-                    output += base.substring(0, base.lastIndexOf('.'));
+                    lastDot = base.lastIndexOf('.');
+                    output += lastDot > -1 ? base.substring(0, base.lastIndexOf('.')) : base;
                     break;
                 default:
                 case 'locale':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1970,7 +1970,7 @@ module.exports.formatPath = function (template, parameters, project, filetype) {
                 case 'basename':
                     base = path.basename(pathname);
                     lastDot = base.lastIndexOf('.');
-                    output += lastDot > -1 ? base.substring(0, base.lastIndexOf('.')) : base;
+                    output += lastDot > -1 ? base.substring(0, lastDot) : base;
                     break;
                 default:
                 case 'locale':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loctool",
-    "version": "2.25.1",
+    "version": "2.25.2",
     "main": "./loctool.js",
     "bin": "./loctool.js",
     "description": "A string resource extractor for multiple files types and project types",

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -181,6 +181,14 @@ describe("utils", function() {
         })).toBe("de/DE/tr-strings.j");
     });
 
+    test("GetLocalizedPathBasename with no extension", function() {
+        expect.assertions(1);
+        expect(utils.formatPath('[localeDir]/tr-[basename].j', {
+            sourcepath: "x/y/strings",
+            locale: "de-DE"
+        })).toBe("de/DE/tr-strings.j");
+    });
+
     test("GetLocalizedPathBasenameAlternateExtension", function() {
         expect.assertions(1);
         expect(utils.formatPath('[localeDir]/tr-[basename].j', {


### PR DESCRIPTION
* fixed a bug in Utils.formatPath where it did not format the correct basename of a file if the file name did not have an extension on it. Previously, it would put an empty basename. Now it puts the whole file name.